### PR TITLE
ci(review): add CI OK aggregate gate job

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -448,3 +448,39 @@ jobs:
             exit 1
           fi
         shell: bash
+
+  # Single required-status-check gate. Branch protection points at
+  # `CI OK` and this job aggregates every upstream job's result, so
+  # adding or renaming jobs never forces a branch-protection edit —
+  # just keep the list in `needs:` current.
+  ci-ok:
+    name: CI OK
+    runs-on: ubuntu-latest
+    needs:
+      - codex-review
+    if: always()
+    steps:
+      - name: Enforce required job results
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -euo pipefail
+          echo "Upstream job results:"
+          jq -r 'to_entries[] | "  \(.key): \(.value.result)"' <<<"$NEEDS"
+
+          # `skipped` is allowed — the upstream preflight deliberately
+          # skips Codex for draft PRs, forks, and repos without
+          # OPENAI_API_KEY, and we don't want those escape hatches to
+          # block merges. `failure` or `cancelled` fails the gate.
+          bad=$(jq -r '
+            to_entries
+            | map(select(.value.result == "failure" or .value.result == "cancelled"))
+            | map(.key)
+            | join(", ")
+          ' <<<"$NEEDS")
+
+          if [ -n "$bad" ]; then
+            echo "::error::required checks failed or were cancelled: $bad"
+            exit 1
+          fi
+        shell: bash


### PR DESCRIPTION
## Summary

Adds a `CI OK` job to `.github/workflows/pr.yml` that depends on every upstream job and aggregates their results:

- Fails if any `needs.*.result` is `failure` or `cancelled`.
- Passes if everything else (`success`, or `skipped` from the deliberate preflight escape hatches — drafts, forks, repos without `OPENAI_API_KEY`).
- Emits the per-job result to the log so the gate's verdict is auditable at a glance.

## Follow-up for the repo owner

Point branch protection at **`CI OK`** as the single required status check (Settings → Rules → the ruleset you just created). After that, adding or renaming a workflow job only requires editing this job's `needs:` list — branch protection never needs another click.

## Test plan

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/pr.yml'))"` — valid.
- jq aggregator smoke-tested against four scenarios (all-success, one-failure, skipped, cancelled); the "failure" and "cancelled" cases print the offending job name, the others print nothing.

## Spec impact

`AGENTS.md § 8` lists 14 planned gates; the `ci-ok` job is the generalised landing pad each new gate plugs into, so no Spec amendment is needed beyond eventually noting the convention. Happy to add that note in a follow-up doc PR.