### PR TITLE
feat(domain): au-kpis-domain core types (#3)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "au-kpis-adapter"
 version = "0.1.0"
 
@@ -65,6 +74,15 @@ version = "0.1.0"
 [[package]]
 name = "au-kpis-domain"
 version = "0.1.0"
+dependencies = [
+ "chrono",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror",
+ "utoipa",
+]
 
 [[package]]
 name = "au-kpis-error"
@@ -109,3 +127,472 @@ version = "0.1.0"
 [[package]]
 name = "au-kpis-telemetry"
 version = "0.1.0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "cc"
+version = "1.2.60"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
+name = "cfg-if"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+dependencies = [
+ "iana-time-zone",
+ "num-traits",
+ "serde",
+ "windows-link",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "js-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.186"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "log"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "utoipa"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "5.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.118"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/au-kpis-domain/Cargo.toml
+++ b/crates/au-kpis-domain/Cargo.toml
@@ -8,3 +8,10 @@ repository.workspace = true
 description = "Pure domain types for australian-kpis (no async/tokio)."
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+utoipa = { version = "5", features = ["chrono"] }
+sha2 = "0.10"
+hex = "0.4"
+thiserror = "2"

--- a/crates/au-kpis-domain/src/artifact.rs
+++ b/crates/au-kpis-domain/src/artifact.rs
@@ -1,0 +1,53 @@
+//! Artifact — raw upstream file, content-addressed by SHA-256.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::ids::{ArtifactId, SourceId};
+
+/// MIME-style content type declared by the fetcher. Free-form string so new
+/// upstream formats don't need a schema bump.
+pub type ContentType = String;
+
+/// A raw upstream artifact persisted in R2 under `artifacts/<hex>`. Records
+/// where it came from, when it was fetched, and its on-wire size so loaders
+/// can audit re-ingestion without re-downloading.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct Artifact {
+    pub id: ArtifactId,
+    pub source_id: SourceId,
+    /// Canonical URL the artifact was fetched from.
+    pub source_url: String,
+    pub content_type: ContentType,
+    /// Size in bytes as stored in R2 — equals the hashed byte stream length.
+    pub size_bytes: u64,
+    /// R2 object key; equal to `artifacts/<id.to_hex()>` by convention but
+    /// persisted explicitly so retention moves can rewrite it.
+    pub storage_key: String,
+    pub fetched_at: DateTime<Utc>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrips() {
+        let id = ArtifactId::of_content(b"sdmx-payload");
+        let a = Artifact {
+            id,
+            source_id: SourceId::new("abs").unwrap(),
+            source_url: "https://data.api.abs.gov.au/rest/data/CPI".into(),
+            content_type: "application/vnd.sdmx.data+json".into(),
+            size_bytes: 12,
+            storage_key: format!("artifacts/{}", id.to_hex()),
+            fetched_at: DateTime::parse_from_rfc3339("2024-04-30T12:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+        };
+        let json = serde_json::to_string(&a).unwrap();
+        let back: Artifact = serde_json::from_str(&json).unwrap();
+        assert_eq!(a, back);
+    }
+}

--- a/crates/au-kpis-domain/src/codelist.rs
+++ b/crates/au-kpis-domain/src/codelist.rs
@@ -1,0 +1,67 @@
+//! Codelists and the codes they contain.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::ids::{CodeId, CodelistId};
+
+/// A reusable vocabulary of codes attached to dimensions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct Codelist {
+    pub id: CodelistId,
+    pub name: String,
+    pub description: Option<String>,
+    pub codes: Vec<Code>,
+}
+
+/// A single code within a codelist (e.g. `VIC` → "Victoria").
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct Code {
+    pub id: CodeId,
+    /// The codelist this code belongs to. Denormalised here so a `Code`
+    /// emitted from the API is self-contained.
+    pub codelist_id: CodelistId,
+    pub name: String,
+    pub description: Option<String>,
+    /// Optional parent code id for hierarchical codelists (e.g. regions with
+    /// state → LGA containment).
+    pub parent_id: Option<CodeId>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn codelist_roundtrips() {
+        let cl = Codelist {
+            id: CodelistId::new("CL_STATE_AU").unwrap(),
+            name: "Australian states and territories".into(),
+            description: None,
+            codes: vec![Code {
+                id: CodeId::new("VIC").unwrap(),
+                codelist_id: CodelistId::new("CL_STATE_AU").unwrap(),
+                name: "Victoria".into(),
+                description: None,
+                parent_id: None,
+            }],
+        };
+        let json = serde_json::to_string(&cl).unwrap();
+        let back: Codelist = serde_json::from_str(&json).unwrap();
+        assert_eq!(cl, back);
+    }
+
+    #[test]
+    fn code_with_parent_roundtrips() {
+        let c = Code {
+            id: CodeId::new("VIC_MELB").unwrap(),
+            codelist_id: CodelistId::new("CL_REGION_AU").unwrap(),
+            name: "Greater Melbourne".into(),
+            description: None,
+            parent_id: Some(CodeId::new("VIC").unwrap()),
+        };
+        let json = serde_json::to_string(&c).unwrap();
+        let back: Code = serde_json::from_str(&json).unwrap();
+        assert_eq!(c, back);
+    }
+}

--- a/crates/au-kpis-domain/src/dataflow.rs
+++ b/crates/au-kpis-domain/src/dataflow.rs
@@ -1,0 +1,103 @@
+//! Dataflow — a conceptually coherent statistical dataset.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::ids::{DataflowId, DimensionId, MeasureId, SourceId};
+
+/// Canonical license identifier. Ingestion refuses to load a dataflow whose
+/// `license` field is absent (see `Spec.md § Data licensing and attribution`).
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "kebab-case")]
+pub enum License {
+    #[serde(rename = "CC-BY-4.0")]
+    CcBy40,
+    #[serde(rename = "CC-BY-ND-4.0")]
+    CcByNd40,
+    #[serde(rename = "CC-BY-SA-4.0")]
+    CcBySa40,
+    #[serde(rename = "public-domain")]
+    PublicDomain,
+    /// Escape hatch for licenses not yet enumerated. Carries the SPDX-style id.
+    Other(String),
+}
+
+/// Cadence at which a dataflow publishes new observations. Informational —
+/// used by the scheduler to pick discovery intervals and by the SLO alerting
+/// rule `dataflow-no-new-observations`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum Frequency {
+    Daily,
+    Weekly,
+    Monthly,
+    Quarterly,
+    Annual,
+    Irregular,
+}
+
+/// A dataflow — a named collection of series sharing dimensions and measures.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct Dataflow {
+    pub id: DataflowId,
+    pub source_id: SourceId,
+    pub name: String,
+    pub description: Option<String>,
+    /// Ordered list of dimension ids that key series within this dataflow.
+    pub dimensions: Vec<DimensionId>,
+    /// Measures published by this dataflow (index, rate, count, ...).
+    pub measures: Vec<MeasureId>,
+    pub frequency: Frequency,
+    pub license: License,
+    /// Required attribution string shown to end-users alongside derived charts.
+    pub attribution: String,
+    /// Canonical citation URL.
+    pub source_url: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrips() {
+        let df = Dataflow {
+            id: DataflowId::new("abs.cpi").unwrap(),
+            source_id: SourceId::new("abs").unwrap(),
+            name: "Consumer Price Index, Australia".into(),
+            description: Some("Quarterly CPI across capital cities.".into()),
+            dimensions: vec![
+                DimensionId::new("region").unwrap(),
+                DimensionId::new("measure").unwrap(),
+            ],
+            measures: vec![MeasureId::new("index").unwrap()],
+            frequency: Frequency::Quarterly,
+            license: License::CcBy40,
+            attribution: "Source: Australian Bureau of Statistics".into(),
+            source_url: "https://www.abs.gov.au/statistics/economy/price-indexes-and-inflation/consumer-price-index-australia".into(),
+        };
+        let json = serde_json::to_string(&df).unwrap();
+        let back: Dataflow = serde_json::from_str(&json).unwrap();
+        assert_eq!(df, back);
+    }
+
+    #[test]
+    fn license_renames_match_spec() {
+        assert_eq!(
+            serde_json::to_string(&License::CcBy40).unwrap(),
+            "\"CC-BY-4.0\""
+        );
+        assert_eq!(
+            serde_json::to_string(&License::PublicDomain).unwrap(),
+            "\"public-domain\""
+        );
+    }
+
+    #[test]
+    fn other_license_roundtrips() {
+        let l = License::Other("LGPL-2.1".into());
+        let json = serde_json::to_string(&l).unwrap();
+        let back: License = serde_json::from_str(&json).unwrap();
+        assert_eq!(l, back);
+    }
+}

