### PR TITLE
ci(review): fix codex review workflow (schema + model + inline fallback)

### DIFF
--- a/.github/codex/output-schema.json
+++ b/.github/codex/output-schema.json
@@ -161,8 +161,7 @@
           "architecture"
         ]
       },
-      "maxItems": 3,
-      "uniqueItems": true
+      "maxItems": 3
     },
     "spec_update_required": {
       "type": "boolean"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -244,7 +244,10 @@ jobs:
             -H "Authorization: Bearer ${GITHUB_TOKEN}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
             "$issue_comments_url" |
-            jq -r '.[] | select(.body | contains("<!-- codex-review-summary -->")) | .id' |
+            jq -r '.[] | select(
+              (.body | contains("<!-- codex-review-summary -->"))
+              or (.body | contains("<!-- codex-review-inline-fallback -->"))
+            ) | .id' |
             while IFS= read -r comment_id; do
               curl -fsSL \
                 -X DELETE \
@@ -274,20 +277,55 @@ jobs:
             exit 0
           fi
 
+          # Each finding produces a pair of payloads:
+          #   .inline   — the standard inline review-comment payload
+          #   .fallback — an issue-comment payload posted only when the
+          #               inline POST is rejected (typically 422:
+          #               "pull_request_review_thread.line could not be
+          #               resolved", which happens when Codex points at
+          #               a line outside the PR's diff hunks).
+          # Emitting both up-front keeps jq out of the retry path.
           jq -c \
             --arg commit "$HEAD_SHA" \
             --arg workspace "${GITHUB_WORKSPACE%/}/" '
-            .findings[] | {
-              body: ("<!-- codex-review-inline -->\n**[" + .category + "][" + .subsystem + "] " + .title + "**\n\n" + .body + "\n\nInvariant: `" + .invariant + "`\nSuggested test layer: `" + .suggested_test_layer + "`\nConfidence: " + (.confidence_score | tostring) + "\nPriority: P" + (.priority | tostring)),
-              commit_id: $commit,
-              path: (.code_location.absolute_file_path | sub("^" + $workspace; "")),
-              line: .code_location.line_range.end,
-              side: "RIGHT",
-              start_line: (if .code_location.line_range.start != .code_location.line_range.end then .code_location.line_range.start else null end),
-              start_side: (if .code_location.line_range.start != .code_location.line_range.end then "RIGHT" else null end)
-            } | with_entries(select(.value != null))' "$REVIEW_JSON" > findings.jsonl
+            .findings[]
+            | (.code_location.absolute_file_path | sub("^" + $workspace; "")) as $relpath
+            | (
+                "**[" + .category + "][" + .subsystem + "] " + .title + "**\n\n"
+                + .body
+                + "\n\nInvariant: `" + .invariant + "`"
+                + "\nSuggested test layer: `" + .suggested_test_layer + "`"
+                + "\nConfidence: " + (.confidence_score | tostring)
+                + "\nPriority: P" + (.priority | tostring)
+              ) as $core
+            | (
+                if .code_location.line_range.start == .code_location.line_range.end
+                then (.code_location.line_range.end | tostring)
+                else (.code_location.line_range.start | tostring) + "-" + (.code_location.line_range.end | tostring)
+                end
+              ) as $range
+            | {
+                inline: ({
+                  body: ("<!-- codex-review-inline -->\n" + $core),
+                  commit_id: $commit,
+                  path: $relpath,
+                  line: .code_location.line_range.end,
+                  side: "RIGHT",
+                  start_line: (if .code_location.line_range.start != .code_location.line_range.end then .code_location.line_range.start else null end),
+                  start_side: (if .code_location.line_range.start != .code_location.line_range.end then "RIGHT" else null end)
+                } | with_entries(select(.value != null))),
+                fallback: {
+                  body: ("<!-- codex-review-inline-fallback -->\n"
+                    + "_Inline comment could not attach to the PR diff — falling back to a thread comment._\n\n"
+                    + "📎 `" + $relpath + ":" + $range + "`\n\n"
+                    + $core)
+                }
+              }' "$REVIEW_JSON" > findings.jsonl
 
-          while IFS= read -r payload; do
+          while IFS= read -r combined; do
+            inline_payload=$(jq -c '.inline' <<<"$combined")
+            fallback_payload=$(jq -c '.fallback' <<<"$combined")
+
             response_file="$(mktemp)"
             status_code=$(curl -sS \
               -o "$response_file" \
@@ -297,11 +335,27 @@ jobs:
               -H "Authorization: Bearer ${GITHUB_TOKEN}" \
               -H "X-GitHub-Api-Version: 2022-11-28" \
               "https://api.github.com/repos/${REPOSITORY}/pulls/${PR_NUMBER}/comments" \
-              -d "$payload")
+              -d "$inline_payload")
 
             if [ "${status_code}" -lt 200 ] || [ "${status_code}" -ge 300 ]; then
