### PR TITLE
fix(repo): align closed issue contracts (#79)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,20 @@
+{
+  "gitignore": true,
+  "globs": [
+    "**/*.md"
+  ],
+  "ignores": [
+    ".context/**",
+    "target/**"
+  ],
+  "config": {
+    "MD013": false,
+    "MD022": false,
+    "MD031": false,
+    "MD032": false,
+    "MD036": false,
+    "MD040": false,
+    "MD041": false,
+    "MD060": false
+  }
+}

--- a/.sqlx/query-e8f890bc5c5f636e469eda26984cb3bc79a56d2bb5362d3aca600d6cacd14e73.json
+++ b/.sqlx/query-e8f890bc5c5f636e469eda26984cb3bc79a56d2bb5362d3aca600d6cacd14e73.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT extversion FROM pg_extension WHERE extname = 'timescaledb'",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "extversion",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "e8f890bc5c5f636e469eda26984cb3bc79a56d2bb5362d3aca600d6cacd14e73"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for contributing to australian-kpis. This guide covers the workflow fo
 
 Prerequisites:
 
-- Rust 1.83+ (see `rust-toolchain.toml`)
+- Rust 1.85+ (see `rust-toolchain.toml`)
 - Bun 1.1+ or Node 20+ with pnpm 9
 - Docker (for local infra)
 - `sqlx-cli`, `cargo-nextest`, `cargo-deny`, `cargo-audit`, `cargo-llvm-cov`, `lefthook`

--- a/Spec.md
+++ b/Spec.md
@@ -80,7 +80,7 @@ returns clean, validated, SDMX-compliant time series regardless of upstream sour
 - SDK: **TypeScript first**; Python/Go SDKs later via same OpenAPI codegen.
 - First dataflow: **ABS CPI** (higher public demand than Labour Force; monthly + quarterly releases).
 - Raw artifacts: **retained in S3/R2 indefinitely** — lifecycle policy moves >1yr objects to cold storage. Streaming uploads land first in `artifacts-staging/<uuid>` and are copied to `artifacts/<sha256>` once the hash is known; a second lifecycle rule expires `artifacts-staging/` after 7 days so any rare delete-failure leak from the storage crate is bounded. The declarative policy lives in `infra/r2/lifecycle.json`.
-- Rust: **2024 edition, MSRV 1.83**.
+- Rust: **2024 edition, MSRV 1.85**.
 - Migrations: **`sqlx migrate`** (sync-at-startup).
 
 ## Stack (locked)
@@ -189,7 +189,7 @@ members = ["crates/*", "crates/adapters/*", "crates/bins/*"]
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.83"
+rust-version = "1.85"
 license = "Apache-2.0"
 
 [workspace.dependencies]
@@ -445,7 +445,7 @@ pub struct Series {
     pub series_key: SeriesKey,           // sha256 hash of (dataflow_id || sorted dimensions)
     pub dataflow_id: DataflowId,
     pub measure_id: MeasureId,
-    pub dimensions: BTreeMap<String, String>,  // JSONB in DB, GIN-indexed
+    pub dimensions: BTreeMap<DimensionId, CodeId>,  // JSONB in DB, GIN-indexed
     pub unit: String,
     pub first_observed: Option<DateTime<Utc>>,
     pub last_observed: Option<DateTime<Utc>>,
@@ -467,7 +467,7 @@ pub struct Observation {
 }
 ```
 
-Core types: `Source`, `Dataflow`, `Dimension`, `Codelist`, `Code`, `Measure`, `Series`, `Observation`, `Artifact`. `ToSchema` derive (utoipa) makes them OpenAPI-visible. `SeriesKey` is a newtype wrapping a hash — not `String` — for type-safety at all boundaries.
+Core types: `Source`, `Dataflow`, `Dimension`, `Codelist`, `Code`, `Measure`, `Series`, `Observation`, `Artifact`. `ToSchema` derive (utoipa) makes them OpenAPI-visible. `SeriesKey` is a newtype wrapping a hash — not `String` — for type-safety at all boundaries, and series dimensions stay typed in-memory (`DimensionId`/`CodeId`) while serializing to ordinary JSON object keys/values.
 
 ### Database schema (key tables)
 
@@ -1273,7 +1273,7 @@ All confirmed 2026-04-23:
 - SDK: TypeScript first; others via OpenAPI codegen
 - First dataflow: ABS CPI
 - Raw artifacts: retain indefinitely in R2, lifecycle-to-cold after 1 year
-- Rust 2024 edition, MSRV 1.83
+- Rust 2024 edition, MSRV 1.85
 - `sqlx migrate` for migrations
 
 ---

--- a/crates/au-kpis-domain/src/ids.rs
+++ b/crates/au-kpis-domain/src/ids.rs
@@ -52,7 +52,7 @@ fn validate_slug(s: &str) -> Result<(), IdError> {
 macro_rules! slug_id {
     ($(#[$meta:meta])* $name:ident) => {
         $(#[$meta])*
-        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, ToSchema)]
+        #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, ToSchema)]
         #[serde(transparent)]
         pub struct $name(String);
 
@@ -91,6 +91,33 @@ macro_rules! slug_id {
         impl AsRef<str> for $name {
             fn as_ref(&self) -> &str {
                 &self.0
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+                struct SlugIdVisitor;
+
+                impl<'de> serde::de::Visitor<'de> for SlugIdVisitor {
+                    type Value = $name;
+
+                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        formatter.write_str("a non-empty identifier string")
+                    }
+
+                    fn visit_str<E: serde::de::Error>(self, value: &str) -> Result<Self::Value, E> {
+                        $name::new(value).map_err(E::custom)
+                    }
+
+                    fn visit_string<E: serde::de::Error>(
+                        self,
+                        value: String,
+                    ) -> Result<Self::Value, E> {
+                        $name::new(value).map_err(E::custom)
+                    }
+                }
+
+                deserializer.deserialize_string(SlugIdVisitor)
             }
         }
     };
@@ -442,6 +469,22 @@ mod tests {
     fn sha256_digest_rejects_non_hex() {
         let s = "z".repeat(64);
         assert_eq!(Sha256Digest::from_hex(&s), Err(IdError::HashEncoding));
+    }
+
+    #[test]
+    fn slug_id_json_deserialization_validates_input() {
+        let err = serde_json::from_str::<DimensionId>("\"\"").unwrap_err();
+        assert!(
+            err.to_string().contains("identifier must not be empty"),
+            "unexpected error: {err}"
+        );
+
+        let too_long = "x".repeat(MAX_ID_LEN + 1);
+        let err = serde_json::from_str::<CodeId>(&format!("\"{too_long}\"")).unwrap_err();
+        assert!(
+            err.to_string().contains("identifier exceeds"),
+            "unexpected error: {err}"
+        );
     }
 
     #[test]

--- a/crates/au-kpis-domain/src/ids.rs
+++ b/crates/au-kpis-domain/src/ids.rs
@@ -20,7 +20,7 @@ use sha2::{Digest, Sha256};
 use utoipa::ToSchema;
 
 /// Errors produced while constructing an identifier.
-#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+#[derive(Debug, thiserror::Error, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 pub enum IdError {
     #[error("identifier must not be empty")]
     Empty,
@@ -353,6 +353,7 @@ impl ObservationId {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use utoipa::ToSchema;
 
     #[test]
     fn slug_id_rejects_empty() {
@@ -441,5 +442,14 @@ mod tests {
     fn sha256_digest_rejects_non_hex() {
         let s = "z".repeat(64);
         assert_eq!(Sha256Digest::from_hex(&s), Err(IdError::HashEncoding));
+    }
+
+    #[test]
+    fn id_error_roundtrips_and_has_openapi_schema() {
+        let err = IdError::TooLong { max: MAX_ID_LEN };
+        let json = serde_json::to_string(&err).unwrap();
+        let back: IdError = serde_json::from_str(&json).unwrap();
+        assert_eq!(err, back);
+        assert_eq!(IdError::name(), "IdError");
     }
 }

--- a/crates/au-kpis-domain/src/series.rs
+++ b/crates/au-kpis-domain/src/series.rs
@@ -70,6 +70,8 @@ impl SeriesDescriptor {
 mod tests {
     use super::*;
     use crate::ids::{CodeId, DimensionId};
+    use serde_json::{Value, json};
+    use utoipa::PartialSchema;
 
     fn example_series() -> Series {
         let df = DataflowId::new("abs.cpi").unwrap();
@@ -96,6 +98,40 @@ mod tests {
         }
     }
 
+    fn example_descriptor() -> SeriesDescriptor {
+        let s = example_series();
+        SeriesDescriptor {
+            series_key: s.series_key,
+            dataflow_id: s.dataflow_id,
+            measure_id: s.measure_id,
+            dimensions: s.dimensions,
+            unit: s.unit,
+        }
+    }
+
+    fn assert_dimensions_schema(schema: &Value) {
+        let dimensions = &schema["properties"]["dimensions"];
+        assert_eq!(dimensions["type"], "object");
+        assert!(
+            dimensions.get("additionalProperties").is_some(),
+            "expected additionalProperties in schema: {schema}"
+        );
+        let additional_properties = &dimensions["additionalProperties"];
+        assert!(
+            additional_properties.get("type") == Some(&json!("string"))
+                || additional_properties.get("$ref").is_some(),
+            "expected string-like additionalProperties schema: {schema}"
+        );
+
+        let property_names = &dimensions["propertyNames"];
+        assert!(
+            property_names.is_null()
+                || property_names.get("type") == Some(&json!("string"))
+                || property_names.get("$ref").is_some(),
+            "expected string-like propertyNames schema: {schema}"
+        );
+    }
+
     #[test]
     fn series_roundtrips() {
         let s = example_series();
@@ -113,16 +149,51 @@ mod tests {
     #[test]
     fn descriptor_roundtrips_and_matches_series_key() {
         let s = example_series();
-        let d = SeriesDescriptor {
-            series_key: s.series_key,
-            dataflow_id: s.dataflow_id.clone(),
-            measure_id: s.measure_id.clone(),
-            dimensions: s.dimensions.clone(),
-            unit: s.unit.clone(),
-        };
+        let d = example_descriptor();
         let json = serde_json::to_string(&d).unwrap();
         let back: SeriesDescriptor = serde_json::from_str(&json).unwrap();
         assert_eq!(d, back);
         assert_eq!(d.compute_series_key(), s.series_key);
+    }
+
+    #[test]
+    fn series_rejects_invalid_dimensions_at_json_boundary() {
+        let s = example_series();
+        let invalid = json!({
+            "series_key": s.series_key.to_hex(),
+            "dataflow_id": s.dataflow_id.as_str(),
+            "measure_id": s.measure_id.as_str(),
+            "dimensions": { "": "AUS" },
+            "unit": s.unit,
+            "first_observed": s.first_observed,
+            "last_observed": s.last_observed,
+            "active": s.active
+        });
+
+        let err = serde_json::from_value::<Series>(invalid).unwrap_err();
+        assert!(
+            err.to_string().contains("identifier must not be empty"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn series_contract_serializes_dimensions_as_string_keyed_object() {
+        let s = example_series();
+        let json = serde_json::to_value(&s).unwrap();
+        assert_eq!(json["dimensions"], json!({ "region": "AUS" }));
+
+        let schema = serde_json::to_value(Series::schema()).unwrap();
+        assert_dimensions_schema(&schema);
+    }
+
+    #[test]
+    fn descriptor_contract_serializes_dimensions_as_string_keyed_object() {
+        let descriptor = example_descriptor();
+        let json = serde_json::to_value(&descriptor).unwrap();
+        assert_eq!(json["dimensions"], json!({ "region": "AUS" }));
+
+        let schema = serde_json::to_value(SeriesDescriptor::schema()).unwrap();
+        assert_dimensions_schema(&schema);
     }
 }

--- a/crates/au-kpis-domain/src/series.rs
+++ b/crates/au-kpis-domain/src/series.rs
@@ -7,7 +7,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
-use crate::ids::{DataflowId, MeasureId, SeriesKey};
+use crate::ids::{CodeId, DataflowId, DimensionId, MeasureId, SeriesKey};
 
 /// One time series within a dataflow. `dimensions` is the sorted bag of
 /// `(key, value)` pairs that, together with `dataflow_id`, seeds `series_key`.
@@ -16,10 +16,10 @@ pub struct Series {
     pub series_key: SeriesKey,
     pub dataflow_id: DataflowId,
     pub measure_id: MeasureId,
-    /// Dimension values keyed by `DimensionId::as_str()`. Stored sorted (via
-    /// `BTreeMap`) so iteration order is stable across serialisation +
-    /// re-hashing.
-    pub dimensions: BTreeMap<String, String>,
+    /// Dimension values keyed by typed dimension ids and code ids. Stored
+    /// sorted (via `BTreeMap`) so iteration order is stable across
+    /// serialisation + re-hashing.
+    pub dimensions: BTreeMap<DimensionId, CodeId>,
     pub unit: String,
     pub first_observed: Option<DateTime<Utc>>,
     pub last_observed: Option<DateTime<Utc>>,
@@ -51,7 +51,7 @@ pub struct SeriesDescriptor {
     pub series_key: SeriesKey,
     pub dataflow_id: DataflowId,
     pub measure_id: MeasureId,
-    pub dimensions: BTreeMap<String, String>,
+    pub dimensions: BTreeMap<DimensionId, CodeId>,
     pub unit: String,
 }
 
@@ -69,12 +69,16 @@ impl SeriesDescriptor {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ids::{CodeId, DimensionId};
 
     fn example_series() -> Series {
         let df = DataflowId::new("abs.cpi").unwrap();
-        let dims: BTreeMap<String, String> = [("region".to_string(), "AUS".to_string())]
-            .into_iter()
-            .collect();
+        let dims: BTreeMap<DimensionId, CodeId> = [(
+            DimensionId::new("region").unwrap(),
+            CodeId::new("AUS").unwrap(),
+        )]
+        .into_iter()
+        .collect();
         let key = SeriesKey::derive(&df, dims.iter().map(|(k, v)| (k.as_str(), v.as_str())));
         Series {
             series_key: key,


### PR DESCRIPTION
## Summary

- align the Rust 2024/MSRV docs with the repo's actual 1.85 baseline
- make `au-kpis-domain` satisfy the closed-issue contract around public serde/OpenAPI-visible types
- commit offline `.sqlx/` metadata for the DB crate and add repo-level markdownlint configuration

Closes #79

## Pass requirements

- [x] `Spec.md` and contributor docs no longer claim Rust 2024 works on 1.83
- [x] `au-kpis-domain` public types used by issue #3 satisfy serde/OpenAPI expectations
- [x] `.sqlx/` metadata exists for compile-checked queries
- [x] `markdownlint-cli2` passes with committed repo configuration
- [x] verification commands documented in the PR

## Test plan

- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `SQLX_OFFLINE=true cargo check -p au-kpis-db`
- `npx -y markdownlint-cli2`

## Spec impact

Included in this PR:
- update `Spec.md` to use the real Rust 2024 baseline (`1.85`)
- update the series dimensions snippet to reflect typed `DimensionId`/`CodeId` usage in the domain model
