### PR TITLE
ci(review): add repo-specific Codex PR review

### DIFF
--- a/.github/codex/guides/adapters.md
+++ b/.github/codex/guides/adapters.md
@@ -1,0 +1,22 @@
+## Adapter Review Guide
+
+Applies to:
+- `crates/au-kpis-adapter/**`
+- `crates/adapters/**`
+- `crates/au-kpis-pdf-client/**`
+
+Primary review goal:
+- protect source-specific parser correctness without breaking abstraction boundaries
+
+Focus on:
+- parser correctness
+- snapshot/property coverage
+- adapter rate-limit and retry behavior
+- adapter output staying persistence-agnostic
+- PDF/network safety for difficult sources
+
+Ask:
+- does the adapter still emit domain parse results instead of touching storage concerns?
+- is this parser change missing golden-file or property coverage?
+- could this lose attribution, source artifact linkage, or format-drift observability?
+- are Python/http timeout expectations still satisfied where relevant?

--- a/.github/codex/guides/api-sdk.md
+++ b/.github/codex/guides/api-sdk.md
@@ -1,0 +1,24 @@
+## API, OpenAPI, And SDK Review Guide
+
+Applies to:
+- `crates/au-kpis-api-http/**`
+- `crates/au-kpis-openapi/**`
+- `crates/bins/au-kpis-api/**`
+- `packages/sdk/**`
+- `packages/sdk-generated/**`
+
+Primary review goal:
+- protect the public contract exposed to API and SDK consumers
+
+Focus on:
+- OpenAPI parity
+- additive vs breaking API changes
+- SDK regeneration expectations
+- attribution and metadata in outward-facing responses
+- contract and integration test coverage
+
+Ask:
+- does the handler/schema diff require updated OpenAPI artifacts or SDK generation?
+- is this a breaking change that should be versioned?
+- do response-shape changes have contract coverage?
+- is outward-facing attribution or license metadata now missing or inconsistent?

--- a/.github/codex/guides/ci-spec.md
+++ b/.github/codex/guides/ci-spec.md
@@ -1,0 +1,21 @@
+## CI And Spec Review Guide
+
+Applies to:
+- `.github/workflows/**`
+- `Spec.md`
+- `AGENTS.md`
+- `CONTRIBUTING.md`
+
+Primary review goal:
+- keep repository policy, CI behavior, and documented contracts aligned
+
+Focus on:
+- weakened gates
+- silent skips
+- workflow behavior diverging from spec
+- missing `Spec.md` updates when architecture or CI contracts change
+
+Ask:
+- does this change weaken a stated gate or silently bypass one?
+- is there a workflow/contract change without a matching spec update?
+- is the review signal advisory vs blocking behavior still explicit?

--- a/.github/codex/guides/db.md
+++ b/.github/codex/guides/db.md
@@ -1,0 +1,21 @@
+## DB And Migration Review Guide
+
+Applies to:
+- `crates/au-kpis-db/**`
+- `infra/migrations/**`
+
+Primary review goal:
+- protect correctness and performance of Timescale-backed storage
+
+Focus on:
+- hypertable correctness
+- reversible migrations
+- `observations_latest` correctness
+- query safety and `sqlx::query!` usage
+- revision history preservation
+
+Ask:
+- could this break revision semantics or latest-value reads?
+- is there a destructive schema change without a spec/deprecation note?
+- should this have a real integration test against Postgres/Timescale?
+- does this create a likely performance regression on hot queries?

--- a/.github/codex/guides/domain.md
+++ b/.github/codex/guides/domain.md
@@ -1,0 +1,19 @@
+## Domain Review Guide
+
+Applies to:
+- `crates/au-kpis-domain/**`
+- shared domain types used across crates
+
+Primary review goal:
+- protect the canonical data model and type boundaries
+
+Focus on:
+- accidental weakening of typed IDs and `SeriesKey`
+- mixing transport/storage concerns into pure domain types
+- changes that blur `Series` vs `Observation`
+- serialization/schema changes that ripple into OpenAPI or SDKs
+
+Ask:
+- does this preserve the `series` and `observations` split?
+- does this keep `SeriesKey` as a type-safe boundary rather than a plain string?
+- does this change require updated tests for serialization or schema derivation?