-              echo "::warning::Failed to publish an inline Codex review comment."
+              echo "::warning::Inline Codex review comment rejected (HTTP ${status_code}); falling back to a thread comment."
               cat "$response_file"
+
+              fallback_response="$(mktemp)"
+              fallback_status=$(curl -sS \
+                -o "$fallback_response" \
+                -w '%{http_code}' \
+                -X POST \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                "https://api.github.com/repos/${REPOSITORY}/issues/${PR_NUMBER}/comments" \
+                -d "$fallback_payload")
+              if [ "${fallback_status}" -lt 200 ] || [ "${fallback_status}" -ge 300 ]; then
+                echo "::warning::Fallback thread comment also failed (HTTP ${fallback_status})."
+                cat "$fallback_response"
+              fi
+              rm -f "$fallback_response"
             fi
 
             rm -f "$response_file"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -407,16 +407,17 @@ jobs:
               --arg categories "$category_breakdown" \
               --arg subsystems "$subsystem_breakdown" \
               '{
-                body:
-                  "<!-- codex-review-summary -->\n**Codex automated review**\n\n" +
-                  "Verdict: " + $verdict + "\n" +
-                  "Confidence: " + $confidence + "\n" +
-                  "Findings: " + $findings + "\n" +
-                  "Primary risk areas: " + (if $risks != "" then $risks else "none" end) + "\n" +
-                  "Spec update required: " + $spec_required + (if $spec_required == "true" and $spec_reason != "" then " (" + $spec_reason + ")" else "" end) + "\n\n" +
-                  (if $categories != "" then "**Category Breakdown**\n" + $categories + "\n\n" else "" end) +
-                  (if $subsystems != "" then "**Subsystem Breakdown**\n" + $subsystems + "\n\n" else "" end) +
-                  $explanation
+                body: (
+                  "<!-- codex-review-summary -->\n**Codex automated review**\n\n"
+                  + "Verdict: " + $verdict + "\n"
+                  + "Confidence: " + $confidence + "\n"
+                  + "Findings: " + $findings + "\n"
+                  + "Primary risk areas: " + (if $risks != "" then $risks else "none" end) + "\n"
+                  + "Spec update required: " + $spec_required + (if $spec_required == "true" and $spec_reason != "" then " (" + $spec_reason + ")" else "" end) + "\n\n"
+                  + (if $categories != "" then "**Category Breakdown**\n" + $categories + "\n\n" else "" end)
+                  + (if $subsystems != "" then "**Subsystem Breakdown**\n" + $subsystems + "\n\n" else "" end)
+                  + $explanation
+                )
               }'
           )
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -21,7 +21,7 @@ jobs:
       issues: write
       pull-requests: write
     env:
-      CODEX_MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.5' }}
+      CODEX_MODEL: ${{ vars.CODEX_MODEL || 'gpt-5.4' }}
       CODEX_REVIEW_EFFORT: ${{ vars.CODEX_REVIEW_EFFORT || 'high' }}
       CODEX_REVIEW_BLOCK_ON_INCORRECT: ${{ vars.CODEX_REVIEW_BLOCK_ON_INCORRECT || 'false' }}
       PR_NUMBER: ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

Three tiny fixes to the Codex review workflow, kept together because each blocks the next from running cleanly:

- **Drop unsupported `uniqueItems`** from `.github/codex/output-schema.json`. OpenAI's structured-output `response_format` rejects it (`'uniqueItems' is not permitted`), crashing the review step on every PR. `maxItems: 3` stays.
- **Default `CODEX_MODEL` to `gpt-5.4`** (from `gpt-5.5`). Repo-level `vars.CODEX_MODEL` still overrides for anyone who wants a different model.
- **Fall back to a thread comment when an inline review comment cannot attach.** GitHub returns `422: pull_request_review_thread.line could not be resolved` when Codex points at a line outside the PR's diff hunks; the previous workflow logged a `::warning::` and dropped the finding. Now each finding carries a secondary issue-comment payload (`<!-- codex-review-inline-fallback -->`) that's posted only when the inline POST fails. The cleanup step also removes stale fallback comments on the next run.

## Test plan

- `jq . .github/codex/output-schema.json` — valid.
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr.yml'))"` — valid.
- jq pipeline that emits the `inline` + `fallback` payload pair smoke-tested locally against a synthetic finding.
- On the next PR run: `Run Codex structured review` should get past the schema crash, report `model: gpt-5.4`, and when an inline comment is rejected the step should log a warning and post a thread comment with `📎 <path>:<line>` instead of silently dropping the finding.

## Spec impact

No Spec changes required.

## Supersedes

Replaces #75 (schema fix alone).