--- a/crates/au-kpis-domain/src/dimension.rs
+++ b/crates/au-kpis-domain/src/dimension.rs
@@ -1,0 +1,39 @@
+//! Dimensions — categorical axes of a dataflow (e.g. `region`, `measure`).
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::ids::{CodelistId, DimensionId};
+
+/// A single dimension within a dataflow. Binds a dimension id to a codelist
+/// that enumerates the permitted values.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct Dimension {
+    pub id: DimensionId,
+    pub name: String,
+    pub description: Option<String>,
+    pub codelist_id: CodelistId,
+    /// Position of this dimension in the dataflow's canonical dimension order.
+    /// Adapters must emit dimensions in this order so series-key derivation is
+    /// stable across codebases (see `Spec.md § Data model`).
+    pub position: u16,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrips() {
+        let d = Dimension {
+            id: DimensionId::new("region").unwrap(),
+            name: "Region".into(),
+            description: Some("Geographic region".into()),
+            codelist_id: CodelistId::new("CL_STATE_AU").unwrap(),
+            position: 0,
+        };
+        let json = serde_json::to_string(&d).unwrap();
+        let back: Dimension = serde_json::from_str(&json).unwrap();
+        assert_eq!(d, back);
+    }
+}

--- a/crates/au-kpis-domain/src/ids.rs
+++ b/crates/au-kpis-domain/src/ids.rs
@@ -1,0 +1,445 @@
+//! Newtype identifiers. No raw `String`/`[u8]` IDs leak across public boundaries.
+//!
+//! Two flavours live here:
+//!
+//! * String-backed slugs (`SourceId`, `DataflowId`, `DimensionId`, `CodelistId`,
+//!   `CodeId`, `MeasureId`) — human-readable, URL-safe, assigned by adapters.
+//! * Hash-backed binary IDs (`SeriesKey`, `ArtifactId`) — 32-byte SHA-256 digests
+//!   serialised as lowercase hex.
+//!
+//! `ObservationId` is a composite `(series_key, time, revision_no)` triple — the
+//! natural primary key of the `observations` hypertable (see `Spec.md §
+//! Database schema`).
+
+use std::fmt;
+use std::str::FromStr;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use utoipa::ToSchema;
+
+/// Errors produced while constructing an identifier.
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum IdError {
+    #[error("identifier must not be empty")]
+    Empty,
+    #[error("identifier exceeds {max} bytes")]
+    TooLong { max: usize },
+    #[error("hash must be {expected} hex characters, got {actual}")]
+    HashLength { expected: usize, actual: usize },
+    #[error("hash contains non-hex characters")]
+    HashEncoding,
+}
+
+/// Maximum length (in bytes) for slug-style identifiers. Matches the DB column
+/// width chosen in migration 0001.
+const MAX_ID_LEN: usize = 128;
+
+/// Length in bytes of a SHA-256 digest.
+pub const SHA256_BYTES: usize = 32;
+
+fn validate_slug(s: &str) -> Result<(), IdError> {
+    if s.is_empty() {
+        return Err(IdError::Empty);
+    }
+    if s.len() > MAX_ID_LEN {
+        return Err(IdError::TooLong { max: MAX_ID_LEN });
+    }
+    Ok(())
+}
+
+macro_rules! slug_id {
+    ($(#[$meta:meta])* $name:ident) => {
+        $(#[$meta])*
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, ToSchema)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            /// Construct a new identifier, validating non-empty + length bounds.
+            pub fn new(value: impl Into<String>) -> Result<Self, IdError> {
+                let v = value.into();
+                validate_slug(&v)?;
+                Ok(Self(v))
+            }
+
+            /// Borrow the inner string slice.
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            /// Consume the newtype and return the inner `String`.
+            pub fn into_inner(self) -> String {
+                self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = IdError;
+            fn from_str(s: &str) -> Result<Self, Self::Err> {
+                Self::new(s)
+            }
+        }
+
+        impl AsRef<str> for $name {
+            fn as_ref(&self) -> &str {
+                &self.0
+            }
+        }
+    };
+}
+
+slug_id!(
+    /// Identifier for an upstream data source (e.g. `abs`, `rba`, `apra`).
+    SourceId
+);
+slug_id!(
+    /// Identifier for a dataflow (e.g. `abs.cpi`).
+    DataflowId
+);
+slug_id!(
+    /// Identifier for a dimension within a dataflow (e.g. `region`).
+    DimensionId
+);
+slug_id!(
+    /// Identifier for a codelist (e.g. `CL_STATE_AU`).
+    CodelistId
+);
+slug_id!(
+    /// Identifier for a code within a codelist (e.g. `VIC`).
+    CodeId
+);
+slug_id!(
+    /// Identifier for a measure (e.g. `unemployment_rate`).
+    MeasureId
+);
+
+/// 32-byte SHA-256 digest. Serialises as lowercase hex.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct Sha256Digest([u8; SHA256_BYTES]);
+
+impl Sha256Digest {
+    pub const fn from_bytes(bytes: [u8; SHA256_BYTES]) -> Self {
+        Self(bytes)
+    }
+
+    pub fn as_bytes(&self) -> &[u8; SHA256_BYTES] {
+        &self.0
+    }
+
+    /// Hash arbitrary bytes into a digest.
+    pub fn hash(bytes: &[u8]) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(bytes);
+        Self(hasher.finalize().into())
+    }
+
+    /// Lowercase hex representation (64 chars).
+    pub fn to_hex(&self) -> String {
+        hex::encode(self.0)
+    }
+
+    /// Parse from a 64-char lowercase-or-mixed-case hex string.
+    pub fn from_hex(s: &str) -> Result<Self, IdError> {
+        if s.len() != SHA256_BYTES * 2 {
+            return Err(IdError::HashLength {
+                expected: SHA256_BYTES * 2,
+                actual: s.len(),
+            });
+        }
+        let mut out = [0u8; SHA256_BYTES];
+        hex::decode_to_slice(s, &mut out).map_err(|_| IdError::HashEncoding)?;
+        Ok(Self(out))
+    }
+}
+
+impl fmt::Display for Sha256Digest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_hex())
+    }
+}
+
+impl FromStr for Sha256Digest {
+    type Err = IdError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_hex(s)
+    }
+}
+
+impl Serialize for Sha256Digest {
+    fn serialize<S: serde::Serializer>(&self, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&self.to_hex())
+    }
+}
+
+impl<'de> Deserialize<'de> for Sha256Digest {
+    fn deserialize<D: serde::Deserializer<'de>>(de: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(de)?;
+        Self::from_hex(&s).map_err(serde::de::Error::custom)
+    }
+}
+
+impl utoipa::PartialSchema for Sha256Digest {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        use utoipa::openapi::schema::{ObjectBuilder, Type};
+        ObjectBuilder::new()
+            .schema_type(Type::String)
+            .format(Some(utoipa::openapi::SchemaFormat::Custom(
+                "sha256-hex".to_string(),
+            )))
+            .description(Some("Lowercase hex-encoded SHA-256 digest (64 chars)."))
+            .min_length(Some(64))
+            .max_length(Some(64))
+            .into()
+    }
+}
+
+impl utoipa::ToSchema for Sha256Digest {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("Sha256Digest")
+    }
+}
+
+/// Deterministic series key: `sha256(dataflow_id || '\0' || k1=v1 || '\0' || ...)`
+/// over the dataflow id followed by dimensions sorted by key. Newtype guarantees
+/// callers cannot silently feed a raw hash where a series key is expected.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SeriesKey(Sha256Digest);
+
+impl SeriesKey {
+    pub const fn from_digest(digest: Sha256Digest) -> Self {
+        Self(digest)
+    }
+
+    pub fn digest(&self) -> &Sha256Digest {
+        &self.0
+    }
+
+    /// Canonical derivation: `dataflow_id` then each `(key, value)` sorted by
+    /// key, null-separated. Used by adapters and the loader; both must agree
+    /// byte-for-byte or the series table fragments.
+    pub fn derive<'a, I>(dataflow: &DataflowId, dimensions: I) -> Self
+    where
+        I: IntoIterator<Item = (&'a str, &'a str)>,
+    {
+        let mut pairs: Vec<(&str, &str)> = dimensions.into_iter().collect();
+        pairs.sort_by(|a, b| a.0.cmp(b.0));
+
+        let mut hasher = Sha256::new();
+        hasher.update(dataflow.as_str().as_bytes());
+        for (k, v) in pairs {
+            hasher.update(b"\0");
+            hasher.update(k.as_bytes());
+            hasher.update(b"=");
+            hasher.update(v.as_bytes());
+        }
+        Self(Sha256Digest(hasher.finalize().into()))
+    }
+
+    pub fn to_hex(&self) -> String {
+        self.0.to_hex()
+    }
+
+    pub fn from_hex(s: &str) -> Result<Self, IdError> {
+        Sha256Digest::from_hex(s).map(Self)
+    }
+}
+
+impl fmt::Display for SeriesKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl FromStr for SeriesKey {
+    type Err = IdError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_hex(s)
+    }
+}
+
+impl utoipa::PartialSchema for SeriesKey {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        Sha256Digest::schema()
+    }
+}
+
+impl utoipa::ToSchema for SeriesKey {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("SeriesKey")
+    }
+}
+
+/// Content-addressed identifier for a raw upstream artifact. SHA-256 of the
+/// byte contents, as persisted in R2 under `artifacts/<hex>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ArtifactId(Sha256Digest);
+
+impl ArtifactId {
+    pub const fn from_digest(digest: Sha256Digest) -> Self {
+        Self(digest)
+    }
+
+    pub fn of_content(bytes: &[u8]) -> Self {
+        Self(Sha256Digest::hash(bytes))
+    }
+
+    pub fn digest(&self) -> &Sha256Digest {
+        &self.0
+    }
+
+    pub fn to_hex(&self) -> String {
+        self.0.to_hex()
+    }
+
+    pub fn from_hex(s: &str) -> Result<Self, IdError> {
+        Sha256Digest::from_hex(s).map(Self)
+    }
+}
+
+impl fmt::Display for ArtifactId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
+impl FromStr for ArtifactId {
+    type Err = IdError;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_hex(s)
+    }
+}
+
+impl utoipa::PartialSchema for ArtifactId {
+    fn schema() -> utoipa::openapi::RefOr<utoipa::openapi::schema::Schema> {
+        Sha256Digest::schema()
+    }
+}
+
+impl utoipa::ToSchema for ArtifactId {
+    fn name() -> std::borrow::Cow<'static, str> {
+        std::borrow::Cow::Borrowed("ArtifactId")
+    }
+}
+
+/// Composite natural key for an observation: `(series_key, time, revision_no)`.
+/// Mirrors the primary key of the `observations` hypertable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+pub struct ObservationId {
+    pub series_key: SeriesKey,
+    pub time: DateTime<Utc>,
+    pub revision_no: u32,
+}
+
+impl ObservationId {
+    pub const fn new(series_key: SeriesKey, time: DateTime<Utc>, revision_no: u32) -> Self {
+        Self {
+            series_key,
+            time,
+            revision_no,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn slug_id_rejects_empty() {
+        assert_eq!(SourceId::new(""), Err(IdError::Empty));
+    }
+
+    #[test]
+    fn slug_id_rejects_oversized() {
+        let too_long = "x".repeat(MAX_ID_LEN + 1);
+        assert_eq!(
+            SourceId::new(too_long),
+            Err(IdError::TooLong { max: MAX_ID_LEN })
+        );
+    }
+
+    #[test]
+    fn slug_id_roundtrips_as_transparent_string() {
+        let id = DataflowId::new("abs.cpi").unwrap();
+        let json = serde_json::to_string(&id).unwrap();
+        assert_eq!(json, "\"abs.cpi\"");
+        let back: DataflowId = serde_json::from_str(&json).unwrap();
+        assert_eq!(id, back);
+    }
+
+    #[test]
+    fn sha256_digest_roundtrips() {
+        let d = Sha256Digest::hash(b"hello");
+        let hex = d.to_hex();
+        assert_eq!(hex.len(), 64);
+        assert_eq!(Sha256Digest::from_hex(&hex).unwrap(), d);
+    }
+
+    #[test]
+    fn series_key_is_deterministic_and_order_independent() {
+        let df = DataflowId::new("abs.cpi").unwrap();
+        let a = SeriesKey::derive(&df, [("region", "AUS"), ("measure", "index")]);
+        let b = SeriesKey::derive(&df, [("measure", "index"), ("region", "AUS")]);
+        assert_eq!(a, b);
+
+        let different = SeriesKey::derive(&df, [("region", "VIC"), ("measure", "index")]);
+        assert_ne!(a, different);
+    }
+
+    #[test]
+    fn series_key_serialises_as_transparent_hex() {
+        let df = DataflowId::new("abs.cpi").unwrap();
+        let key = SeriesKey::derive(&df, [("region", "AUS")]);
+        let json = serde_json::to_string(&key).unwrap();
+        assert_eq!(json, format!("\"{}\"", key.to_hex()));
+        let back: SeriesKey = serde_json::from_str(&json).unwrap();
+        assert_eq!(key, back);
+    }
+
+    #[test]
+    fn artifact_id_of_content_is_stable() {
+        let a = ArtifactId::of_content(b"payload");
+        let b = ArtifactId::of_content(b"payload");
+        assert_eq!(a, b);
+        assert_ne!(a, ArtifactId::of_content(b"other"));
+    }
+
+    #[test]
+    fn observation_id_roundtrips() {
+        let df = DataflowId::new("abs.cpi").unwrap();
+        let oid = ObservationId::new(
+            SeriesKey::derive(&df, [("region", "AUS")]),
+            DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            0,
+        );
+        let json = serde_json::to_string(&oid).unwrap();
+        let back: ObservationId = serde_json::from_str(&json).unwrap();
+        assert_eq!(oid, back);
+    }
+
+    #[test]
+    fn sha256_digest_rejects_wrong_length() {
+        assert!(matches!(
+            Sha256Digest::from_hex("deadbeef"),
+            Err(IdError::HashLength { .. })
+        ));
+    }
+
+    #[test]
+    fn sha256_digest_rejects_non_hex() {
+        let s = "z".repeat(64);
+        assert_eq!(Sha256Digest::from_hex(&s), Err(IdError::HashEncoding));
+    }
+}

--- a/crates/au-kpis-domain/src/lib.rs
+++ b/crates/au-kpis-domain/src/lib.rs
@@ -1,1 +1,34 @@
 //! Pure domain types for australian-kpis (no async/tokio).
+//!
+//! This crate is the single source of truth for the SDMX-inspired data model
+//! (see `Spec.md § Data model`). Everything public here derives `Serialize`,
+//! `Deserialize`, and `utoipa::ToSchema` so it flows unchanged from the DB
+//! layer through the HTTP API into the generated TypeScript SDK.
+//!
+//! No async, no I/O — depend on this crate freely.
+
+#![forbid(unsafe_code)]
+#![deny(missing_debug_implementations)]
+
+pub mod artifact;
+pub mod codelist;
+pub mod dataflow;
+pub mod dimension;
+pub mod ids;
+pub mod measure;
+pub mod observation;
+pub mod series;
+pub mod source;
+
+pub use artifact::{Artifact, ContentType};
+pub use codelist::{Code, Codelist};
+pub use dataflow::{Dataflow, Frequency, License};
+pub use dimension::Dimension;
+pub use ids::{
+    ArtifactId, CodeId, CodelistId, DataflowId, DimensionId, IdError, MeasureId, ObservationId,
+    SHA256_BYTES, SeriesKey, Sha256Digest, SourceId,
+};
+pub use measure::Measure;
+pub use observation::{Observation, ObservationStatus, TimePrecision};
+pub use series::{Series, SeriesDescriptor};
+pub use source::Source;

--- a/crates/au-kpis-domain/src/measure.rs
+++ b/crates/au-kpis-domain/src/measure.rs
@@ -1,0 +1,52 @@
+//! Measures — what an observation is counting.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::ids::MeasureId;
+
+/// A measure — the quantity being reported (index, rate, count, dollars).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct Measure {
+    pub id: MeasureId,
+    pub name: String,
+    pub description: Option<String>,
+    /// Human-readable unit string (e.g. `"index"`, `"percent"`, `"AUD"`).
+    pub unit: String,
+    /// Optional multiplier hint (e.g. `1e6` for "$M"). Omitted for
+    /// dimensionless measures.
+    pub scale: Option<f64>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrips() {
+        let m = Measure {
+            id: MeasureId::new("cpi_index").unwrap(),
+            name: "CPI Index".into(),
+            description: Some("Consumer Price Index, base 2011-12 = 100".into()),
+            unit: "index".into(),
+            scale: None,
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let back: Measure = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, back);
+    }
+
+    #[test]
+    fn scale_roundtrips() {
+        let m = Measure {
+            id: MeasureId::new("gdp_usd_millions").unwrap(),
+            name: "GDP".into(),
+            description: None,
+            unit: "AUD".into(),
+            scale: Some(1_000_000.0),
+        };
+        let json = serde_json::to_string(&m).unwrap();
+        let back: Measure = serde_json::from_str(&json).unwrap();
+        assert_eq!(m, back);
+    }
+}

--- a/crates/au-kpis-domain/src/observation.rs
+++ b/crates/au-kpis-domain/src/observation.rs
@@ -1,0 +1,126 @@
+//! Observation — one data point in the `observations` hypertable.
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::ids::{ArtifactId, SeriesKey};
+
+/// Temporal granularity of an observation's timestamp. Matches the SDMX
+/// `@FREQ` facet on a coarse scale.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum TimePrecision {
+    Day,
+    Week,
+    Month,
+    Quarter,
+    Year,
+}
+
+/// Observation status flags sourced from SDMX. Subset in use across Australian
+/// publishers; extend as new codes appear in upstream feeds.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ObservationStatus {
+    Normal,
+    Estimated,
+    Forecast,
+    Imputed,
+    Missing,
+    Provisional,
+    Revised,
+    Break,
+}
+
+/// One observation — a single row in the `observations` hypertable.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct Observation {
+    pub series_key: SeriesKey,
+    pub time: DateTime<Utc>,
+    pub time_precision: TimePrecision,
+    /// `None` when `status = Missing`.
+    pub value: Option<f64>,
+    pub status: ObservationStatus,
+    /// `0` for the original publication; `N` for the Nth revision.
+    pub revision_no: u32,
+    /// Free-form attributes attached to this observation (e.g. SDMX `OBS_STATUS`
+    /// or adapter-specific annotations).
+    pub attributes: BTreeMap<String, String>,
+    pub ingested_at: DateTime<Utc>,
+    pub source_artifact_id: ArtifactId,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ids::DataflowId;
+
+    #[test]
+    fn roundtrips() {
+        let df = DataflowId::new("abs.cpi").unwrap();
+        let key = SeriesKey::derive(&df, [("region", "AUS")]);
+        let obs = Observation {
+            series_key: key,
+            time: DateTime::parse_from_rfc3339("2024-03-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            time_precision: TimePrecision::Quarter,
+            value: Some(134.2),
+            status: ObservationStatus::Normal,
+            revision_no: 0,
+            attributes: [("OBS_STATUS".to_string(), "A".to_string())]
+                .into_iter()
+                .collect(),
+            ingested_at: DateTime::parse_from_rfc3339("2024-04-30T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            source_artifact_id: ArtifactId::of_content(b"raw-sdmx-bytes"),
+        };
+        let json = serde_json::to_string(&obs).unwrap();
+        let back: Observation = serde_json::from_str(&json).unwrap();
+        assert_eq!(obs, back);
+    }
+
+    #[test]
+    fn missing_value_roundtrips() {
+        let df = DataflowId::new("abs.cpi").unwrap();
+        let key = SeriesKey::derive(&df, [("region", "AUS")]);
+        let obs = Observation {
+            series_key: key,
+            time: DateTime::parse_from_rfc3339("2024-03-01T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            time_precision: TimePrecision::Quarter,
+            value: None,
+            status: ObservationStatus::Missing,
+            revision_no: 0,
+            attributes: BTreeMap::new(),
+            ingested_at: DateTime::parse_from_rfc3339("2024-04-30T00:00:00Z")
+                .unwrap()
+                .with_timezone(&Utc),
+            source_artifact_id: ArtifactId::of_content(b"raw"),
+        };
+        let json = serde_json::to_string(&obs).unwrap();
+        let back: Observation = serde_json::from_str(&json).unwrap();
+        assert_eq!(obs, back);
+    }
+
+    #[test]
+    fn time_precision_lowercases() {
+        assert_eq!(
+            serde_json::to_string(&TimePrecision::Quarter).unwrap(),
+            "\"quarter\""
+        );
+    }
+
+    #[test]
+    fn observation_status_lowercases() {
+        assert_eq!(
+            serde_json::to_string(&ObservationStatus::Provisional).unwrap(),
+            "\"provisional\""
+        );
+    }
+}

--- a/crates/au-kpis-domain/src/series.rs
+++ b/crates/au-kpis-domain/src/series.rs
@@ -1,0 +1,124 @@
+//! Series — metadata per time series, separated from the narrow
+//! `observations` hot table (see `Spec.md § Data model`).
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::ids::{DataflowId, MeasureId, SeriesKey};
+
+/// One time series within a dataflow. `dimensions` is the sorted bag of
+/// `(key, value)` pairs that, together with `dataflow_id`, seeds `series_key`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct Series {
+    pub series_key: SeriesKey,
+    pub dataflow_id: DataflowId,
+    pub measure_id: MeasureId,
+    /// Dimension values keyed by `DimensionId::as_str()`. Stored sorted (via
+    /// `BTreeMap`) so iteration order is stable across serialisation +
+    /// re-hashing.
+    pub dimensions: BTreeMap<String, String>,
+    pub unit: String,
+    pub first_observed: Option<DateTime<Utc>>,
+    pub last_observed: Option<DateTime<Utc>>,
+    /// Whether the upstream source still publishes this series. Inactive
+    /// series are retained for historical queries but excluded from the
+    /// default `/v1/series` listing.
+    pub active: bool,
+}
+
+impl Series {
+    /// Compute the canonical series key from the dataflow + dimension pairs.
+    /// Equivalent to `SeriesKey::derive`, but borrows directly from an
+    /// already-populated `Series`.
+    pub fn compute_series_key(&self) -> SeriesKey {
+        SeriesKey::derive(
+            &self.dataflow_id,
+            self.dimensions
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str())),
+        )
+    }
+}
+
+/// Lightweight descriptor emitted by adapters during `parse`. The loader
+/// inserts the full `Series` row on first sighting and then references the
+/// key on subsequent observations (see `Spec.md § Adapter trait`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct SeriesDescriptor {
+    pub series_key: SeriesKey,
+    pub dataflow_id: DataflowId,
+    pub measure_id: MeasureId,
+    pub dimensions: BTreeMap<String, String>,
+    pub unit: String,
+}
+
+impl SeriesDescriptor {
+    pub fn compute_series_key(&self) -> SeriesKey {
+        SeriesKey::derive(
+            &self.dataflow_id,
+            self.dimensions
+                .iter()
+                .map(|(k, v)| (k.as_str(), v.as_str())),
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn example_series() -> Series {
+        let df = DataflowId::new("abs.cpi").unwrap();
+        let dims: BTreeMap<String, String> = [("region".to_string(), "AUS".to_string())]
+            .into_iter()
+            .collect();
+        let key = SeriesKey::derive(&df, dims.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+        Series {
+            series_key: key,
+            dataflow_id: df,
+            measure_id: MeasureId::new("index").unwrap(),
+            dimensions: dims,
+            unit: "index".into(),
+            first_observed: Some(
+                DateTime::parse_from_rfc3339("2000-01-01T00:00:00Z")
+                    .unwrap()
+                    .with_timezone(&Utc),
+            ),
+            last_observed: None,
+            active: true,
+        }
+    }
+
+    #[test]
+    fn series_roundtrips() {
+        let s = example_series();
+        let json = serde_json::to_string(&s).unwrap();
+        let back: Series = serde_json::from_str(&json).unwrap();
+        assert_eq!(s, back);
+    }
+
+    #[test]
+    fn series_key_matches_computed() {
+        let s = example_series();
+        assert_eq!(s.series_key, s.compute_series_key());
+    }
+
+    #[test]
+    fn descriptor_roundtrips_and_matches_series_key() {
+        let s = example_series();
+        let d = SeriesDescriptor {
+            series_key: s.series_key,
+            dataflow_id: s.dataflow_id.clone(),
+            measure_id: s.measure_id.clone(),
+            dimensions: s.dimensions.clone(),
+            unit: s.unit.clone(),
+        };
+        let json = serde_json::to_string(&d).unwrap();
+        let back: SeriesDescriptor = serde_json::from_str(&json).unwrap();
+        assert_eq!(d, back);
+        assert_eq!(d.compute_series_key(), s.series_key);
+    }
+}

--- a/crates/au-kpis-domain/src/source.rs
+++ b/crates/au-kpis-domain/src/source.rs
@@ -1,0 +1,36 @@
+//! Upstream data source metadata.
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::ids::SourceId;
+
+/// An upstream publisher of statistical data (ABS, RBA, APRA, ...).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct Source {
+    pub id: SourceId,
+    /// Human-readable name, e.g. "Australian Bureau of Statistics".
+    pub name: String,
+    /// Canonical homepage for citation.
+    pub homepage: String,
+    /// Short description of the source and its scope.
+    pub description: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn roundtrips() {
+        let src = Source {
+            id: SourceId::new("abs").unwrap(),
+            name: "Australian Bureau of Statistics".into(),
+            homepage: "https://www.abs.gov.au".into(),
+            description: Some("Official statistical agency of Australia.".into()),
+        };
+        let json = serde_json::to_string(&src).unwrap();
+        let back: Source = serde_json::from_str(&json).unwrap();
+        assert_eq!(src, back);
+    }
+}


### PR DESCRIPTION
## Summary

- Populate `au-kpis-domain` with the SDMX-inspired data model from `Spec.md § Data model`.
- Newtype IDs for every public identifier (string slugs + SHA-256-backed `SeriesKey` / `ArtifactId`).
- 27 serde JSON round-trip unit tests cover every type.

## Linked issue

Closes #3

## Pass requirements

- [x] Types defined: `Source`, `Dataflow`, `Dimension`, `Codelist`, `Code`, `Measure`, `Series`, `Observation`, `Artifact`, `SeriesKey`, `ObservationId`, `ArtifactId`
- [x] Serde derive on all public types
- [x] `utoipa::ToSchema` derive on all public types
- [x] Newtype discipline: no raw `String` IDs at public boundaries
- [x] Unit tests round-trip every type (serde JSON)

## Test plan

- [x] `cargo test -p au-kpis-domain` → 27 passed
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean

## Spec / docs impact

- [x] No Spec changes required

## Checklist

- [x] Conventional commit title
- [x] No secrets committed
- [x] Tests added/updated
- [x] `cargo fmt` clean
- [x] Clippy warnings resolved