--- a/.github/codex/guides/frontend.md
+++ b/.github/codex/guides/frontend.md
@@ -1,0 +1,17 @@
+## Frontend Review Guide
+
+Applies to:
+- `apps/web/**`
+
+Primary review goal:
+- protect correctness and accessibility of the reference client
+
+Focus on:
+- broken data assumptions from API changes
+- missing Playwright or axe coverage
+- regressions in key explorer/compare flows
+
+Ask:
+- does this UI change depend on an API contract that is not covered elsewhere?
+- should there be E2E or accessibility coverage?
+- is the change hiding a deeper contract mismatch rather than just a UI issue?

--- a/.github/codex/guides/ingestion.md
+++ b/.github/codex/guides/ingestion.md
@@ -1,0 +1,24 @@
+## Ingestion And Loader Review Guide
+
+Applies to:
+- `crates/au-kpis-loader/**`
+- `crates/au-kpis-ingestion-core/**`
+- `crates/au-kpis-queue/**`
+- `crates/bins/au-kpis-ingestion/**`
+- `crates/bins/au-kpis-scheduler/**`
+
+Primary review goal:
+- protect idempotent, auditable, stream-oriented ingestion
+
+Focus on:
+- COPY-based batching
+- series upsert vs observation insert boundaries
+- retry behavior and backpressure
+- revision ordering and idempotency
+- queue abstraction boundaries
+
+Ask:
+- does this preserve raw artifact provenance and auditability?
+- does this leak DB concerns into adapters or orchestration layers?
+- does this materialize large datasets where streaming should be used?
+- are integration or benchmark tests missing for hot-path behavior?

--- a/.github/codex/output-schema.json
+++ b/.github/codex/output-schema.json
@@ -1,0 +1,189 @@
+{
+  "type": "object",
+  "properties": {
+    "findings": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "category": {
+            "type": "string",
+            "enum": [
+              "data_integrity",
+              "api_contract",
+              "migration",
+              "ingestion",
+              "performance",
+              "security",
+              "testing",
+              "ci",
+              "architecture"
+            ]
+          },
+          "subsystem": {
+            "type": "string",
+            "enum": [
+              "domain",
+              "db",
+              "loader",
+              "ingestion_core",
+              "adapter",
+              "api_http",
+              "openapi_sdk",
+              "infra",
+              "ci",
+              "frontend",
+              "python_pdf",
+              "bin",
+              "cross_cutting"
+            ]
+          },
+          "invariant": {
+            "type": "string",
+            "enum": [
+              "series_observation_split",
+              "revision_chain",
+              "observations_latest",
+              "series_key_boundary",
+              "adapter_db_boundary",
+              "attribution_required",
+              "streaming_preferred",
+              "queue_trait_boundary",
+              "openapi_contract",
+              "migration_reversibility",
+              "ci_contract",
+              "none"
+            ]
+          },
+          "suggested_test_layer": {
+            "type": "string",
+            "enum": [
+              "unit",
+              "snapshot",
+              "property",
+              "integration",
+              "contract",
+              "sdk_integration",
+              "e2e_a11y",
+              "benchmark",
+              "none"
+            ]
+          },
+          "title": {
+            "type": "string",
+            "maxLength": 80
+          },
+          "body": {
+            "type": "string",
+            "minLength": 1
+          },
+          "confidence_score": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1
+          },
+          "priority": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 3
+          },
+          "code_location": {
+            "type": "object",
+            "properties": {
+              "absolute_file_path": {
+                "type": "string",
+                "minLength": 1
+              },
+              "line_range": {
+                "type": "object",
+                "properties": {
+                  "start": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "end": {
+                    "type": "integer",
+                    "minimum": 1
+                  }
+                },
+                "required": [
+                  "start",
+                  "end"
+                ],
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "absolute_file_path",
+              "line_range"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "required": [
+          "category",
+          "subsystem",
+          "invariant",
+          "suggested_test_layer",
+          "title",
+          "body",
+          "confidence_score",
+          "priority",
+          "code_location"
+        ],
+        "additionalProperties": false
+      }
+    },
+    "overall_correctness": {
+      "type": "string",
+      "enum": [
+        "patch is correct",
+        "patch is incorrect"
+      ]
+    },
+    "overall_explanation": {
+      "type": "string",
+      "minLength": 1
+    },
+    "primary_risk_areas": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": [
+          "data_integrity",
+          "api_contract",
+          "migration",
+          "ingestion",
+          "performance",
+          "security",
+          "testing",
+          "ci",
+          "architecture"
+        ]
+      },
+      "maxItems": 3,
+      "uniqueItems": true
+    },
+    "spec_update_required": {
+      "type": "boolean"
+    },
+    "spec_update_reason": {
+      "type": "string"
+    },
+    "overall_confidence_score": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    }
+  },
+  "required": [
+    "findings",
+    "overall_correctness",
+    "overall_explanation",
+    "primary_risk_areas",
+    "spec_update_required",
+    "spec_update_reason",
+    "overall_confidence_score"
+  ],
+  "additionalProperties": false
+}

