### PR TITLE
feat(error): au-kpis-error shared primitives (#4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,10 @@ version = "0.1.0"
 [[package]]
 name = "au-kpis-error"
 version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "thiserror",
+]
 
 [[package]]
 name = "au-kpis-ingestion"
@@ -105,7 +109,126 @@ version = "0.1.0"
 [[package]]
 name = "au-kpis-storage"
 version = "0.1.0"
+dependencies = [
+ "au-kpis-error",
+ "thiserror",
+]
 
 [[package]]
 name = "au-kpis-telemetry"
 version = "0.1.0"
+
+[[package]]
+name = "itoa"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "memchr"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+dependencies = [
+ "proc-macro2",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "unicode-ident"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "zmij"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/crates/au-kpis-error/Cargo.toml
+++ b/crates/au-kpis-error/Cargo.toml
@@ -8,3 +8,5 @@ repository.workspace = true
 description = "Shared error types for australian-kpis."
 
 [dependencies]
+thiserror = "2"
+serde_json = "1"

--- a/crates/au-kpis-error/src/lib.rs
+++ b/crates/au-kpis-error/src/lib.rs
@@ -1,1 +1,201 @@
-//! Shared error types for australian-kpis.
+//! Shared error primitives for australian-kpis library crates.
+//!
+//! # What this crate exposes
+//!
+//! * [`ErrorClass`] — how callers should react (retry, DLQ, return 400).
+//! * [`Classify`] — trait implemented by error types that want to broadcast
+//!   their class without forcing callers to pattern-match every variant.
+//! * [`CoreError`] — a compact enum of cross-cutting error variants (I/O,
+//!   JSON, UTF-8, validation, not-found) that several library crates
+//!   compose via `#[from]`.
+//!
+//! Library crates are expected to define their **own** `thiserror` enums and
+//! use `#[from]` to absorb `CoreError` (or its sub-variants directly). See
+//! `Spec.md § Error handling across crates` — `anyhow::Error` never appears
+//! in public library APIs.
+//!
+//! # Example
+//!
+//! ```
+//! use au_kpis_error::{Classify, CoreError, ErrorClass};
+//!
+//! #[derive(Debug, thiserror::Error)]
+//! enum MyError {
+//!     #[error(transparent)]
+//!     Core(#[from] CoreError),
+//!     #[error("downstream service unavailable")]
+//!     Downstream,
+//! }
+//!
+//! impl Classify for MyError {
+//!     fn class(&self) -> ErrorClass {
+//!         match self {
+//!             MyError::Core(e) => e.class(),
+//!             MyError::Downstream => ErrorClass::Transient,
+//!         }
+//!     }
+//! }
+//! ```
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Classification of an error used by retry-aware callers.
+///
+/// The ingestion queue uses this to decide between retry-with-backoff and
+/// immediate DLQ; the HTTP layer uses it to map internal errors to the right
+/// status code (5xx vs 4xx vs 422).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ErrorClass {
+    /// Transient — retry with backoff is safe and expected to eventually succeed
+    /// (network blip, upstream 5xx, DB lock contention).
+    Transient,
+    /// Permanent — retrying will never succeed. Push to DLQ / surface to the
+    /// caller (schema drift, missing artifact, bad credentials).
+    Permanent,
+    /// Validation — input failed a precondition. Callers render these as
+    /// user-visible 400/422 responses without alerting on-call.
+    Validation,
+}
+
+impl ErrorClass {
+    /// `true` when the queue should retry this job with backoff.
+    pub const fn is_retryable(self) -> bool {
+        matches!(self, ErrorClass::Transient)
+    }
+}
+
+/// Implemented by error types that can report their retry classification.
+///
+/// Keep the blanket implementation on the crate boundary — don't add it to
+/// foreign types (orphan rule aside, it prevents cross-crate policy drift).
+pub trait Classify {
+    /// Return the retry class of this error.
+    fn class(&self) -> ErrorClass;
+
+    /// Suggested delay before retry. Only meaningful for [`ErrorClass::Transient`];
+    /// the default returns `None` so callers fall back to the queue's backoff
+    /// policy. Override when the underlying error carries an explicit hint
+    /// (e.g. a `Retry-After` header, a `429` from an upstream API).
+    fn retry_after(&self) -> Option<Duration> {
+        None
+    }
+}
+
+/// Cross-cutting error variants shared by multiple library crates.
+///
+/// Library crates that need richer errors should define their own
+/// `thiserror` enum and embed `CoreError` as a source via `#[from]`.
+#[derive(Debug, Error)]
+pub enum CoreError {
+    /// Generic I/O failure.
+    #[error("i/o error: {0}")]
+    Io(#[from] std::io::Error),
+
+    /// JSON serialisation or deserialisation failure.
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// UTF-8 decoding failure over a borrowed byte slice.
+    #[error("invalid utf-8: {0}")]
+    Utf8(#[from] std::str::Utf8Error),
+
+    /// UTF-8 decoding failure over an owned `Vec<u8>`.
+    #[error("invalid utf-8: {0}")]
+    FromUtf8(#[from] std::string::FromUtf8Error),
+
+    /// Precondition failed on user input (400/422 material).
+    #[error("validation: {0}")]
+    Validation(String),
+
+    /// Target resource not found.
+    #[error("not found: {0}")]
+    NotFound(String),
+}
+
+impl Classify for CoreError {
+    fn class(&self) -> ErrorClass {
+        match self {
+            // I/O is usually transient (disk, socket, temp network); callers
+            // that know otherwise wrap it in their own Permanent variant.
+            CoreError::Io(_) => ErrorClass::Transient,
+            // Parse/decoding errors are permanent — the artifact won't decode
+            // differently on the next attempt.
+            CoreError::Json(_) | CoreError::Utf8(_) | CoreError::FromUtf8(_) => {
+                ErrorClass::Permanent
+            }
+            CoreError::Validation(_) => ErrorClass::Validation,
+            CoreError::NotFound(_) => ErrorClass::Permanent,
+        }
+    }
+}
+
+/// Convenience: result alias using [`CoreError`].
+pub type CoreResult<T> = std::result::Result<T, CoreError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn error_class_retryable_flag() {
+        assert!(ErrorClass::Transient.is_retryable());
+        assert!(!ErrorClass::Permanent.is_retryable());
+        assert!(!ErrorClass::Validation.is_retryable());
+    }
+
+    #[test]
+    fn core_error_io_is_transient() {
+        let io: std::io::Error = std::io::Error::other("unreachable");
+        let err: CoreError = io.into();
+        assert_eq!(err.class(), ErrorClass::Transient);
+    }
+
+    #[test]
+    fn core_error_json_is_permanent() {
+        let json_err = serde_json::from_str::<i32>("not-a-number").unwrap_err();
+        let err: CoreError = json_err.into();
+        assert_eq!(err.class(), ErrorClass::Permanent);
+    }
+
+    #[test]
+    fn core_error_validation_class() {
+        let err = CoreError::Validation("missing field `name`".into());
+        assert_eq!(err.class(), ErrorClass::Validation);
+    }
+
+    #[test]
+    fn downstream_enum_can_compose_via_from() {
+        #[derive(Debug, Error)]
+        enum Wrapped {
+            #[error(transparent)]
+            Core(#[from] CoreError),
+            #[error("gone")]
+            Gone,
+        }
+
+        impl Classify for Wrapped {
+            fn class(&self) -> ErrorClass {
+                match self {
+                    Wrapped::Core(c) => c.class(),
+                    Wrapped::Gone => ErrorClass::Permanent,
+                }
+            }
+        }
+
+        let io: std::io::Error = std::io::Error::other("flaky");
+        let w: Wrapped = CoreError::from(io).into();
+        assert_eq!(w.class(), ErrorClass::Transient);
+        assert_eq!(Wrapped::Gone.class(), ErrorClass::Permanent);
+    }
+
+    #[test]
+    fn default_retry_after_is_none() {
+        let err = CoreError::Validation("x".into());
+        assert!(err.retry_after().is_none());
+    }
+}

--- a/crates/au-kpis-storage/Cargo.toml
+++ b/crates/au-kpis-storage/Cargo.toml
@@ -8,3 +8,5 @@ repository.workspace = true
 description = "object_store wrapper for S3/R2."
 
 [dependencies]
+au-kpis-error = { workspace = true }
+thiserror = "2"

--- a/crates/au-kpis-storage/src/lib.rs
+++ b/crates/au-kpis-storage/src/lib.rs
@@ -1,1 +1,67 @@
 //! object_store wrapper for S3/R2.
+//!
+//! Only the error type is fleshed out at this stage — it demonstrates the
+//! composition pattern from `au-kpis-error` that all library crates follow:
+//! cross-cutting variants come in via `#[from] CoreError`, backend-specific
+//! variants are added as explicit members, and `Classify` bubbles retry
+//! policy up to the queue.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use au_kpis_error::{Classify, CoreError, ErrorClass};
+use thiserror::Error;
+
+/// Errors returned by the storage layer.
+#[derive(Debug, Error)]
+pub enum StorageError {
+    /// Shared I/O, serde, or validation failure.
+    #[error(transparent)]
+    Core(#[from] CoreError),
+
+    /// Upstream object-store backend returned an unexpected failure.
+    #[error("object store backend: {0}")]
+    Backend(String),
+
+    /// The requested key does not exist in the backend.
+    #[error("object not found: {0}")]
+    NotFound(String),
+}
+
+impl Classify for StorageError {
+    fn class(&self) -> ErrorClass {
+        match self {
+            StorageError::Core(e) => e.class(),
+            StorageError::Backend(_) => ErrorClass::Transient,
+            StorageError::NotFound(_) => ErrorClass::Permanent,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn core_error_flows_through_from() {
+        let io: std::io::Error = std::io::Error::other("down");
+        let err: StorageError = CoreError::from(io).into();
+        assert_eq!(err.class(), ErrorClass::Transient);
+    }
+
+    #[test]
+    fn backend_is_transient() {
+        assert_eq!(
+            StorageError::Backend("timeout".into()).class(),
+            ErrorClass::Transient
+        );
+    }
+
+    #[test]
+    fn not_found_is_permanent() {
+        assert_eq!(
+            StorageError::NotFound("artifacts/abc".into()).class(),
+            ErrorClass::Permanent
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Populate `au-kpis-error` with cross-cutting building blocks: `ErrorClass`, `Classify` trait, `CoreError` enum with `#[from]` conversions.
- Wire `au-kpis-storage` as the first downstream consumer to prove the composition pattern.
- Docs render cleanly (module-level example + variant docs) under `RUSTDOCFLAGS="-D missing_docs"`.

## Linked issue

Closes #4

## Pass requirements

- [x] Base error enums with `#[from]` conversions
- [x] Used as source by at least one downstream crate (`au-kpis-storage::StorageError` embeds `CoreError`)
- [x] `cargo doc` renders error docs

## Test plan

- [x] `cargo test -p au-kpis-error -p au-kpis-storage` → 10 passed (unit + doctest)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean
- [x] `RUSTDOCFLAGS="-D warnings -D missing_docs" cargo doc -p au-kpis-error --no-deps` → clean

## Spec / docs impact

- [x] No Spec changes required

## Checklist

- [x] Conventional commit title
- [x] No secrets committed
- [x] Tests added/updated
- [x] `cargo fmt` clean
- [x] Clippy warnings resolved