### PR TITLE
feat(config): au-kpis-config figment-based loader (#5)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.102"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "au-kpis-adapter"
 version = "0.1.0"
 
@@ -66,6 +81,12 @@ version = "0.1.0"
 [[package]]
 name = "au-kpis-config"
 version = "0.1.0"
+dependencies = [
+ "au-kpis-error",
+ "figment",
+ "serde",
+ "thiserror",
+]
 
 [[package]]
 name = "au-kpis-db"
@@ -143,6 +164,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bitflags"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -156,6 +183,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "cc"
@@ -227,10 +260,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "figment"
+version = "0.10.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
+dependencies = [
+ "atomic",
+ "parking_lot",
+ "pear",
+ "serde",
+ "tempfile",
+ "toml",
+ "uncased",
+ "version_check",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "generic-array"
@@ -243,10 +314,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+ "wasip3",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hex"
@@ -279,16 +378,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
+
+[[package]]
+name = "inlinable_string"
+version = "0.1.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
 name = "itoa"
@@ -307,10 +418,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
 
 [[package]]
 name = "log"
@@ -340,12 +472,81 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
+name = "pear"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdeeaa00ce488657faba8ebf44ab9361f9365a97bd39ffb8a60663f57ff4b467"
+dependencies = [
+ "inlinable_string",
+ "pear_codegen",
+ "yansi",
+]
+
+[[package]]
+name = "pear_codegen"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4bab5b985dc082b345f812b7df84e1bef27e7207b39e448439ba8bd69c93f147"
+dependencies = [
+ "proc-macro2",
+ "proc-macro2-diagnostics",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "proc-macro2-diagnostics"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+ "yansi",
 ]
 
 [[package]]
@@ -358,10 +559,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -407,6 +648,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -424,6 +674,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +688,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -455,16 +724,72 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "uncased"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b88fcfe09e89d3866a5c11019378088af2d24c3fbd4f0543f96b479ec90697"
+dependencies = [
+ "version_check",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utoipa"
@@ -494,6 +819,24 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -538,6 +881,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -598,6 +975,124 @@ checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
+
+[[package]]
+name = "yansi"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "zmij"

--- a/crates/au-kpis-config/Cargo.toml
+++ b/crates/au-kpis-config/Cargo.toml
@@ -8,3 +8,10 @@ repository.workspace = true
 description = "figment-based config loader."
 
 [dependencies]
+au-kpis-error = { workspace = true }
+figment = { version = "0.10", features = ["toml", "env"] }
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"
+
+[dev-dependencies]
+figment = { version = "0.10", features = ["toml", "env", "test"] }

--- a/crates/au-kpis-config/src/lib.rs
+++ b/crates/au-kpis-config/src/lib.rs
@@ -1,1 +1,297 @@
-//! figment-based config loader.
+//! Layered config loader for australian-kpis binaries.
+//!
+//! Precedence is **defaults → TOML file → environment variables** (later
+//! layers override earlier ones). See `Spec.md § Tech stack` — `figment` was
+//! chosen for the layered, type-safe model.
+//!
+//! # Environment variables
+//!
+//! Variables are read with a fixed prefix ([`ENV_PREFIX`]) and nested field
+//! paths joined with [`ENV_NESTED_SEPARATOR`]. For example
+//! `AU_KPIS_HTTP__BIND=0.0.0.0:9000` maps to `http.bind`.
+//!
+//! # Errors
+//!
+//! A missing required field (notably `database.url`, which has no default)
+//! makes [`load`] fail fast with a [`ConfigError::Figment`] whose message
+//! names the missing path — callers do not have to wait for a runtime
+//! connection attempt to notice the misconfiguration.
+//!
+//! # Example
+//!
+//! ```no_run
+//! use std::path::Path;
+//! use au_kpis_config::{load, AppConfig};
+//!
+//! let cfg: AppConfig = load(Some(Path::new("au-kpis.toml")))
+//!     .expect("config");
+//! let _ = cfg.http.bind;
+//! ```
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::path::Path;
+
+use au_kpis_error::{Classify, CoreError, ErrorClass};
+use figment::{
+    Figment,
+    providers::{Env, Format, Serialized, Toml},
+};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Prefix applied to every environment variable consumed by [`load`].
+pub const ENV_PREFIX: &str = "AU_KPIS_";
+
+/// Separator between nested fields in environment variables.
+///
+/// `AU_KPIS_HTTP__BIND` overrides `http.bind`.
+pub const ENV_NESTED_SEPARATOR: &str = "__";
+
+/// Errors returned by the config loader.
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    /// Shared I/O, serde, or validation failure (see
+    /// [`au_kpis_error::CoreError`]).
+    #[error(transparent)]
+    Core(#[from] CoreError),
+
+    /// `figment` layer failure — missing required field, TOML parse error,
+    /// or malformed env var.
+    #[error("config load: {0}")]
+    Figment(#[from] figment::Error),
+}
+
+impl Classify for ConfigError {
+    fn class(&self) -> ErrorClass {
+        match self {
+            ConfigError::Core(e) => e.class(),
+            // Config errors surface at startup; retrying the same inputs
+            // produces the same failure.
+            ConfigError::Figment(_) => ErrorClass::Permanent,
+        }
+    }
+}
+
+/// Top-level application config.
+///
+/// Sections exist only for fields that already have a downstream consumer;
+/// new sections are added alongside the dependent crate. Required fields
+/// without a [`Default`] (currently `database.url`) force [`load`] to fail
+/// at startup if unset.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AppConfig {
+    /// HTTP server configuration — consumed by `au-kpis-api`.
+    pub http: HttpConfig,
+    /// Database connection configuration — consumed by `au-kpis-db`.
+    pub database: DatabaseConfig,
+    /// Telemetry configuration — consumed by `au-kpis-telemetry`.
+    pub telemetry: TelemetryConfig,
+}
+
+/// HTTP server configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct HttpConfig {
+    /// Socket address the API binary binds to.
+    pub bind: String,
+}
+
+impl Default for HttpConfig {
+    fn default() -> Self {
+        Self {
+            bind: "0.0.0.0:8080".into(),
+        }
+    }
+}
+
+/// Database connection configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct DatabaseConfig {
+    /// Postgres (Timescale) connection URL. Required — no default.
+    pub url: String,
+}
+
+/// Telemetry and logging configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct TelemetryConfig {
+    /// Service name emitted on traces and logs.
+    pub service_name: String,
+    /// Log output format.
+    pub log_format: LogFormat,
+    /// Log filter, interpreted by `tracing-subscriber`'s `EnvFilter`.
+    pub log_level: String,
+    /// OTLP endpoint for span export. `None` disables OTel export.
+    pub otlp_endpoint: Option<String>,
+}
+
+impl Default for TelemetryConfig {
+    fn default() -> Self {
+        Self {
+            service_name: "au-kpis".into(),
+            log_format: LogFormat::Json,
+            log_level: "info".into(),
+            otlp_endpoint: None,
+        }
+    }
+}
+
+/// Log output format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum LogFormat {
+    /// JSON-per-line, production default.
+    Json,
+    /// Human-readable, recommended for local dev.
+    Pretty,
+}
+
+/// Default values serialised as the first figment layer.
+///
+/// Sections without a default (e.g. `database`) are intentionally omitted
+/// so figment surfaces a clear "missing field" error when the caller
+/// forgets to supply them.
+#[derive(Debug, Clone, Default, Serialize)]
+struct Defaults {
+    http: HttpConfig,
+    telemetry: TelemetryConfig,
+}
+
+/// Load [`AppConfig`] using the standard **defaults → TOML → env** precedence.
+///
+/// - Defaults come from each field's [`Default`] impl.
+/// - `toml_path`, when `Some`, is merged in; a missing file or parse error
+///   fails fast.
+/// - Environment variables prefixed with [`ENV_PREFIX`] override everything
+///   else; nested fields use [`ENV_NESTED_SEPARATOR`]
+///   (`AU_KPIS_HTTP__BIND=0.0.0.0:9000`).
+pub fn load(toml_path: Option<&Path>) -> Result<AppConfig, ConfigError> {
+    let mut fig = Figment::from(Serialized::defaults(Defaults::default()));
+
+    if let Some(path) = toml_path {
+        fig = fig.merge(Toml::file_exact(path));
+    }
+
+    fig = fig.merge(Env::prefixed(ENV_PREFIX).split(ENV_NESTED_SEPARATOR));
+
+    Ok(fig.extract()?)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use figment::Jail;
+
+    #[test]
+    fn missing_required_field_fails_fast() {
+        Jail::expect_with(|_jail| {
+            let err = load(None).expect_err("database.url has no default");
+            let msg = err.to_string();
+            assert!(
+                msg.contains("database") || msg.contains("url"),
+                "expected error to reference the missing path, got: {msg}"
+            );
+            match err {
+                ConfigError::Figment(_) => {}
+                other => panic!("expected Figment variant, got {other:?}"),
+            }
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn env_alone_supplies_required_field() {
+        Jail::expect_with(|jail| {
+            jail.set_env("AU_KPIS_DATABASE__URL", "postgres://env/db");
+            let cfg = load(None).expect("env supplies required field");
+            assert_eq!(cfg.database.url, "postgres://env/db");
+            assert_eq!(cfg.http.bind, "0.0.0.0:8080");
+            assert_eq!(cfg.telemetry.service_name, "au-kpis");
+            assert_eq!(cfg.telemetry.log_format, LogFormat::Json);
+            assert!(cfg.telemetry.otlp_endpoint.is_none());
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn toml_overrides_defaults() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "au-kpis.toml",
+                r#"
+                    [http]
+                    bind = "127.0.0.1:3000"
+
+                    [database]
+                    url = "postgres://from-toml/db"
+
+                    [telemetry]
+                    service_name = "from-toml"
+                    log_format = "pretty"
+                    log_level = "debug"
+                "#,
+            )?;
+            let cfg = load(Some(Path::new("au-kpis.toml"))).unwrap();
+            assert_eq!(cfg.http.bind, "127.0.0.1:3000");
+            assert_eq!(cfg.database.url, "postgres://from-toml/db");
+            assert_eq!(cfg.telemetry.service_name, "from-toml");
+            assert_eq!(cfg.telemetry.log_format, LogFormat::Pretty);
+            assert_eq!(cfg.telemetry.log_level, "debug");
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn env_overrides_toml() {
+        Jail::expect_with(|jail| {
+            jail.create_file(
+                "au-kpis.toml",
+                r#"
+                    [http]
+                    bind = "127.0.0.1:3000"
+
+                    [database]
+                    url = "postgres://from-toml/db"
+                "#,
+            )?;
+            jail.set_env("AU_KPIS_HTTP__BIND", "0.0.0.0:9999");
+            jail.set_env("AU_KPIS_DATABASE__URL", "postgres://from-env/db");
+            jail.set_env("AU_KPIS_TELEMETRY__OTLP_ENDPOINT", "http://otel:4317");
+            let cfg = load(Some(Path::new("au-kpis.toml"))).unwrap();
+            assert_eq!(cfg.http.bind, "0.0.0.0:9999");
+            assert_eq!(cfg.database.url, "postgres://from-env/db");
+            assert_eq!(
+                cfg.telemetry.otlp_endpoint.as_deref(),
+                Some("http://otel:4317")
+            );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn missing_toml_file_fails_fast() {
+        Jail::expect_with(|jail| {
+            jail.set_env("AU_KPIS_DATABASE__URL", "postgres://env/db");
+            let err =
+                load(Some(Path::new("does-not-exist.toml"))).expect_err("missing TOML should fail");
+            assert!(matches!(err, ConfigError::Figment(_)));
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn config_error_is_permanent() {
+        Jail::expect_with(|_jail| {
+            let err = load(None).expect_err("no database.url");
+            assert_eq!(err.class(), ErrorClass::Permanent);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn core_error_composes_via_from() {
+        let io: std::io::Error = std::io::Error::other("unreachable");
+        let err: ConfigError = CoreError::from(io).into();
+        assert_eq!(err.class(), ErrorClass::Transient);
+    }
+}


### PR DESCRIPTION
## Summary

- Populate `au-kpis-config` with a strongly-typed `AppConfig` plus a `load(toml_path)` function that layers figment providers in the order **defaults → TOML → env**.
- Missing required fields (notably `database.url`, which has no default) fail fast at startup with a precise error path.
- `ConfigError` composes `au_kpis_error::CoreError` via `#[from]` and adds a `Figment` variant; `Classify` marks figment failures as `Permanent`.

## Linked issue

Closes #5

## Pass requirements

- [x] Strongly typed `AppConfig` struct
- [x] Layered loading: env overrides TOML overrides defaults
- [x] Missing required field → fast failure with clear error
- [x] Unit tests

## Test plan

- [x] `cargo test -p au-kpis-config` → 7 unit + 1 doctest passed
- [x] `cargo test --workspace` → clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` → clean
- [x] `cargo fmt --all --check` → clean
- [x] `RUSTDOCFLAGS="-D warnings -D missing_docs" cargo doc -p au-kpis-config --no-deps` → clean

Tests cover: missing required field fails fast, env-alone satisfies required field, TOML overrides defaults, env overrides TOML, missing TOML path fails fast (via `Toml::file_exact`), error classification, and `CoreError` composition.

## Spec / docs impact

- [x] No Spec changes required — follows `Spec.md § Tech stack` (figment layered config) and `§ Monorepo layout`.

## Checklist

- [x] Conventional commit title
- [x] No secrets committed
- [x] Tests added
- [x] `cargo fmt` clean
- [x] Clippy warnings resolved