### PR TITLE
fix(ci): drop unsupported uniqueItems from codex review schema

### DIFF
--- a/.github/codex/output-schema.json
+++ b/.github/codex/output-schema.json
@@ -161,8 +161,7 @@
           "architecture"
         ]
       },
-      "maxItems": 3,
-      "uniqueItems": true
+      "maxItems": 3
     },
     "spec_update_required": {
       "type": "boolean"


### PR DESCRIPTION
## Summary

The Codex structured-review workflow crashes on every PR with:

```
Invalid schema for response_format 'codex_output_schema':
In context=('properties', 'primary_risk_areas'), 'uniqueItems' is not permitted.
```

OpenAI's structured-output `response_format` uses a restricted JSON
Schema subset that does not allow `uniqueItems`. This PR drops the
single unsupported keyword; `maxItems: 3` stays so the model still
returns a bounded list.

Duplicates in the top-3 would be a prompt-level issue (the enum only
has 9 values and the prompt asks for distinct top risk areas), not
something schema validation can enforce here anyway.

## Test plan

- Validated the edited schema is still well-formed: `jq . .github/codex/output-schema.json`.
- The next PR run should take the `Run Codex structured review` step through to completion instead of exiting at the schema-validation error.

## Spec impact

No Spec changes required.