--- a/.github/codex/review_prompt.md
+++ b/.github/codex/review_prompt.md
@@ -1,0 +1,144 @@
+You are acting as a reviewer for a proposed code change made by another engineer.
+
+This repository is `australian-kpis`: a pre-implementation monorepo for a unified Rust API, TypeScript SDK, and Python PDF sidecar that ingest fragmented Australian economic data from sources such as ABS, RBA, APRA, Treasury, ASX, AEMO, and state governments into one consistent SDMX-inspired model.
+
+The mission is not generic CRUD software. The main failure modes are:
+- silent data corruption
+- broken revision tracking
+- schema or API drift
+- ingestion paths that lose auditability or provenance
+- performance regressions in hot data paths
+- CI/test gaps that let these defects ship
+
+Treat `Spec.md` as the architecture ground truth and `AGENTS.md` as repo policy. Flag changes that violate either. Do not invent new architecture in review comments; compare the diff against the repository's stated design.
+You may receive one or more additional review-guide sections later in the prompt. Treat them as path-specific instructions for the files changed in this PR. Apply those guide sections before falling back to generic review heuristics.
+
+Focus on issues that materially affect correctness, data integrity, performance, security, maintainability, developer experience, or CI reliability.
+Flag only actionable issues introduced by the pull request.
+When you flag an issue, provide a short, direct explanation and cite the affected file and line range.
+Prioritize severe issues and avoid nit-level comments unless they block understanding of the diff.
+Ignore formatting-only issues and minor style preferences unless they hide a real defect.
+After listing findings, produce an overall correctness verdict ("patch is correct" or "patch is incorrect") with a concise justification and a confidence score between 0 and 1.
+Ensure that file citations and line numbers are exactly correct using the tools available; if they are incorrect your comments will be rejected.
+
+For every finding, assign exactly one category from this repo-specific set:
+- `data_integrity`
+- `api_contract`
+- `migration`
+- `ingestion`
+- `performance`
+- `security`
+- `testing`
+- `ci`
+- `architecture`
+
+For every finding, also assign:
+- one `subsystem` from:
+  - `domain`
+  - `db`
+  - `loader`
+  - `ingestion_core`
+  - `adapter`
+  - `api_http`
+  - `openapi_sdk`
+  - `infra`
+  - `ci`
+  - `frontend`
+  - `python_pdf`
+  - `bin`
+  - `cross_cutting`
+- one `invariant` from:
+  - `series_observation_split`
+  - `revision_chain`
+  - `observations_latest`
+  - `series_key_boundary`
+  - `adapter_db_boundary`
+  - `attribution_required`
+  - `streaming_preferred`
+  - `queue_trait_boundary`
+  - `openapi_contract`
+  - `migration_reversibility`
+  - `ci_contract`
+  - `none`
+- one `suggested_test_layer` from:
+  - `unit`
+  - `snapshot`
+  - `property`
+  - `integration`
+  - `contract`
+  - `sdk_integration`
+  - `e2e_a11y`
+  - `benchmark`
+  - `none`
+
+Use `none` only when no specific invariant or test layer applies.
+
+Repository architecture map:
+- `crates/au-kpis-domain`: pure domain types only; no async runtime concerns
+- `crates/au-kpis-db`: sqlx + Timescale queries and migration-sensitive database logic
+- `crates/au-kpis-loader`: COPY-based ingest, series upsert, revision handling
+- `crates/au-kpis-ingestion-core`: discover -> fetch -> parse -> load orchestration
+- `crates/au-kpis-adapter` and `crates/adapters/*`: source adapters and parsing logic
+- `crates/au-kpis-api-http` and `crates/au-kpis-openapi`: HTTP contract and OpenAPI surface
+- `crates/au-kpis-queue`, `au-kpis-cache`, `au-kpis-storage`, `au-kpis-auth`, `au-kpis-pdf-client`: infrastructure boundaries
+- `crates/bins/*`: composition roots, not business-logic dumping grounds
+- `apps/web`, `packages/sdk`, `packages/sdk-generated`: client-facing TS surfaces and SDK contract
+- `infra/migrations`, `.github/workflows`: operational correctness and CI contract
+
+Core domain invariants to protect:
+- `series` and `observations` are intentionally split; do not duplicate dimensions into hot observation rows or collapse the boundary accidentally.
+- `revision_no` is part of revision handling; `observations_latest` is the default latest-value surface.
+- `SeriesKey` is a typed newtype/hash boundary, not an arbitrary string.
+- Adapters should emit parse results without DB-specific coupling; ingestion/loader owns persistence semantics.
+- Every dataflow requires attribution and license metadata; ingestion should not make unattributed data loadable.
+- Streaming is preferred over large in-memory materialization for large datasets or responses.
+- The queue abstraction should remain behind the `Queue` trait rather than leaking implementation details upward.
+- OpenAPI is the public contract; additive change is acceptable, breaking change requires explicit versioning policy (`/v2`).
+
+Language and subsystem review rules:
+- Rust:
+  - Flag `unwrap()` or equivalent panic-prone behavior in non-test code.
+  - Flag locks held across `.await`.
+  - Flag runtime-checked SQL where compile-checked `sqlx::query!` should be used.
+  - Flag business logic creeping into bins instead of library crates.
+  - Flag architecture drift across crate boundaries or layering violations.
+- Database and migrations:
+  - Flag changes that risk incorrect hypertable setup, broken reversibility, revision corruption, or mismatch with `observations_latest`.
+  - Flag destructive migration behavior without a documented deprecation/spec note.
+  - Flag query changes that could break Timescale performance expectations or correctness.
+- Adapters and ingestion:
+  - Prioritize parser correctness, raw artifact retention, revision ordering, idempotency, retry/circuit-breaker behavior, and backpressure.
+  - Flag eager `Vec` collection where streaming is the intended design for large flows.
+- API, OpenAPI, and SDK:
+  - Flag handler/schema changes that are not reflected in OpenAPI or would introduce a breaking contract.
+  - Flag changes that should require SDK regeneration, contract tests, or `oasdiff` coverage.
+  - Flag missing attribution metadata in outward-facing API responses where relevant.
+- TypeScript:
+  - Flag `any`, invalid boundary validation, broken generated/manual SDK separation, and missing type/test coverage for API-facing changes.
+- Python sidecar:
+  - Flag missing explicit timeouts, weak typing relative to `mypy --strict`, or unsafe PDF/network handling.
+- CI/workflows:
+  - Flag changes that weaken gates, silently skip required checks, or contradict the spec's CI contract.
+  - Flag cases where workflow behavior changes but `Spec.md` is not updated.
+
+Testing expectations are part of correctness. Flag missing or insufficient tests when the change affects:
+- pure logic -> unit tests
+- parsers -> snapshot and property tests
+- SQL or migrations -> integration tests against real Postgres/Timescale paths
+- API endpoints or schema -> integration plus contract/OpenAPI coverage
+- SDK methods -> SDK integration tests
+- UI changes -> Playwright plus axe-core coverage
+- performance-sensitive paths -> benchmark coverage when relevant
+
+Review process:
+1. Infer which subsystem(s) the changed files belong to.
+2. Apply any included path-specific review guide sections before generic review heuristics.
+3. Prefer high-signal findings about architecture, invariants, tests, and contract safety.
+4. Do not complain about unimplemented future phases unless the diff claims to implement them incorrectly.
+5. If the diff is scaffolding-only, focus on whether it preserves the repo's intended future structure and contracts.
+6. In the overall summary, include:
+   - `primary_risk_areas`: up to 3 categories that best describe the diff's main risks
+   - `spec_update_required`: `true` only if the diff changes architecture, CI contract, or public behavior that should update `Spec.md`
+   - `spec_update_reason`: one short sentence; use an empty string if `spec_update_required` is `false`
+
+Review only the changes between the provided base and head SHAs.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,395 @@
+name: PR Review
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+
+concurrency:
+  group: codex-structured-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  codex-review:
+    name: Codex Structured Review
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    env:
+      CODEX_MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.5' }}
+      CODEX_REVIEW_EFFORT: ${{ vars.CODEX_REVIEW_EFFORT || 'high' }}
+      CODEX_REVIEW_BLOCK_ON_INCORRECT: ${{ vars.CODEX_REVIEW_BLOCK_ON_INCORRECT || 'false' }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+      REPOSITORY: ${{ github.repository }}
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+    steps:
+      - name: Check review preconditions
+        id: preflight
+        env:
+          HAS_OPENAI_KEY: ${{ secrets.OPENAI_API_KEY != '' && 'true' || 'false' }}
+          IS_DRAFT: ${{ github.event.pull_request.draft && 'true' || 'false' }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          should_run=true
+          reason="ready"
+
+          if [ "$HAS_OPENAI_KEY" != "true" ]; then
+            should_run=false
+            reason="OPENAI_API_KEY is not configured"
+          elif [ "$IS_DRAFT" = "true" ]; then
+            should_run=false
+            reason="draft pull requests are skipped"
+          elif [ "$HEAD_REPO" != "$BASE_REPO" ]; then
+            should_run=false
+            reason="fork pull requests do not receive repository secrets"
+          fi
+
+          echo "should_run=$should_run" >>"$GITHUB_OUTPUT"
+          echo "reason=$reason" >>"$GITHUB_OUTPUT"
+          printf 'Codex review %s: %s\n' "$([ "$should_run" = true ] && echo enabled || echo skipped)" "$reason" >>"$GITHUB_STEP_SUMMARY"
+        shell: bash
+
+      - name: Checkout pull request merge commit
+        if: steps.preflight.outputs.should_run == 'true'
+        uses: actions/checkout@v5
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+
+      - name: Fetch base and head refs
+        if: steps.preflight.outputs.should_run == 'true'
+        run: |
+          set -euxo pipefail
+          git fetch --no-tags origin \
+            "$BASE_REF" \
+            "+refs/pull/$PR_NUMBER/head"
+        shell: bash
+
+      - name: Build Codex review prompt
+        if: steps.preflight.outputs.should_run == 'true'
+        run: |
+          set -euo pipefail
+
+          cp .github/codex/review_prompt.md codex-prompt.md
+
+          changed_files="$(git --no-pager diff --name-only "${BASE_SHA}" "${HEAD_SHA}")"
+          guide_list_file="$(mktemp)"
+
+          review_lenses=""
+          case "$changed_files" in
+            *crates/au-kpis-db/*|*infra/migrations/*)
+              review_lenses="${review_lenses}\n- Database lens: protect hypertable correctness, query safety, reversibility, revision semantics, and observations_latest behavior."
+              echo ".github/codex/guides/db.md" >>"$guide_list_file"
+              ;;
+          esac
+          case "$changed_files" in
+            *crates/au-kpis-loader/*|*crates/au-kpis-ingestion-core/*|*crates/au-kpis-queue/*|*crates/bins/au-kpis-ingestion/*|*crates/bins/au-kpis-scheduler/*)
+              review_lenses="${review_lenses}\n- Ingestion lens: protect streaming, idempotency, raw artifact provenance, adapter/DB separation, retry behavior, and revision ordering."
+              echo ".github/codex/guides/ingestion.md" >>"$guide_list_file"
+              ;;
+          esac
+          case "$changed_files" in
+            *crates/au-kpis-adapter/*|*crates/adapters/*|*crates/au-kpis-pdf-client/*)
+              review_lenses="${review_lenses}\n- Adapter lens: protect parser correctness, source artifact linkage, format-drift safety, and adapter abstraction boundaries."
+              echo ".github/codex/guides/adapters.md" >>"$guide_list_file"
+              ;;
+          esac
+          case "$changed_files" in
+            *crates/au-kpis-domain/*)
+              review_lenses="${review_lenses}\n- Domain lens: protect typed boundaries, schema stability, and the canonical series/observation model."
+              echo ".github/codex/guides/domain.md" >>"$guide_list_file"
+              ;;
+          esac
+          case "$changed_files" in
+            *crates/au-kpis-api-http/*|*crates/au-kpis-openapi/*|*packages/sdk/*|*packages/sdk-generated/*)
+              review_lenses="${review_lenses}\n- API lens: protect OpenAPI parity, response compatibility, SDK regeneration expectations, and attribution in outward-facing payloads."
+              echo ".github/codex/guides/api-sdk.md" >>"$guide_list_file"
+              ;;
+          esac
+          case "$changed_files" in
+            *apps/web/*)
+              review_lenses="${review_lenses}\n- Frontend lens: protect explorer/client correctness and required E2E plus accessibility coverage."
+              echo ".github/codex/guides/frontend.md" >>"$guide_list_file"
+              ;;
+          esac
+          case "$changed_files" in
+            *.github/workflows/*|*AGENTS.md|*Spec.md)
+              review_lenses="${review_lenses}\n- CI/spec lens: verify that repo policy and documented CI behavior stay aligned."
+              echo ".github/codex/guides/ci-spec.md" >>"$guide_list_file"
+              ;;
+          esac
+
+          sort -u "$guide_list_file" -o "$guide_list_file"
+
+          {
+            echo ""
+            echo "Repository: ${REPOSITORY}"
+            echo "Pull Request #: ${PR_NUMBER}"
+            echo "Base ref: ${BASE_REF}"
+            echo "Head ref: ${HEAD_REF}"
+            echo "Base SHA: ${BASE_SHA}"
+            echo "Head SHA: ${HEAD_SHA}"
+            echo ""
+            echo "Pull request title:"
+            printf '%s\n' "${PR_TITLE}"
+            echo ""
+            echo "Pull request body:"
+            printf '%s\n' "${PR_BODY}"
+            echo ""
+            echo "Detected review lenses:"
+            if [ -n "$review_lenses" ]; then
+              printf '%b\n' "$review_lenses"
+            else
+              echo "- General lens: infer subsystem-specific risks from the changed files."
+            fi
+            echo ""
+            echo "Included path-specific guides:"
+            if [ -s "$guide_list_file" ]; then
+              while IFS= read -r guide_path; do
+                echo "- ${guide_path}"
+              done <"$guide_list_file"
+            else
+              echo "- none"
+            fi
+            echo ""
+            echo "Changed files:"
+            git --no-pager diff --name-status "${BASE_SHA}" "${HEAD_SHA}"
+            echo ""
+            if [ -s "$guide_list_file" ]; then
+              while IFS= read -r guide_path; do
+                echo ""
+                echo "--- BEGIN GUIDE: ${guide_path} ---"
+                cat "$guide_path"
+                echo "--- END GUIDE: ${guide_path} ---"
+              done <"$guide_list_file"
+              echo ""
+            fi
+            echo "Unified diff (context=5):"
+            git --no-pager diff --unified=5 --stat=200 "${BASE_SHA}" "${HEAD_SHA}" > /tmp/diffstat.txt
+            git --no-pager diff --unified=5 "${BASE_SHA}" "${HEAD_SHA}" > /tmp/full.diff
+            cat /tmp/diffstat.txt
+            echo ""
+            cat /tmp/full.diff
+          } >>codex-prompt.md
+
+          rm -f "$guide_list_file"
+        shell: bash
+
+      - name: Run Codex structured review
+        if: steps.preflight.outputs.should_run == 'true'
+        id: run-codex
+        uses: openai/codex-action@v1
+        with:
+          openai-api-key: ${{ secrets.OPENAI_API_KEY }}
+          prompt-file: codex-prompt.md
+          output-schema-file: .github/codex/output-schema.json
+          output-file: codex-output.json
+          model: ${{ env.CODEX_MODEL }}
+          effort: ${{ env.CODEX_REVIEW_EFFORT }}
+          sandbox: read-only
+          safety-strategy: drop-sudo
+
+      - name: Inspect structured Codex output
+        if: steps.preflight.outputs.should_run == 'true' && always()
+        run: |
+          set -euo pipefail
+
+          if [ -s codex-output.json ]; then
+            jq '.' codex-output.json
+          else
+            echo "Codex output file missing"
+            exit 1
+          fi
+        shell: bash
+
+      - name: Remove prior Codex review comments
+        if: steps.preflight.outputs.should_run == 'true' && always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          inline_comments_url="https://api.github.com/repos/${REPOSITORY}/pulls/${PR_NUMBER}/comments?per_page=100"
+          issue_comments_url="https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments?per_page=100"
+
+          curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$inline_comments_url" |
+            jq -r '.[] | select(.body | contains("<!-- codex-review-inline -->")) | .id' |
+            while IFS= read -r comment_id; do
+              curl -fsSL \
+                -X DELETE \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/${REPOSITORY}/pulls/comments/${comment_id}"
+            done
+
+          curl -fsSL \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "$issue_comments_url" |
+            jq -r '.[] | select(.body | contains("<!-- codex-review-summary -->")) | .id' |
+            while IFS= read -r comment_id; do
+              curl -fsSL \
+                -X DELETE \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/${REPOSITORY}/issues/comments/${comment_id}"
+            done
+        shell: bash
+
+      - name: Publish inline review comments
+        if: steps.preflight.outputs.should_run == 'true' && always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REVIEW_JSON: codex-output.json
+        run: |
+          set -euo pipefail
+
+          if [ ! -s "$REVIEW_JSON" ]; then
+            echo "No Codex output file present; skipping comment publishing."
+            exit 0
+          fi
+
+          findings_count=$(jq '.findings | length' "$REVIEW_JSON")
+          if [ "$findings_count" -eq 0 ]; then
+            echo "Codex returned no findings; skipping inline comments."
+            exit 0
+          fi
+
+          jq -c \
+            --arg commit "$HEAD_SHA" \
+            --arg workspace "${GITHUB_WORKSPACE%/}/" '
+            .findings[] | {
+              body: ("<!-- codex-review-inline -->\n**[" + .category + "][" + .subsystem + "] " + .title + "**\n\n" + .body + "\n\nInvariant: `" + .invariant + "`\nSuggested test layer: `" + .suggested_test_layer + "`\nConfidence: " + (.confidence_score | tostring) + "\nPriority: P" + (.priority | tostring)),
+              commit_id: $commit,
+              path: (.code_location.absolute_file_path | sub("^" + $workspace; "")),
+              line: .code_location.line_range.end,
+              side: "RIGHT",
+              start_line: (if .code_location.line_range.start != .code_location.line_range.end then .code_location.line_range.start else null end),
+              start_side: (if .code_location.line_range.start != .code_location.line_range.end then "RIGHT" else null end)
+            } | with_entries(select(.value != null))' "$REVIEW_JSON" > findings.jsonl
+
+          while IFS= read -r payload; do
+            response_file="$(mktemp)"
+            status_code=$(curl -sS \
+              -o "$response_file" \
+              -w '%{http_code}' \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${REPOSITORY}/pulls/${PR_NUMBER}/comments" \
+              -d "$payload")
+
+            if [ "${status_code}" -lt 200 ] || [ "${status_code}" -ge 300 ]; then
+              echo "::warning::Failed to publish an inline Codex review comment."
+              cat "$response_file"
+            fi
+
+            rm -f "$response_file"
+          done < findings.jsonl
+        shell: bash
+
+      - name: Publish overall summary comment
+        if: steps.preflight.outputs.should_run == 'true' && always()
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          REVIEW_JSON: codex-output.json
+        run: |
+          set -euo pipefail
+
+          if [ ! -s "$REVIEW_JSON" ]; then
+            echo "Codex output missing; skipping summary."
+            exit 0
+          fi
+
+          overall_state=$(jq -r '.overall_correctness' "$REVIEW_JSON")
+          overall_body=$(jq -r '.overall_explanation' "$REVIEW_JSON")
+          confidence=$(jq -r '.overall_confidence_score' "$REVIEW_JSON")
+          findings_count=$(jq '.findings | length' "$REVIEW_JSON")
+          primary_risk_areas=$(jq -r '.primary_risk_areas | map("`" + . + "`") | join(", ")' "$REVIEW_JSON")
+          spec_update_required=$(jq -r '.spec_update_required' "$REVIEW_JSON")
+          spec_update_reason=$(jq -r '.spec_update_reason' "$REVIEW_JSON")
+          category_breakdown=$(jq -r '
+            .findings
+            | group_by(.category)
+            | map("- `" + .[0].category + "`: " + (length | tostring))
+            | join("\n")
+          ' "$REVIEW_JSON")
+          subsystem_breakdown=$(jq -r '
+            .findings
+            | group_by(.subsystem)
+            | map("- `" + .[0].subsystem + "`: " + (length | tostring))
+            | join("\n")
+          ' "$REVIEW_JSON")
+
+          comment_body=$(
+            jq -n \
+              --arg verdict "$overall_state" \
+              --arg confidence "$confidence" \
+              --arg explanation "$overall_body" \
+              --arg findings "$findings_count" \
+              --arg risks "$primary_risk_areas" \
+              --arg spec_required "$spec_update_required" \
+              --arg spec_reason "$spec_update_reason" \
+              --arg categories "$category_breakdown" \
+              --arg subsystems "$subsystem_breakdown" \
+              '{
+                body:
+                  "<!-- codex-review-summary -->\n**Codex automated review**\n\n" +
+                  "Verdict: " + $verdict + "\n" +
+                  "Confidence: " + $confidence + "\n" +
+                  "Findings: " + $findings + "\n" +
+                  "Primary risk areas: " + (if $risks != "" then $risks else "none" end) + "\n" +
+                  "Spec update required: " + $spec_required + (if $spec_required == "true" and $spec_reason != "" then " (" + $spec_reason + ")" else "" end) + "\n\n" +
+                  (if $categories != "" then "**Category Breakdown**\n" + $categories + "\n\n" else "" end) +
+                  (if $subsystems != "" then "**Subsystem Breakdown**\n" + $subsystems + "\n\n" else "" end) +
+                  $explanation
+              }'
+          )
+
+          curl -fsSL \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+            -d "$comment_body"
+        shell: bash
+
+      - name: Enforce Codex verdict
+        if: steps.preflight.outputs.should_run == 'true' && always()
+        env:
+          REVIEW_JSON: codex-output.json
+        run: |
+          set -euo pipefail
+
+          if [ "${CODEX_REVIEW_BLOCK_ON_INCORRECT}" != "true" ]; then
+            echo "Blocking mode disabled; leaving Codex review advisory."
+            exit 0
+          fi
+
+          verdict=$(jq -r '.overall_correctness' "$REVIEW_JSON")
+          if [ "$verdict" = "patch is incorrect" ]; then
+            echo "Codex marked this patch incorrect and blocking mode is enabled."
+            exit 1
+          fi
+        shell: bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,6 +136,13 @@ oasdiff breaking openapi-main.json openapi.json    # must be empty
 - No lock held across `.await` (clippy catches it; don't silence the lint)
 - No secrets or real production data in fixtures
 
+### Automated review guidance
+
+- Prioritise correctness, security, data integrity, CI regressions, and spec drift over style commentary
+- Flag missing tests for behaviour changes, migrations, API changes, or workflow logic as at least P1
+- Flag missing `Spec.md` updates when a PR changes the CI contract or other architecture-level behaviour
+- Ignore formatting-only nits unless they block understanding of the diff
+
 ## 8. CI rules (what must pass)
 
 Full details in `Spec.md § CI/CD pipeline`. Summary:

--- a/Spec.md
+++ b/Spec.md
@@ -895,6 +895,7 @@ Triggered on PR open/update. All jobs in parallel where possible; total target <
 
 ```
 parallel:
+  - review          (Codex structured PR review → inline findings + summary; advisory unless repo vars enable blocking)
   - typecheck       (cargo check + tsc)
   - lint            (clippy, biome, gitleaks, cargo-deny)
   - build           (sccache cargo + pnpm build)
@@ -908,6 +909,8 @@ parallel:
 ```
 
 All gates from the table above run here. Blocking for merge.
+
+Codex review is an additional review signal, not part of the 14 blocking gates by default. It runs only when `OPENAI_API_KEY` is configured for the repository and the PR originates from the same repository (not a fork). Default model: `gpt-5.5`; allow `CODEX_MODEL`, `CODEX_REVIEW_EFFORT`, and `CODEX_REVIEW_BLOCK_ON_INCORRECT` as repository variables for tuning.
 
 ### 2. Merge-queue flow (`.github/workflows/merge.yml`)
 


### PR DESCRIPTION
## Summary

- Add a GitHub Actions PR review workflow that runs Codex in read-only mode, posts inline findings, and publishes a structured summary comment.
- Add repo-specific review context under `.github/codex/`, including a structured output schema, a mission-aware prompt, and path-specific review guides for domain, DB, ingestion, adapters, API/SDK, frontend, and CI/spec changes.
- Update `AGENTS.md` and `Spec.md` so the automated review behavior and repo-specific review guidance are documented alongside the CI contract.

## Linked issue

No linked GitHub issue was available for this workspace.

## Pass requirements

- [x] Add a Codex-backed PR review stage to GitHub Actions.
- [x] Tailor the review prompt and structure to the repo mission, architecture, and subsystem boundaries.
- [x] Document the automated review behavior in `Spec.md` and `AGENTS.md`.

## Test plan

- [x] Parse-check `.github/workflows/pr.yml` with Ruby `YAML.load_file`
- [x] Validate `.github/codex/output-schema.json` with `jq empty`
- [ ] Full local pre-flight block was not run in this workspace

## Spec / docs impact

- [ ] No Spec changes required
- [x] Spec amended in this PR
- [ ] Spec amendment filed separately (#)

## Checklist

- [x] Conventional commit title
- [x] No secrets committed
- [ ] Tests added/updated
- [ ] `cargo fmt` + `biome format` clean
- [ ] Clippy / Biome warnings resolved
