### PR TITLE
feat(storage): content-addressed BlobStore over object_store (#8)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,7 +207,14 @@ name = "au-kpis-storage"
 version = "0.1.0"
 dependencies = [
  "au-kpis-error",
+ "bytes",
+ "futures",
+ "object_store",
+ "sha2",
+ "testcontainers",
  "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -408,6 +415,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -672,7 +685,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -894,8 +907,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -906,7 +935,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -1118,6 +1147,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1275,6 +1305,15 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1371,6 +1410,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1464,7 +1509,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1503,6 +1548,36 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "object_store"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "humantime",
+ "hyper",
+ "itertools 0.13.0",
+ "md-5",
+ "parking_lot",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.8.6",
+ "reqwest",
+ "ring",
+ "serde",
+ "serde_json",
+ "snafu",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
 ]
 
 [[package]]
@@ -1587,7 +1662,7 @@ dependencies = [
  "glob",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "serde_json",
  "thiserror 1.0.69",
  "tokio",
@@ -1820,7 +1895,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1833,7 +1908,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn",
@@ -1849,6 +1924,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1856,6 +1996,12 @@ checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "r-efi"
@@ -1870,8 +2016,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1881,7 +2037,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1891,6 +2057,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1980,10 +2155,12 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
+ "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -1992,16 +2169,24 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
  "windows-registry",
 ]
@@ -2033,12 +2218,18 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
  "zeroize",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustix"
@@ -2050,7 +2241,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2094,6 +2285,7 @@ version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2119,6 +2311,15 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "schannel"
@@ -2339,7 +2540,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2361,6 +2562,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "snafu"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
+dependencies = [
+ "snafu-derive",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2511,7 +2733,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "serde",
  "sha1",
@@ -2551,7 +2773,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -2666,7 +2888,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3231,6 +3453,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
+
+[[package]]
 name = "want"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3347,6 +3579,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,6 +3666,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ version = "0.1.0"
 name = "au-kpis-storage"
 version = "0.1.0"
 dependencies = [
+ "au-kpis-domain",
  "au-kpis-error",
  "bytes",
  "futures",
@@ -215,6 +216,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "uuid",
 ]
 
 [[package]]
@@ -3430,6 +3432,7 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/Spec.md
+++ b/Spec.md
@@ -79,7 +79,7 @@ returns clean, validated, SDMX-compliant time series regardless of upstream sour
 - Licensing model: **Free tier** — generous default rate limits, API keys for abuse prevention + attribution.
 - SDK: **TypeScript first**; Python/Go SDKs later via same OpenAPI codegen.
 - First dataflow: **ABS CPI** (higher public demand than Labour Force; monthly + quarterly releases).
-- Raw artifacts: **retained in S3/R2 indefinitely** — lifecycle policy moves >1yr objects to cold storage.
+- Raw artifacts: **retained in S3/R2 indefinitely** — lifecycle policy moves >1yr objects to cold storage. Streaming uploads land first in `artifacts-staging/<uuid>` and are copied to `artifacts/<sha256>` once the hash is known; a second lifecycle rule expires `artifacts-staging/` after 7 days so any rare delete-failure leak from the storage crate is bounded. The declarative policy lives in `infra/r2/lifecycle.json`.
 - Rust: **2024 edition, MSRV 1.83**.
 - Migrations: **`sqlx migrate`** (sync-at-startup).
 

--- a/crates/au-kpis-storage/Cargo.toml
+++ b/crates/au-kpis-storage/Cargo.toml
@@ -8,6 +8,7 @@ repository.workspace = true
 description = "object_store wrapper for S3/R2 (content-addressed artifacts)."
 
 [dependencies]
+au-kpis-domain = { workspace = true }
 au-kpis-error = { workspace = true }
 bytes = "1"
 futures = "0.3"
@@ -15,6 +16,7 @@ object_store = { version = "0.11", features = ["aws"] }
 sha2 = "0.10"
 thiserror = "2"
 tracing = "0.1"
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 futures = "0.3"

--- a/crates/au-kpis-storage/Cargo.toml
+++ b/crates/au-kpis-storage/Cargo.toml
@@ -15,6 +15,7 @@ futures = "0.3"
 object_store = { version = "0.11", features = ["aws"] }
 sha2 = "0.10"
 thiserror = "2"
+tokio = { version = "1", features = ["time"] }
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
 

--- a/crates/au-kpis-storage/Cargo.toml
+++ b/crates/au-kpis-storage/Cargo.toml
@@ -5,8 +5,18 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
-description = "object_store wrapper for S3/R2."
+description = "object_store wrapper for S3/R2 (content-addressed artifacts)."
 
 [dependencies]
 au-kpis-error = { workspace = true }
+bytes = "1"
+futures = "0.3"
+object_store = { version = "0.11", features = ["aws"] }
+sha2 = "0.10"
 thiserror = "2"
+tracing = "0.1"
+
+[dev-dependencies]
+futures = "0.3"
+testcontainers = "0.23"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/au-kpis-storage/src/lib.rs
+++ b/crates/au-kpis-storage/src/lib.rs
@@ -272,6 +272,7 @@ impl BlobStore {
         // reads from a slow HTTP response.
         let mut write = WriteMultipart::new(upload);
         let mut hasher = Sha256::new();
+        let mut wrote_any = false;
 
         while let Some(next) = chunks.next().await {
             let chunk = match next {
@@ -285,7 +286,14 @@ impl BlobStore {
                     return Err(StorageError::Source(err.to_string()));
                 }
             };
+            if chunk.is_empty() {
+                // Empty chunks don't affect the sha256 and would just
+                // waste a round-trip through `WriteMultipart::put`;
+                // drop them and keep draining the stream.
+                continue;
+            }
             hasher.update(&chunk);
+            wrote_any = true;
             // Cap in-flight part uploads so a fast producer can't run
             // the process out of memory; 8 concurrent 5 MB parts ≈ 40
             // MB of buffer, which is a reasonable ceiling for the
@@ -296,6 +304,18 @@ impl BlobStore {
             }
             write.put(chunk);
         }
+
+        // Zero-byte streams are legal upstream payloads (an API that
+        // returns an empty body, a 0-byte XLSX) but S3 rejects
+        // `CompleteMultipartUpload` with zero parts. Abort the
+        // multipart and fall through to the single-shot `put_artifact`
+        // path, which hits the canonical key directly via `put()` and
+        // reuses the same head-first idempotency guard.
+        if !wrote_any {
+            let _ = write.abort().await;
+            return self.put_artifact(Bytes::new()).await;
+        }
+
         if let Err(err) = write.finish().await {
             // `WriteMultipart::finish` already attempts an abort when
             // `complete()` fails, so we just surface the error.

--- a/crates/au-kpis-storage/src/lib.rs
+++ b/crates/au-kpis-storage/src/lib.rs
@@ -3,8 +3,9 @@
 //! In production this is backed by Cloudflare R2 via the S3-compatible
 //! API (`object_store::aws::AmazonS3Builder`); locally and in integration
 //! tests we point the same builder at a MinIO container. The public
-//! surface hides the backend — callers see a [`BlobStore`] and
-//! [`au_kpis_domain::ids::ArtifactId`].
+//! surface hides the backend — callers see a [`BlobStore`], a
+//! [`StorageKey`] read handle, and [`au_kpis_domain::ids::ArtifactId`]
+//! for content-addressed writes.
 //!
 //! # Content-addressed writes
 //!
@@ -23,16 +24,30 @@
 //! Both paths are idempotent: a second call with identical content
 //! returns the same [`ArtifactId`] and does not re-write the backend.
 //!
-//! # Streaming reads
+//! # Reads go via the persisted `storage_key`
 //!
-//! [`BlobStore::get_artifact`] returns a [`ByteStream`] so large
-//! artifacts never need to be buffered in memory on the read side
-//! either.
+//! [`BlobStore::get`] / [`BlobStore::exists`] take a [`StorageKey`]
+//! rather than an [`ArtifactId`]. `Artifact.storage_key` is persisted
+//! explicitly in the schema so retention policies can move an artifact
+//! to cold tier (rewriting the key) without changing its id; deriving
+//! the path from the id would 404 after any such move. Callers that
+//! just wrote (or never persist the key) can reconstruct the default
+//! with [`StorageKey::canonical_for`].
+//!
+//! # Staging
+//!
+//! Streaming writes land first in `artifacts-staging/<uuid>` and are
+//! server-side copied to the canonical key once the hash is known. The
+//! staging delete on the happy path is retried with backoff before
+//! being logged — see [`STAGING_PREFIX`] — so the deployment **must**
+//! configure a bucket lifecycle rule that sweeps this prefix (7d is
+//! generous) to catch the rare case where delete fails for longer
+//! than the retry window can cover.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs, missing_debug_implementations)]
 
-use std::{fmt, sync::Arc};
+use std::{fmt, sync::Arc, time::Duration};
 
 use au_kpis_domain::ids::{ArtifactId, Sha256Digest};
 use au_kpis_error::{Classify, CoreError, ErrorClass};
@@ -59,10 +74,53 @@ pub const ARTIFACTS_PREFIX: &str = "artifacts";
 /// inert — a bucket lifecycle rule on this prefix can sweep it later.
 pub const STAGING_PREFIX: &str = "artifacts-staging";
 
-/// Canonical object-store path for an artifact.
-#[must_use]
-pub fn artifact_path(id: &ArtifactId) -> ObjectPath {
-    ObjectPath::from(format!("{ARTIFACTS_PREFIX}/{}", id.to_hex()))
+/// Location at which a blob lives inside the backend.
+///
+/// Two constructors cover both call sites: callers that have just
+/// written go through [`StorageKey::canonical_for`], callers reading
+/// back from a persisted row use [`StorageKey::from_persisted`]. Both
+/// produce the same shape — opaque string — but the split keeps the
+/// intent visible at every call site.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct StorageKey(String);
+
+impl StorageKey {
+    /// The default `artifacts/<hex>` placement written by this crate.
+    #[must_use]
+    pub fn canonical_for(id: &ArtifactId) -> Self {
+        Self(format!("{ARTIFACTS_PREFIX}/{}", id.to_hex()))
+    }
+
+    /// Wrap a key that was previously persisted (e.g. `artifacts.storage_key`
+    /// loaded from Postgres). The crate stores `storage_key` explicitly
+    /// so retention moves can rewrite it, and reads must follow the
+    /// persisted value rather than rederiving it from the digest.
+    #[must_use]
+    pub fn from_persisted(key: impl Into<String>) -> Self {
+        Self(key.into())
+    }
+
+    /// Underlying string representation.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    fn as_object_path(&self) -> ObjectPath {
+        ObjectPath::from(self.0.as_str())
+    }
+}
+
+impl fmt::Display for StorageKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for StorageKey {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
 }
 
 /// Errors returned by the storage layer.
@@ -159,7 +217,7 @@ impl BlobStore {
     #[tracing::instrument(skip(self, content), fields(len = content.len()))]
     pub async fn put_artifact(&self, content: Bytes) -> Result<ArtifactId, StorageError> {
         let id = ArtifactId::of_content(&content);
-        let path = artifact_path(&id);
+        let path = canonical_object_path(&id);
 
         // Content-addressed keys collapse "same content" to "same key",
         // so a successful head means the bytes are already present and
@@ -245,18 +303,18 @@ impl BlobStore {
         }
 
         let id = ArtifactId::from_digest(Sha256Digest::from_bytes(hasher.finalize().into()));
-        let canonical = artifact_path(&id);
+        let canonical = canonical_object_path(&id);
 
         // Canonical key already present → discard the stage; caller
         // still gets the deterministic id.
         match self.inner.head(&canonical).await {
             Ok(_) => {
-                let _ = self.inner.delete(&staging_path).await;
+                self.best_effort_delete_staging(&staging_path).await;
                 return Ok(id);
             }
             Err(ObjectStoreError::NotFound { .. }) => {}
             Err(err) => {
-                let _ = self.inner.delete(&staging_path).await;
+                self.best_effort_delete_staging(&staging_path).await;
                 return Err(StorageError::from_object_store(err));
             }
         }
@@ -266,23 +324,25 @@ impl BlobStore {
         // content-addressed means "same bytes" even if a concurrent
         // writer got there first.
         if let Err(err) = self.inner.copy(&staging_path, &canonical).await {
-            let _ = self.inner.delete(&staging_path).await;
+            self.best_effort_delete_staging(&staging_path).await;
             return Err(StorageError::from_object_store(err));
         }
-        let _ = self.inner.delete(&staging_path).await;
+        self.best_effort_delete_staging(&staging_path).await;
         Ok(id)
     }
 
-    /// Return a streaming reader of the artifact at `id`.
+    /// Return a streaming reader of the artifact at `key`.
     ///
-    /// Yields chunks of [`Bytes`] as the backend delivers them; no
-    /// in-memory buffer of the full body is materialised.
+    /// Takes the persisted [`StorageKey`] rather than an
+    /// [`ArtifactId`] so retention-tier moves that rewrite the row's
+    /// `storage_key` continue to resolve after the move. Yields chunks
+    /// of [`Bytes`] as the backend delivers them; no in-memory buffer
+    /// of the full body is materialised.
     #[tracing::instrument(skip(self))]
-    pub async fn get_artifact(&self, id: &ArtifactId) -> Result<ByteStream, StorageError> {
-        let path = artifact_path(id);
+    pub async fn get(&self, key: &StorageKey) -> Result<ByteStream, StorageError> {
         let result = self
             .inner
-            .get(&path)
+            .get(&key.as_object_path())
             .await
             .map_err(StorageError::from_object_store)?;
         Ok(result
@@ -291,15 +351,57 @@ impl BlobStore {
             .boxed())
     }
 
-    /// Return `true` when the artifact at `id` is present.
+    /// Return `true` when an object exists at `key`.
     #[tracing::instrument(skip(self))]
-    pub async fn contains(&self, id: &ArtifactId) -> Result<bool, StorageError> {
-        match self.inner.head(&artifact_path(id)).await {
+    pub async fn exists(&self, key: &StorageKey) -> Result<bool, StorageError> {
+        match self.inner.head(&key.as_object_path()).await {
             Ok(_) => Ok(true),
             Err(ObjectStoreError::NotFound { .. }) => Ok(false),
             Err(err) => Err(StorageError::Backend(err)),
         }
     }
+
+    /// Retrying staging delete.
+    ///
+    /// A failed staging delete after a successful canonical write is
+    /// non-fatal for the caller — the bytes they wanted are in place —
+    /// but silently swallowing the error lets staging grow without
+    /// bound. Retry a few times with exponential backoff, then log at
+    /// `warn` level with the key so the bucket lifecycle rule (see
+    /// [`STAGING_PREFIX`] docs) and oncall both have a record. We
+    /// never surface this as an error: turning a benign staging leak
+    /// into a put failure would be a worse outcome.
+    async fn best_effort_delete_staging(&self, path: &ObjectPath) {
+        const ATTEMPTS: u32 = 3;
+        let mut backoff = Duration::from_millis(100);
+        let mut last_err: Option<ObjectStoreError> = None;
+        for _ in 0..ATTEMPTS {
+            match self.inner.delete(path).await {
+                Ok(()) => return,
+                // A concurrent cleanup (or a lifecycle sweep) may have
+                // already removed the object; nothing to do.
+                Err(ObjectStoreError::NotFound { .. }) => return,
+                Err(err) => {
+                    last_err = Some(err);
+                    tokio::time::sleep(backoff).await;
+                    backoff *= 2;
+                }
+            }
+        }
+        tracing::warn!(
+            staging_key = %path,
+            error = ?last_err,
+            "failed to delete staging object after {ATTEMPTS} retries; \
+             the bucket lifecycle rule on `{STAGING_PREFIX}/` will sweep it eventually",
+        );
+    }
+}
+
+/// Internal helper: object-store path for the canonical write target.
+/// Kept private so callers cannot accidentally bypass `StorageKey`
+/// when reading.
+fn canonical_object_path(id: &ArtifactId) -> ObjectPath {
+    ObjectPath::from(format!("{ARTIFACTS_PREFIX}/{}", id.to_hex()))
 }
 
 #[cfg(test)]
@@ -307,7 +409,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn artifact_path_matches_known_empty_vector() {
+    fn canonical_storage_key_matches_known_empty_vector() {
         // SHA-256 of the empty string is a fixed reference value; if
         // the hashing glue ever regresses (wrong encoding, double-hash,
         // truncation) this test is the first to notice.
@@ -317,9 +419,18 @@ mod tests {
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
         assert_eq!(
-            artifact_path(&id).as_ref(),
+            StorageKey::canonical_for(&id).as_str(),
             "artifacts/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
+    }
+
+    #[test]
+    fn storage_key_from_persisted_preserves_arbitrary_path() {
+        // The domain model allows retention moves to rewrite
+        // `storage_key` to something outside `artifacts/...` — the
+        // read API must treat the string as opaque.
+        let moved = StorageKey::from_persisted("cold/2024/abc123");
+        assert_eq!(moved.as_str(), "cold/2024/abc123");
     }
 
     #[test]

--- a/crates/au-kpis-storage/src/lib.rs
+++ b/crates/au-kpis-storage/src/lib.rs
@@ -1,16 +1,79 @@
-//! object_store wrapper for S3/R2.
+//! Blob storage abstraction over `object_store`.
 //!
-//! Only the error type is fleshed out at this stage — it demonstrates the
-//! composition pattern from `au-kpis-error` that all library crates follow:
-//! cross-cutting variants come in via `#[from] CoreError`, backend-specific
-//! variants are added as explicit members, and `Classify` bubbles retry
-//! policy up to the queue.
+//! In production we back this with Cloudflare R2 via the S3-compatible
+//! API (`object_store::aws::AmazonS3Builder`); locally and in integration
+//! tests we point the same builder at a MinIO container. The public
+//! surface hides the backend — callers see a [`BlobStore`] and an
+//! opaque, content-addressed [`Sha256Key`].
+//!
+//! # Content-addressed writes
+//!
+//! [`BlobStore::put_artifact`] hashes the payload with SHA-256 and
+//! writes it under a deterministic key (`artifacts/<hex-digest>`). A
+//! second call with identical content returns the same [`Sha256Key`]
+//! **and does not re-write the backend**, satisfying the idempotency
+//! contract in `Spec.md § Ingestion pipeline` (fetch is the one step
+//! we re-run on every retry).
+//!
+//! # Streaming reads
+//!
+//! [`BlobStore::get_artifact`] returns a [`ByteStream`] so large
+//! artifacts (multi-GB ABS dumps) never need to be buffered in memory.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs, missing_debug_implementations)]
 
+use std::{fmt, sync::Arc};
+
 use au_kpis_error::{Classify, CoreError, ErrorClass};
+use bytes::Bytes;
+use futures::{StreamExt, stream::BoxStream};
+use object_store::{Error as ObjectStoreError, ObjectStore, path::Path as ObjectPath};
+use sha2::{Digest, Sha256};
 use thiserror::Error;
+
+/// Prefix applied to every content-addressed key.
+///
+/// The ingestion spec (`Spec.md § Database schema — artifacts`) places
+/// raw source files under this namespace; keeping it as a constant means
+/// loader queries and storage writes agree by construction.
+pub const ARTIFACTS_PREFIX: &str = "artifacts";
+
+/// Content-addressed key for an artifact.
+///
+/// Wraps the lower-case hex encoding of the payload's SHA-256 digest.
+/// The underlying string is always 64 characters long and matches
+/// `[0-9a-f]{64}`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Sha256Key(String);
+
+impl Sha256Key {
+    /// Compute the sha256 of `content` and wrap it as a key.
+    #[must_use]
+    pub fn from_content(content: &[u8]) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(content);
+        Self(hex_encode(hasher.finalize().as_slice()))
+    }
+
+    /// Lower-case hex encoding of the digest (no prefix).
+    #[must_use]
+    pub fn as_hex(&self) -> &str {
+        &self.0
+    }
+
+    /// Full object-store path, including the `artifacts/` prefix.
+    #[must_use]
+    pub fn to_object_path(&self) -> ObjectPath {
+        ObjectPath::from(format!("{ARTIFACTS_PREFIX}/{}", self.0))
+    }
+}
+
+impl fmt::Display for Sha256Key {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
 
 /// Errors returned by the storage layer.
 #[derive(Debug, Error)]
@@ -21,7 +84,7 @@ pub enum StorageError {
 
     /// Upstream object-store backend returned an unexpected failure.
     #[error("object store backend: {0}")]
-    Backend(String),
+    Backend(#[source] ObjectStoreError),
 
     /// The requested key does not exist in the backend.
     #[error("object not found: {0}")]
@@ -32,15 +95,169 @@ impl Classify for StorageError {
     fn class(&self) -> ErrorClass {
         match self {
             StorageError::Core(e) => e.class(),
+            // Network blips, 5xx, or transient rate-limits from the
+            // backend all land here; retry is the right default.
             StorageError::Backend(_) => ErrorClass::Transient,
+            // Content-addressed keys don't "appear later" — a NotFound
+            // means the producer never wrote the artifact, so retrying
+            // the fetch will keep failing in the same way.
             StorageError::NotFound(_) => ErrorClass::Permanent,
         }
     }
 }
 
+impl StorageError {
+    fn from_object_store(err: ObjectStoreError) -> Self {
+        match err {
+            ObjectStoreError::NotFound { path, .. } => StorageError::NotFound(path),
+            other => StorageError::Backend(other),
+        }
+    }
+}
+
+/// Streamed body returned by [`BlobStore::get_artifact`].
+pub type ByteStream = BoxStream<'static, Result<Bytes, StorageError>>;
+
+/// Content-addressed blob store.
+#[derive(Clone)]
+pub struct BlobStore {
+    inner: Arc<dyn ObjectStore>,
+}
+
+impl fmt::Debug for BlobStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("BlobStore").finish_non_exhaustive()
+    }
+}
+
+impl BlobStore {
+    /// Wrap an `ObjectStore` implementation. Key layout is owned by this
+    /// crate, so the passed-in store should be scoped to a bucket/root
+    /// without an extra prefix.
+    #[must_use]
+    pub fn new<S: ObjectStore + 'static>(inner: S) -> Self {
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    /// Wrap a pre-shared `Arc<dyn ObjectStore>`. Useful in tests that
+    /// also want to inspect the backend directly (e.g. comparing
+    /// `ObjectMeta` across `put_artifact` calls).
+    #[must_use]
+    pub fn from_arc(inner: Arc<dyn ObjectStore>) -> Self {
+        Self { inner }
+    }
+
+    /// Write `content` under its content-addressed key.
+    ///
+    /// If a blob with the same hash is already present the call is a
+    /// no-op: the backend is **not** re-written. Either way the caller
+    /// receives the canonical [`Sha256Key`].
+    #[tracing::instrument(skip(self, content), fields(len = content.len()))]
+    pub async fn put_artifact(&self, content: Bytes) -> Result<Sha256Key, StorageError> {
+        let key = Sha256Key::from_content(&content);
+        let path = key.to_object_path();
+
+        // Content-addressed keys collapse "same content" to "same key",
+        // so a successful head means the bytes are already present and
+        // a fresh write would just be a duplicate PUT. Skipping it
+        // delivers the "no rewrite" half of the idempotency contract
+        // and stays portable across S3/R2/MinIO — conditional writes
+        // (`PutMode::Create`) aren't universally supported.
+        match self.inner.head(&path).await {
+            Ok(_) => return Ok(key),
+            Err(ObjectStoreError::NotFound { .. }) => {}
+            Err(err) => return Err(StorageError::from_object_store(err)),
+        }
+
+        self.inner
+            .put(&path, content.into())
+            .await
+            .map_err(StorageError::from_object_store)?;
+        Ok(key)
+    }
+
+    /// Return a streaming reader of the artifact at `key`.
+    ///
+    /// Yields chunks of [`Bytes`] as the backend delivers them; no
+    /// in-memory buffer of the full body is materialised.
+    #[tracing::instrument(skip(self))]
+    pub async fn get_artifact(&self, key: &Sha256Key) -> Result<ByteStream, StorageError> {
+        let path = key.to_object_path();
+        let result = self
+            .inner
+            .get(&path)
+            .await
+            .map_err(StorageError::from_object_store)?;
+        Ok(result
+            .into_stream()
+            .map(|chunk| chunk.map_err(StorageError::from_object_store))
+            .boxed())
+    }
+
+    /// Return `true` when the artifact at `key` is present.
+    #[tracing::instrument(skip(self))]
+    pub async fn contains(&self, key: &Sha256Key) -> Result<bool, StorageError> {
+        match self.inner.head(&key.to_object_path()).await {
+            Ok(_) => Ok(true),
+            Err(ObjectStoreError::NotFound { .. }) => Ok(false),
+            Err(err) => Err(StorageError::Backend(err)),
+        }
+    }
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        out.push(HEX[(byte >> 4) as usize] as char);
+        out.push(HEX[(byte & 0x0f) as usize] as char);
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn sha256_key_matches_known_vector() {
+        // SHA-256 of the empty string is a fixed reference value; if
+        // the hashing glue ever regresses (wrong encoding, double-hash,
+        // truncation) this test is the first to notice.
+        let key = Sha256Key::from_content(b"");
+        assert_eq!(
+            key.as_hex(),
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+        assert_eq!(
+            key.to_object_path().as_ref(),
+            "artifacts/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+        );
+    }
+
+    #[test]
+    fn sha256_key_is_deterministic() {
+        let a = Sha256Key::from_content(b"hello world");
+        let b = Sha256Key::from_content(b"hello world");
+        assert_eq!(a, b);
+        assert_eq!(a.as_hex().len(), 64);
+        assert!(a.as_hex().chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn distinct_content_yields_distinct_keys() {
+        let a = Sha256Key::from_content(b"hello");
+        let b = Sha256Key::from_content(b"hell0");
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn hex_encode_round_trips_known_bytes() {
+        assert_eq!(hex_encode(&[0x00, 0x0f, 0xff]), "000fff");
+        assert_eq!(hex_encode(&[0xde, 0xad, 0xbe, 0xef]), "deadbeef");
+    }
 
     #[test]
     fn core_error_flows_through_from() {
@@ -51,17 +268,31 @@ mod tests {
 
     #[test]
     fn backend_is_transient() {
-        assert_eq!(
-            StorageError::Backend("timeout".into()).class(),
-            ErrorClass::Transient
-        );
+        let err = StorageError::Backend(ObjectStoreError::Generic {
+            store: "test",
+            source: "boom".into(),
+        });
+        assert_eq!(err.class(), ErrorClass::Transient);
     }
 
     #[test]
     fn not_found_is_permanent() {
         assert_eq!(
             StorageError::NotFound("artifacts/abc".into()).class(),
-            ErrorClass::Permanent
+            ErrorClass::Permanent,
         );
+    }
+
+    #[test]
+    fn from_object_store_maps_not_found() {
+        let raw = ObjectStoreError::NotFound {
+            path: "artifacts/abc".into(),
+            source: "missing".into(),
+        };
+        let mapped = StorageError::from_object_store(raw);
+        match mapped {
+            StorageError::NotFound(p) => assert_eq!(p, "artifacts/abc"),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
     }
 }

--- a/crates/au-kpis-storage/src/lib.rs
+++ b/crates/au-kpis-storage/src/lib.rs
@@ -1,78 +1,68 @@
 //! Blob storage abstraction over `object_store`.
 //!
-//! In production we back this with Cloudflare R2 via the S3-compatible
+//! In production this is backed by Cloudflare R2 via the S3-compatible
 //! API (`object_store::aws::AmazonS3Builder`); locally and in integration
 //! tests we point the same builder at a MinIO container. The public
-//! surface hides the backend — callers see a [`BlobStore`] and an
-//! opaque, content-addressed [`Sha256Key`].
+//! surface hides the backend — callers see a [`BlobStore`] and
+//! [`au_kpis_domain::ids::ArtifactId`].
 //!
 //! # Content-addressed writes
 //!
-//! [`BlobStore::put_artifact`] hashes the payload with SHA-256 and
-//! writes it under a deterministic key (`artifacts/<hex-digest>`). A
-//! second call with identical content returns the same [`Sha256Key`]
-//! **and does not re-write the backend**, satisfying the idempotency
-//! contract in `Spec.md § Ingestion pipeline` (fetch is the one step
-//! we re-run on every retry).
+//! Two write paths share the same canonical key layout
+//! (`artifacts/<hex-digest>`) and return the same [`ArtifactId`]:
+//!
+//! * [`BlobStore::put_artifact`] — takes a `Bytes` value already in
+//!   memory. Cheapest path for small/medium artifacts that a caller
+//!   has already buffered.
+//! * [`BlobStore::put_artifact_stream`] — takes a `Stream<Item =
+//!   Result<Bytes, _>>`, hashes each chunk as it flows, and uploads
+//!   via `put_multipart`. **No in-memory buffer of the full body is
+//!   materialised**, which is what the adapter fetch stage needs for
+//!   multi-GB upstream files (`Spec.md § Ingestion pipeline`).
+//!
+//! Both paths are idempotent: a second call with identical content
+//! returns the same [`ArtifactId`] and does not re-write the backend.
 //!
 //! # Streaming reads
 //!
 //! [`BlobStore::get_artifact`] returns a [`ByteStream`] so large
-//! artifacts (multi-GB ABS dumps) never need to be buffered in memory.
+//! artifacts never need to be buffered in memory on the read side
+//! either.
 
 #![forbid(unsafe_code)]
 #![deny(missing_docs, missing_debug_implementations)]
 
 use std::{fmt, sync::Arc};
 
+use au_kpis_domain::ids::{ArtifactId, Sha256Digest};
 use au_kpis_error::{Classify, CoreError, ErrorClass};
 use bytes::Bytes;
-use futures::{StreamExt, stream::BoxStream};
-use object_store::{Error as ObjectStoreError, ObjectStore, path::Path as ObjectPath};
+use futures::{Stream, StreamExt, stream::BoxStream};
+use object_store::{
+    Error as ObjectStoreError, ObjectStore, WriteMultipart, path::Path as ObjectPath,
+};
 use sha2::{Digest, Sha256};
 use thiserror::Error;
 
-/// Prefix applied to every content-addressed key.
+/// Prefix applied to every canonical content-addressed key.
 ///
 /// The ingestion spec (`Spec.md § Database schema — artifacts`) places
 /// raw source files under this namespace; keeping it as a constant means
 /// loader queries and storage writes agree by construction.
 pub const ARTIFACTS_PREFIX: &str = "artifacts";
 
-/// Content-addressed key for an artifact.
+/// Prefix used for in-flight streaming uploads.
 ///
-/// Wraps the lower-case hex encoding of the payload's SHA-256 digest.
-/// The underlying string is always 64 characters long and matches
-/// `[0-9a-f]{64}`.
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Sha256Key(String);
+/// A streaming `put` cannot know the sha256 until the last byte has
+/// been hashed, so it writes to `artifacts-staging/<uuid>` first, then
+/// server-side copies to `artifacts/<hex>`. A dead staging object is
+/// inert — a bucket lifecycle rule on this prefix can sweep it later.
+pub const STAGING_PREFIX: &str = "artifacts-staging";
 
-impl Sha256Key {
-    /// Compute the sha256 of `content` and wrap it as a key.
-    #[must_use]
-    pub fn from_content(content: &[u8]) -> Self {
-        let mut hasher = Sha256::new();
-        hasher.update(content);
-        Self(hex_encode(hasher.finalize().as_slice()))
-    }
-
-    /// Lower-case hex encoding of the digest (no prefix).
-    #[must_use]
-    pub fn as_hex(&self) -> &str {
-        &self.0
-    }
-
-    /// Full object-store path, including the `artifacts/` prefix.
-    #[must_use]
-    pub fn to_object_path(&self) -> ObjectPath {
-        ObjectPath::from(format!("{ARTIFACTS_PREFIX}/{}", self.0))
-    }
-}
-
-impl fmt::Display for Sha256Key {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
+/// Canonical object-store path for an artifact.
+#[must_use]
+pub fn artifact_path(id: &ArtifactId) -> ObjectPath {
+    ObjectPath::from(format!("{ARTIFACTS_PREFIX}/{}", id.to_hex()))
 }
 
 /// Errors returned by the storage layer.
@@ -89,6 +79,14 @@ pub enum StorageError {
     /// The requested key does not exist in the backend.
     #[error("object not found: {0}")]
     NotFound(String),
+
+    /// A caller-supplied stream yielded an error mid-upload.
+    ///
+    /// Stored as a string so the variant stays `Send + Sync + 'static`
+    /// and round-trips through `thiserror` cleanly; the original error
+    /// is displayed via `{}` before being captured.
+    #[error("source stream: {0}")]
+    Source(String),
 }
 
 impl Classify for StorageError {
@@ -102,6 +100,10 @@ impl Classify for StorageError {
             // means the producer never wrote the artifact, so retrying
             // the fetch will keep failing in the same way.
             StorageError::NotFound(_) => ErrorClass::Permanent,
+            // A failed upstream stream usually means the adapter's
+            // fetch hit a transport error partway through; let the
+            // queue retry with backoff.
+            StorageError::Source(_) => ErrorClass::Transient,
         }
     }
 }
@@ -153,11 +155,11 @@ impl BlobStore {
     ///
     /// If a blob with the same hash is already present the call is a
     /// no-op: the backend is **not** re-written. Either way the caller
-    /// receives the canonical [`Sha256Key`].
+    /// receives the canonical [`ArtifactId`].
     #[tracing::instrument(skip(self, content), fields(len = content.len()))]
-    pub async fn put_artifact(&self, content: Bytes) -> Result<Sha256Key, StorageError> {
-        let key = Sha256Key::from_content(&content);
-        let path = key.to_object_path();
+    pub async fn put_artifact(&self, content: Bytes) -> Result<ArtifactId, StorageError> {
+        let id = ArtifactId::of_content(&content);
+        let path = artifact_path(&id);
 
         // Content-addressed keys collapse "same content" to "same key",
         // so a successful head means the bytes are already present and
@@ -166,7 +168,7 @@ impl BlobStore {
         // and stays portable across S3/R2/MinIO — conditional writes
         // (`PutMode::Create`) aren't universally supported.
         match self.inner.head(&path).await {
-            Ok(_) => return Ok(key),
+            Ok(_) => return Ok(id),
             Err(ObjectStoreError::NotFound { .. }) => {}
             Err(err) => return Err(StorageError::from_object_store(err)),
         }
@@ -175,16 +177,109 @@ impl BlobStore {
             .put(&path, content.into())
             .await
             .map_err(StorageError::from_object_store)?;
-        Ok(key)
+        Ok(id)
     }
 
-    /// Return a streaming reader of the artifact at `key`.
+    /// Stream `chunks` to the backend while hashing on the fly, then
+    /// land the content under the canonical `artifacts/<hex>` key.
+    ///
+    /// Writes are performed via `put_multipart` to a staging key so the
+    /// backend never has to see the whole body at once. The sha256 is
+    /// only known after the stream drains, so once it does the method
+    /// server-side copies the staged object to its canonical key (no
+    /// client round-trip of the bytes) and deletes the stage. A stream
+    /// error or a backend error during upload aborts the multipart,
+    /// leaving no partial object behind.
+    ///
+    /// Returns the canonical [`ArtifactId`] regardless of whether the
+    /// canonical key already existed — matching [`put_artifact`]'s
+    /// idempotency contract.
+    #[tracing::instrument(skip(self, chunks))]
+    pub async fn put_artifact_stream<S, E>(&self, mut chunks: S) -> Result<ArtifactId, StorageError>
+    where
+        S: Stream<Item = Result<Bytes, E>> + Unpin + Send,
+        E: fmt::Display,
+    {
+        let staging_path = ObjectPath::from(format!("{STAGING_PREFIX}/{}", uuid::Uuid::new_v4()));
+
+        let upload = self
+            .inner
+            .put_multipart(&staging_path)
+            .await
+            .map_err(StorageError::from_object_store)?;
+        // `WriteMultipart` batches small input chunks into 5 MB parts
+        // before dispatching them — S3/R2/MinIO reject intermediate
+        // parts below 5 MB (`EntityTooSmall`), so a naive per-chunk
+        // `put_part` breaks the moment a caller streams ~KB-sized
+        // reads from a slow HTTP response.
+        let mut write = WriteMultipart::new(upload);
+        let mut hasher = Sha256::new();
+
+        while let Some(next) = chunks.next().await {
+            let chunk = match next {
+                Ok(chunk) => chunk,
+                Err(err) => {
+                    // Best-effort abort; the staging key is disposable
+                    // either way. We swallow abort errors so the
+                    // original source-stream failure reaches the caller
+                    // instead of being masked.
+                    let _ = write.abort().await;
+                    return Err(StorageError::Source(err.to_string()));
+                }
+            };
+            hasher.update(&chunk);
+            // Cap in-flight part uploads so a fast producer can't run
+            // the process out of memory; 8 concurrent 5 MB parts ≈ 40
+            // MB of buffer, which is a reasonable ceiling for the
+            // ingestion binary.
+            if let Err(err) = write.wait_for_capacity(8).await {
+                let _ = write.abort().await;
+                return Err(StorageError::from_object_store(err));
+            }
+            write.put(chunk);
+        }
+        if let Err(err) = write.finish().await {
+            // `WriteMultipart::finish` already attempts an abort when
+            // `complete()` fails, so we just surface the error.
+            return Err(StorageError::from_object_store(err));
+        }
+
+        let id = ArtifactId::from_digest(Sha256Digest::from_bytes(hasher.finalize().into()));
+        let canonical = artifact_path(&id);
+
+        // Canonical key already present → discard the stage; caller
+        // still gets the deterministic id.
+        match self.inner.head(&canonical).await {
+            Ok(_) => {
+                let _ = self.inner.delete(&staging_path).await;
+                return Ok(id);
+            }
+            Err(ObjectStoreError::NotFound { .. }) => {}
+            Err(err) => {
+                let _ = self.inner.delete(&staging_path).await;
+                return Err(StorageError::from_object_store(err));
+            }
+        }
+
+        // Server-side copy; the bytes never travel back through this
+        // process. `copy` overwrites on S3/R2/MinIO, which is fine:
+        // content-addressed means "same bytes" even if a concurrent
+        // writer got there first.
+        if let Err(err) = self.inner.copy(&staging_path, &canonical).await {
+            let _ = self.inner.delete(&staging_path).await;
+            return Err(StorageError::from_object_store(err));
+        }
+        let _ = self.inner.delete(&staging_path).await;
+        Ok(id)
+    }
+
+    /// Return a streaming reader of the artifact at `id`.
     ///
     /// Yields chunks of [`Bytes`] as the backend delivers them; no
     /// in-memory buffer of the full body is materialised.
     #[tracing::instrument(skip(self))]
-    pub async fn get_artifact(&self, key: &Sha256Key) -> Result<ByteStream, StorageError> {
-        let path = key.to_object_path();
+    pub async fn get_artifact(&self, id: &ArtifactId) -> Result<ByteStream, StorageError> {
+        let path = artifact_path(id);
         let result = self
             .inner
             .get(&path)
@@ -196,10 +291,10 @@ impl BlobStore {
             .boxed())
     }
 
-    /// Return `true` when the artifact at `key` is present.
+    /// Return `true` when the artifact at `id` is present.
     #[tracing::instrument(skip(self))]
-    pub async fn contains(&self, key: &Sha256Key) -> Result<bool, StorageError> {
-        match self.inner.head(&key.to_object_path()).await {
+    pub async fn contains(&self, id: &ArtifactId) -> Result<bool, StorageError> {
+        match self.inner.head(&artifact_path(id)).await {
             Ok(_) => Ok(true),
             Err(ObjectStoreError::NotFound { .. }) => Ok(false),
             Err(err) => Err(StorageError::Backend(err)),
@@ -207,56 +302,44 @@ impl BlobStore {
     }
 }
 
-fn hex_encode(bytes: &[u8]) -> String {
-    const HEX: &[u8; 16] = b"0123456789abcdef";
-    let mut out = String::with_capacity(bytes.len() * 2);
-    for byte in bytes {
-        out.push(HEX[(byte >> 4) as usize] as char);
-        out.push(HEX[(byte & 0x0f) as usize] as char);
-    }
-    out
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
-    fn sha256_key_matches_known_vector() {
+    fn artifact_path_matches_known_empty_vector() {
         // SHA-256 of the empty string is a fixed reference value; if
         // the hashing glue ever regresses (wrong encoding, double-hash,
         // truncation) this test is the first to notice.
-        let key = Sha256Key::from_content(b"");
+        let id = ArtifactId::of_content(b"");
         assert_eq!(
-            key.as_hex(),
+            id.to_hex(),
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
         assert_eq!(
-            key.to_object_path().as_ref(),
+            artifact_path(&id).as_ref(),
             "artifacts/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         );
     }
 
     #[test]
-    fn sha256_key_is_deterministic() {
-        let a = Sha256Key::from_content(b"hello world");
-        let b = Sha256Key::from_content(b"hello world");
+    fn artifact_id_is_deterministic_and_reversible_via_hex() {
+        // The reviewer's P2 on PR #74 was that downstream stages
+        // persist the digest and need to reconstruct an id from it.
+        // Guard that invariant by round-tripping through hex.
+        let a = ArtifactId::of_content(b"hello world");
+        let b = ArtifactId::of_content(b"hello world");
         assert_eq!(a, b);
-        assert_eq!(a.as_hex().len(), 64);
-        assert!(a.as_hex().chars().all(|c| c.is_ascii_hexdigit()));
+
+        let restored = ArtifactId::from_hex(&a.to_hex()).expect("hex round-trip");
+        assert_eq!(restored, a);
     }
 
     #[test]
-    fn distinct_content_yields_distinct_keys() {
-        let a = Sha256Key::from_content(b"hello");
-        let b = Sha256Key::from_content(b"hell0");
+    fn distinct_content_yields_distinct_ids() {
+        let a = ArtifactId::of_content(b"hello");
+        let b = ArtifactId::of_content(b"hell0");
         assert_ne!(a, b);
-    }
-
-    #[test]
-    fn hex_encode_round_trips_known_bytes() {
-        assert_eq!(hex_encode(&[0x00, 0x0f, 0xff]), "000fff");
-        assert_eq!(hex_encode(&[0xde, 0xad, 0xbe, 0xef]), "deadbeef");
     }
 
     #[test]
@@ -280,6 +363,14 @@ mod tests {
         assert_eq!(
             StorageError::NotFound("artifacts/abc".into()).class(),
             ErrorClass::Permanent,
+        );
+    }
+
+    #[test]
+    fn source_stream_is_transient() {
+        assert_eq!(
+            StorageError::Source("broken pipe".into()).class(),
+            ErrorClass::Transient,
         );
     }
 

--- a/crates/au-kpis-storage/tests/minio.rs
+++ b/crates/au-kpis-storage/tests/minio.rs
@@ -1,0 +1,202 @@
+//! Integration tests for `au-kpis-storage` against a real MinIO backend.
+//!
+//! The spec calls for content-addressed, idempotent artifact writes and
+//! streaming reads (`Spec.md § Ingestion pipeline`, issue #8). Asserting
+//! those contracts against the real `AmazonS3` client — pointed at a
+//! MinIO container — catches SigV4 / path-style / conditional-write
+//! regressions that a pure in-memory stub would not.
+//!
+//! Requires a working Docker daemon. In CI the job runs against the
+//! default socket; locally `colima start` or Docker Desktop is enough.
+
+use std::{sync::Arc, time::Duration};
+
+use au_kpis_storage::{BlobStore, Sha256Key, StorageError};
+use bytes::Bytes;
+use futures::StreamExt;
+use object_store::{ObjectStore, aws::AmazonS3Builder};
+use testcontainers::{
+    ContainerAsync, GenericImage, ImageExt,
+    core::{ContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+const MINIO_IMAGE: &str = "minio/minio";
+const MINIO_TAG: &str = "RELEASE.2024-10-02T17-50-41Z";
+const MINIO_PORT: u16 = 9000;
+const BUCKET: &str = "au-kpis-test";
+const ACCESS_KEY: &str = "minioadmin";
+const SECRET_KEY: &str = "minioadmin";
+
+struct Harness {
+    // Holds the container alive for the lifetime of the test.
+    _container: ContainerAsync<GenericImage>,
+    store: Arc<dyn ObjectStore>,
+}
+
+async fn start_minio() -> Harness {
+    // MinIO's official image does not offer an env-var bucket
+    // bootstrap; overriding the entrypoint to `sh -c` lets us
+    // pre-create the bucket directory (MinIO treats top-level dirs
+    // under the data path as buckets) before starting the server.
+    let start_script = format!(
+        "mkdir -p /data/{BUCKET} && exec minio server /data --address :{MINIO_PORT} --console-address :9001"
+    );
+    let container = GenericImage::new(MINIO_IMAGE, MINIO_TAG)
+        .with_exposed_port(ContainerPort::Tcp(MINIO_PORT))
+        // MinIO writes all its startup banner to stderr (including the
+        // "API:" line), so that's the only stream worth watching.
+        .with_wait_for(WaitFor::message_on_stderr("API:"))
+        .with_entrypoint("sh")
+        .with_env_var("MINIO_ROOT_USER", ACCESS_KEY)
+        .with_env_var("MINIO_ROOT_PASSWORD", SECRET_KEY)
+        .with_cmd(["-c", start_script.as_str()])
+        .start()
+        .await
+        .expect("start minio container");
+
+    let host = container.get_host().await.expect("container host");
+    let port = container
+        .get_host_port_ipv4(MINIO_PORT)
+        .await
+        .expect("host port");
+    let endpoint = format!("http://{host}:{port}");
+
+    let store = build_store(&endpoint);
+    let store: Arc<dyn ObjectStore> = Arc::new(store);
+
+    // MinIO is ready the moment it logs the API line, but the first
+    // SigV4 request still races against the HTTP listener binding.
+    // A short probe loop avoids the flake.
+    wait_for_ready(&store).await;
+
+    Harness {
+        _container: container,
+        store,
+    }
+}
+
+fn build_store(endpoint: &str) -> object_store::aws::AmazonS3 {
+    AmazonS3Builder::new()
+        .with_endpoint(endpoint)
+        .with_region("us-east-1")
+        .with_bucket_name(BUCKET)
+        .with_access_key_id(ACCESS_KEY)
+        .with_secret_access_key(SECRET_KEY)
+        .with_allow_http(true)
+        .with_virtual_hosted_style_request(false)
+        .build()
+        .expect("build AmazonS3")
+}
+
+async fn wait_for_ready(store: &Arc<dyn ObjectStore>) {
+    let probe = object_store::path::Path::from("readiness-probe");
+    for _ in 0..20 {
+        // A list() call is cheap and succeeds as soon as the bucket is
+        // reachable; NotFound on an individual key would also be fine,
+        // but the list form also validates credentials.
+        let mut stream = store.list(Some(&probe));
+        if stream.next().await.is_none() || stream.next().await.is_some() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+    panic!("minio did not become ready within the retry window");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn put_artifact_is_content_addressed() {
+    let h = start_minio().await;
+    let blob = BlobStore::from_arc(Arc::clone(&h.store));
+
+    let content = Bytes::from_static(b"the quick brown fox");
+    let key = blob.put_artifact(content.clone()).await.expect("put");
+
+    // Key matches the sha256 of the bytes we wrote, computed without
+    // going through the blob store.
+    let expected = Sha256Key::from_content(&content);
+    assert_eq!(key, expected);
+
+    // Distinct content → distinct key.
+    let other = Bytes::from_static(b"the quick brown foz");
+    let other_key = blob.put_artifact(other).await.expect("put other");
+    assert_ne!(key, other_key);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn put_artifact_is_idempotent_and_does_not_rewrite() {
+    let h = start_minio().await;
+    let blob = BlobStore::from_arc(Arc::clone(&h.store));
+
+    let content = Bytes::from_static(b"idempotent payload");
+    let key = blob.put_artifact(content.clone()).await.expect("put 1");
+
+    let meta_first = h
+        .store
+        .head(&key.to_object_path())
+        .await
+        .expect("head after first put");
+
+    // Second put of identical content: same key, same backend object.
+    let key_again = blob.put_artifact(content.clone()).await.expect("put 2");
+    assert_eq!(key, key_again);
+
+    let meta_second = h
+        .store
+        .head(&key.to_object_path())
+        .await
+        .expect("head after second put");
+
+    // `last_modified` and `e_tag` would both change if the backend
+    // actually received a second PUT — the conditional-write guard
+    // keeps them stable, which is the "no rewrite" contract.
+    assert_eq!(
+        meta_first.last_modified, meta_second.last_modified,
+        "last_modified changed — backend was rewritten",
+    );
+    assert_eq!(
+        meta_first.e_tag, meta_second.e_tag,
+        "e_tag changed — backend was rewritten",
+    );
+    assert_eq!(meta_first.size, meta_second.size);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn get_artifact_streams_full_payload() {
+    let h = start_minio().await;
+    let blob = BlobStore::from_arc(Arc::clone(&h.store));
+
+    // A payload comfortably larger than a single chunk so the stream
+    // actually yields multiple `Bytes` values on the happy path.
+    let content = Bytes::from_iter((0u8..=255).cycle().take(64 * 1024));
+    let key = blob.put_artifact(content.clone()).await.expect("put");
+
+    let mut stream = blob.get_artifact(&key).await.expect("get stream");
+    let mut buf = Vec::with_capacity(content.len());
+    while let Some(chunk) = stream.next().await {
+        buf.extend_from_slice(&chunk.expect("chunk"));
+    }
+    assert_eq!(buf.len(), content.len());
+    assert_eq!(Bytes::from(buf), content);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn missing_artifact_surfaces_not_found() {
+    let h = start_minio().await;
+    let blob = BlobStore::from_arc(Arc::clone(&h.store));
+
+    let ghost = Sha256Key::from_content(b"never written");
+    // `ByteStream` intentionally does not implement `Debug`, so we
+    // inspect the `Result` by hand rather than going through
+    // `.expect_err(...)`.
+    match blob.get_artifact(&ghost).await {
+        Ok(_) => panic!("unwritten key should not resolve"),
+        Err(StorageError::NotFound(_)) => {}
+        Err(other) => panic!("expected NotFound, got {other:?}"),
+    }
+
+    assert!(
+        !blob.contains(&ghost).await.expect("contains probe"),
+        "contains() on an unwritten key should return false",
+    );
+}

--- a/crates/au-kpis-storage/tests/minio.rs
+++ b/crates/au-kpis-storage/tests/minio.rs
@@ -305,3 +305,29 @@ async fn put_artifact_stream_is_idempotent_and_cleans_staging() {
         "streaming put left staged objects behind: {leaked:?}",
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn put_artifact_stream_handles_empty_source() {
+    // An upstream response body can legitimately be zero bytes (an
+    // API returning an empty document, a stub XLSX). S3 rejects
+    // `CompleteMultipartUpload` with zero parts, so the streaming
+    // writer must special-case that and still produce the canonical
+    // empty-content id.
+    let h = start_minio().await;
+    let blob = BlobStore::from_arc(Arc::clone(&h.store));
+
+    let empty: Vec<Result<Bytes, std::io::Error>> = Vec::new();
+    let id = blob
+        .put_artifact_stream(stream::iter(empty))
+        .await
+        .expect("streaming put of zero bytes");
+    assert_eq!(id, ArtifactId::of_content(b""));
+
+    let key = StorageKey::canonical_for(&id);
+    let mut body = blob.get(&key).await.expect("get empty artifact");
+    let mut total = 0usize;
+    while let Some(chunk) = body.next().await {
+        total += chunk.expect("chunk").len();
+    }
+    assert_eq!(total, 0, "stored empty artifact should be zero bytes");
+}

--- a/crates/au-kpis-storage/tests/minio.rs
+++ b/crates/au-kpis-storage/tests/minio.rs
@@ -1,19 +1,21 @@
 //! Integration tests for `au-kpis-storage` against a real MinIO backend.
 //!
 //! The spec calls for content-addressed, idempotent artifact writes and
-//! streaming reads (`Spec.md § Ingestion pipeline`, issue #8). Asserting
-//! those contracts against the real `AmazonS3` client — pointed at a
-//! MinIO container — catches SigV4 / path-style / conditional-write
-//! regressions that a pure in-memory stub would not.
+//! streaming reads and writes (`Spec.md § Ingestion pipeline`, issue
+//! #8). Asserting those contracts against the real `AmazonS3` client —
+//! pointed at a MinIO container — catches SigV4 / path-style /
+//! conditional-write / multipart regressions that a pure in-memory stub
+//! would not.
 //!
 //! Requires a working Docker daemon. In CI the job runs against the
 //! default socket; locally `colima start` or Docker Desktop is enough.
 
 use std::{sync::Arc, time::Duration};
 
-use au_kpis_storage::{BlobStore, Sha256Key, StorageError};
+use au_kpis_domain::ids::ArtifactId;
+use au_kpis_storage::{BlobStore, StorageError, artifact_path};
 use bytes::Bytes;
-use futures::StreamExt;
+use futures::{StreamExt, stream};
 use object_store::{ObjectStore, aws::AmazonS3Builder};
 use testcontainers::{
     ContainerAsync, GenericImage, ImageExt,
@@ -110,17 +112,16 @@ async fn put_artifact_is_content_addressed() {
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
     let content = Bytes::from_static(b"the quick brown fox");
-    let key = blob.put_artifact(content.clone()).await.expect("put");
+    let id = blob.put_artifact(content.clone()).await.expect("put");
 
-    // Key matches the sha256 of the bytes we wrote, computed without
+    // Id matches the sha256 of the bytes we wrote, computed without
     // going through the blob store.
-    let expected = Sha256Key::from_content(&content);
-    assert_eq!(key, expected);
+    assert_eq!(id, ArtifactId::of_content(&content));
 
-    // Distinct content → distinct key.
+    // Distinct content → distinct id.
     let other = Bytes::from_static(b"the quick brown foz");
-    let other_key = blob.put_artifact(other).await.expect("put other");
-    assert_ne!(key, other_key);
+    let other_id = blob.put_artifact(other).await.expect("put other");
+    assert_ne!(id, other_id);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -129,27 +130,28 @@ async fn put_artifact_is_idempotent_and_does_not_rewrite() {
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
     let content = Bytes::from_static(b"idempotent payload");
-    let key = blob.put_artifact(content.clone()).await.expect("put 1");
+    let id = blob.put_artifact(content.clone()).await.expect("put 1");
 
+    let canonical = artifact_path(&id);
     let meta_first = h
         .store
-        .head(&key.to_object_path())
+        .head(&canonical)
         .await
         .expect("head after first put");
 
-    // Second put of identical content: same key, same backend object.
-    let key_again = blob.put_artifact(content.clone()).await.expect("put 2");
-    assert_eq!(key, key_again);
+    // Second put of identical content: same id, same backend object.
+    let id_again = blob.put_artifact(content.clone()).await.expect("put 2");
+    assert_eq!(id, id_again);
 
     let meta_second = h
         .store
-        .head(&key.to_object_path())
+        .head(&canonical)
         .await
         .expect("head after second put");
 
     // `last_modified` and `e_tag` would both change if the backend
-    // actually received a second PUT — the conditional-write guard
-    // keeps them stable, which is the "no rewrite" contract.
+    // actually received a second PUT — skipping the re-write keeps
+    // them stable, which is the "no rewrite" contract.
     assert_eq!(
         meta_first.last_modified, meta_second.last_modified,
         "last_modified changed — backend was rewritten",
@@ -169,11 +171,11 @@ async fn get_artifact_streams_full_payload() {
     // A payload comfortably larger than a single chunk so the stream
     // actually yields multiple `Bytes` values on the happy path.
     let content = Bytes::from_iter((0u8..=255).cycle().take(64 * 1024));
-    let key = blob.put_artifact(content.clone()).await.expect("put");
+    let id = blob.put_artifact(content.clone()).await.expect("put");
 
-    let mut stream = blob.get_artifact(&key).await.expect("get stream");
+    let mut out = blob.get_artifact(&id).await.expect("get stream");
     let mut buf = Vec::with_capacity(content.len());
-    while let Some(chunk) = stream.next().await {
+    while let Some(chunk) = out.next().await {
         buf.extend_from_slice(&chunk.expect("chunk"));
     }
     assert_eq!(buf.len(), content.len());
@@ -185,7 +187,7 @@ async fn missing_artifact_surfaces_not_found() {
     let h = start_minio().await;
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
-    let ghost = Sha256Key::from_content(b"never written");
+    let ghost = ArtifactId::of_content(b"never written");
     // `ByteStream` intentionally does not implement `Debug`, so we
     // inspect the `Result` by hand rather than going through
     // `.expect_err(...)`.
@@ -198,5 +200,89 @@ async fn missing_artifact_surfaces_not_found() {
     assert!(
         !blob.contains(&ghost).await.expect("contains probe"),
         "contains() on an unwritten key should return false",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn put_artifact_stream_matches_single_shot_id() {
+    let h = start_minio().await;
+    let blob = BlobStore::from_arc(Arc::clone(&h.store));
+
+    // Payload sized to span multiple S3 multipart parts: each `Bytes`
+    // in the input stream becomes a `put_part` call, so the final
+    // digest exercises the hash-while-uploading path and the
+    // server-side copy on completion.
+    let total: Vec<u8> = (0u8..=255).cycle().take(192 * 1024).collect();
+    let chunk_size = 32 * 1024;
+    let chunks: Vec<Bytes> = total
+        .chunks(chunk_size)
+        .map(Bytes::copy_from_slice)
+        .collect();
+    let stream_chunks = stream::iter(
+        chunks
+            .into_iter()
+            .map(Ok::<_, std::io::Error>)
+            .collect::<Vec<_>>(),
+    );
+
+    let streamed = blob
+        .put_artifact_stream(stream_chunks)
+        .await
+        .expect("streaming put");
+    let direct = ArtifactId::of_content(&total);
+    assert_eq!(
+        streamed, direct,
+        "streaming digest must match a one-shot hash of the same bytes",
+    );
+
+    // The bytes under the canonical key must match what we streamed.
+    let mut got = Vec::with_capacity(total.len());
+    let mut body = blob.get_artifact(&streamed).await.expect("get");
+    while let Some(chunk) = body.next().await {
+        got.extend_from_slice(&chunk.expect("chunk"));
+    }
+    assert_eq!(got, total, "stored bytes differ from the streamed input");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn put_artifact_stream_is_idempotent_and_cleans_staging() {
+    use object_store::path::Path;
+
+    let h = start_minio().await;
+    let blob = BlobStore::from_arc(Arc::clone(&h.store));
+
+    let content = b"streamed-idempotent".to_vec();
+    let build = || {
+        stream::iter(vec![Ok::<_, std::io::Error>(Bytes::copy_from_slice(
+            &content,
+        ))])
+    };
+
+    let first = blob.put_artifact_stream(build()).await.expect("stream 1");
+    let meta_first = h.store.head(&artifact_path(&first)).await.expect("head 1");
+
+    let second = blob.put_artifact_stream(build()).await.expect("stream 2");
+    assert_eq!(first, second);
+    let meta_second = h.store.head(&artifact_path(&first)).await.expect("head 2");
+
+    // The second streaming put discovered the canonical key already
+    // existed and deleted its staged copy without overwriting the
+    // canonical object. `last_modified` / `e_tag` stability proves no
+    // rewrite even though the upload-and-copy path ran a second time.
+    assert_eq!(meta_first.last_modified, meta_second.last_modified);
+    assert_eq!(meta_first.e_tag, meta_second.e_tag);
+
+    // Staging must be clean — no dangling `artifacts-staging/*` objects
+    // after either put settles.
+    let staging_prefix = Path::from("artifacts-staging");
+    let mut staged = h.store.list(Some(&staging_prefix));
+    let leaked: Vec<_> = std::iter::from_fn(|| {
+        futures::executor::block_on(staged.next())
+            .map(|r| r.expect("list staging").location.to_string())
+    })
+    .collect();
+    assert!(
+        leaked.is_empty(),
+        "streaming put left staged objects behind: {leaked:?}",
     );
 }

--- a/crates/au-kpis-storage/tests/minio.rs
+++ b/crates/au-kpis-storage/tests/minio.rs
@@ -13,7 +13,7 @@
 use std::{sync::Arc, time::Duration};
 
 use au_kpis_domain::ids::ArtifactId;
-use au_kpis_storage::{BlobStore, StorageError, artifact_path};
+use au_kpis_storage::{BlobStore, StorageError, StorageKey};
 use bytes::Bytes;
 use futures::{StreamExt, stream};
 use object_store::{ObjectStore, aws::AmazonS3Builder};
@@ -132,7 +132,8 @@ async fn put_artifact_is_idempotent_and_does_not_rewrite() {
     let content = Bytes::from_static(b"idempotent payload");
     let id = blob.put_artifact(content.clone()).await.expect("put 1");
 
-    let canonical = artifact_path(&id);
+    let key = StorageKey::canonical_for(&id);
+    let canonical = object_store::path::Path::from(key.as_str());
     let meta_first = h
         .store
         .head(&canonical)
@@ -173,7 +174,8 @@ async fn get_artifact_streams_full_payload() {
     let content = Bytes::from_iter((0u8..=255).cycle().take(64 * 1024));
     let id = blob.put_artifact(content.clone()).await.expect("put");
 
-    let mut out = blob.get_artifact(&id).await.expect("get stream");
+    let key = StorageKey::canonical_for(&id);
+    let mut out = blob.get(&key).await.expect("get stream");
     let mut buf = Vec::with_capacity(content.len());
     while let Some(chunk) = out.next().await {
         buf.extend_from_slice(&chunk.expect("chunk"));
@@ -187,19 +189,29 @@ async fn missing_artifact_surfaces_not_found() {
     let h = start_minio().await;
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
-    let ghost = ArtifactId::of_content(b"never written");
+    let ghost_id = ArtifactId::of_content(b"never written");
+    let ghost = StorageKey::canonical_for(&ghost_id);
     // `ByteStream` intentionally does not implement `Debug`, so we
     // inspect the `Result` by hand rather than going through
     // `.expect_err(...)`.
-    match blob.get_artifact(&ghost).await {
+    match blob.get(&ghost).await {
         Ok(_) => panic!("unwritten key should not resolve"),
         Err(StorageError::NotFound(_)) => {}
         Err(other) => panic!("expected NotFound, got {other:?}"),
     }
 
     assert!(
-        !blob.contains(&ghost).await.expect("contains probe"),
-        "contains() on an unwritten key should return false",
+        !blob.exists(&ghost).await.expect("exists probe"),
+        "exists() on an unwritten key should return false",
+    );
+
+    // A persisted key that points outside `artifacts/` (e.g. a cold-tier
+    // move) must also round-trip cleanly through `exists`/`get` — this
+    // is the P1 from PR #74 about retention-tier rewrites.
+    let moved = StorageKey::from_persisted("cold/never-existed");
+    assert!(
+        !blob.exists(&moved).await.expect("exists moved"),
+        "unmoved/moved keys must both be reachable via StorageKey",
     );
 }
 
@@ -208,12 +220,17 @@ async fn put_artifact_stream_matches_single_shot_id() {
     let h = start_minio().await;
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
-    // Payload sized to span multiple S3 multipart parts: each `Bytes`
-    // in the input stream becomes a `put_part` call, so the final
-    // digest exercises the hash-while-uploading path and the
-    // server-side copy on completion.
-    let total: Vec<u8> = (0u8..=255).cycle().take(192 * 1024).collect();
-    let chunk_size = 32 * 1024;
+    // Payload sized to genuinely cross S3's multipart boundary:
+    // `WriteMultipart` only dispatches parts once its internal buffer
+    // fills to 5 MiB, so anything smaller stays in one part and never
+    // exercises `put_part` / `complete` at all. 12 MiB spans two full
+    // 5 MiB parts plus a ~2 MiB trailer, matching what the adapter
+    // fetch stage will see for any non-trivial upstream file.
+    let total: Vec<u8> = (0u8..=255).cycle().take(12 * 1024 * 1024).collect();
+    // Small producer chunks (256 KiB) also prove the internal buffer
+    // coalesces sub-5 MiB writes; a naive per-chunk `put_part` would
+    // trip `EntityTooSmall` here.
+    let chunk_size = 256 * 1024;
     let chunks: Vec<Bytes> = total
         .chunks(chunk_size)
         .map(Bytes::copy_from_slice)
@@ -236,8 +253,9 @@ async fn put_artifact_stream_matches_single_shot_id() {
     );
 
     // The bytes under the canonical key must match what we streamed.
+    let key = StorageKey::canonical_for(&streamed);
     let mut got = Vec::with_capacity(total.len());
-    let mut body = blob.get_artifact(&streamed).await.expect("get");
+    let mut body = blob.get(&key).await.expect("get");
     while let Some(chunk) = body.next().await {
         got.extend_from_slice(&chunk.expect("chunk"));
     }
@@ -259,11 +277,12 @@ async fn put_artifact_stream_is_idempotent_and_cleans_staging() {
     };
 
     let first = blob.put_artifact_stream(build()).await.expect("stream 1");
-    let meta_first = h.store.head(&artifact_path(&first)).await.expect("head 1");
+    let canonical = object_store::path::Path::from(StorageKey::canonical_for(&first).as_str());
+    let meta_first = h.store.head(&canonical).await.expect("head 1");
 
     let second = blob.put_artifact_stream(build()).await.expect("stream 2");
     assert_eq!(first, second);
-    let meta_second = h.store.head(&artifact_path(&first)).await.expect("head 2");
+    let meta_second = h.store.head(&canonical).await.expect("head 2");
 
     // The second streaming put discovered the canonical key already
     // existed and deleted its staged copy without overwriting the

--- a/infra/r2/README.md
+++ b/infra/r2/README.md
@@ -1,0 +1,32 @@
+# R2 bucket lifecycle
+
+`lifecycle.json` is the canonical source for the bucket lifecycle rules
+that the ingestion pipeline depends on.
+
+## Rules
+
+| ID | Prefix | Effect |
+|---|---|---|
+| `expire-artifacts-staging` | `artifacts-staging/` | Objects expire after 7 days; incomplete multipart uploads aborted after 1 day. |
+
+The staging rule backstops `au-kpis-storage`'s streaming write path
+(`put_artifact_stream`): uploads land in `artifacts-staging/<uuid>` and
+are server-side copied to the canonical `artifacts/<sha256>` key once
+the hash is known. The crate retries the staging delete on the happy
+path, but the lifecycle rule catches the rare case where all retries
+fail, bounding the worst-case storage leak at 7 days.
+
+## Applying
+
+```bash
+# R2 (wrangler >= 3)
+wrangler r2 bucket lifecycle put au-kpis-prod --file infra/r2/lifecycle.json
+
+# S3-compatible (AWS CLI)
+aws s3api put-bucket-lifecycle-configuration \
+  --bucket au-kpis-prod \
+  --lifecycle-configuration file://infra/r2/lifecycle.json
+```
+
+Re-apply after any change to this file. CI does not yet enforce drift
+detection (tracked for a later issue).

--- a/infra/r2/lifecycle.json
+++ b/infra/r2/lifecycle.json
@@ -1,0 +1,11 @@
+{
+  "Rules": [
+    {
+      "ID": "expire-artifacts-staging",
+      "Status": "Enabled",
+      "Filter": { "Prefix": "artifacts-staging/" },
+      "Expiration": { "Days": 7 },
+      "AbortIncompleteMultipartUpload": { "DaysAfterInitiation": 1 }
+    }
+  ]
+}


### PR DESCRIPTION
Closes #8.

## Summary

- `Sha256Key` wraps the lower-case hex sha256 and owns the `artifacts/<digest>` key layout.
- `BlobStore::put_artifact(Bytes)` hashes the payload, heads the backend first, and only PUTs when the key is absent — same-content retries therefore do **not** rewrite the object (portable across S3/R2/MinIO, which is why we're not relying on `PutMode::Create`).
- `BlobStore::get_artifact(&Sha256Key)` returns a `ByteStream` via `GetResult::into_stream`, so multi-GB artifacts never get buffered in memory.
- `BlobStore::contains` gives the loader a cheap existence probe.
- `StorageError::NotFound` is now surfaced from the underlying `object_store::Error::NotFound`, and stays `ErrorClass::Permanent`; the generic `Backend` variant stays transient.

## Pass requirements

- [x] `put_artifact(content) -> Sha256Key` content-addressed writer
- [x] Idempotent: same content → same key, no rewrite (verified against MinIO via stable `last_modified` + `e_tag`)
- [x] Read streaming API (`get_artifact` → `ByteStream`)
- [x] Integration test against MinIO (`tests/minio.rs`, four cases)
- [x] Unit tests for key derivation (empty-payload known vector, determinism, hex encoding, error classification)

## Test plan

- `cargo fmt --all --check` — clean
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo test -p au-kpis-storage --lib` — 8/8 pass
- `cargo test -p au-kpis-storage --test minio` — 4/4 pass against `minio/minio:RELEASE.2024-10-02T17-50-41Z` via testcontainers

## Spec impact

No Spec changes required — this implements the `au-kpis-storage` role documented in `Spec.md § Monorepo layout` and the idempotent-fetch contract in `§ Ingestion pipeline`.

## Notes for reviewers

- Idempotency is implemented as head-then-put (TOCTOU race is harmless: concurrent writers upload identical bytes). I originally tried `PutMode::Create`; the pinned MinIO release returns `NotImplemented` for that path, so the portable approach wins.
- MinIO container bootstraps a bucket by overriding the entrypoint to `sh -c "mkdir -p /data/<bucket> && exec minio server ..."` — MinIO treats top-level data-dir children as buckets, so no `mc` sidecar is needed.