### PR TITLE
feat(repo): add cache, OpenAPI, and pre-commit scaffolds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,11 @@ sqlx migrate run
 cargo nextest run --workspace
 ```
 
+`lefthook install` wires a `pre-commit` hook that runs `cargo fmt --check`,
+`biome format --check`, `gitleaks protect --staged`, and a staged-file size
+guard that rejects blobs over 5 MB. The hook body is shell/Python only, so it
+works the same way on macOS and Linux.
+
 ## Workflow
 
 1. Pick an issue from the [milestone board](https://github.com/ponderingdemocritus/australian-kpis/milestones). Respect `Depends on:` — don't start a blocked issue.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,13 @@ version = "0.1.0"
 [[package]]
 name = "au-kpis-api-http"
 version = "0.1.0"
+dependencies = [
+ "axum 0.7.9",
+ "serde",
+ "tokio",
+ "tower",
+ "utoipa",
+]
 
 [[package]]
 name = "au-kpis-auth"
@@ -242,9 +249,10 @@ name = "au-kpis-openapi"
 version = "0.1.0"
 dependencies = [
  "assert_cmd",
+ "au-kpis-api-http",
  "jsonschema",
- "serde",
  "serde_json",
+ "thiserror 2.0.18",
  "utoipa",
 ]
 
@@ -329,18 +337,53 @@ dependencies = [
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "axum-macros",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -350,6 +393,27 @@ dependencies = [
  "tower",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -368,6 +432,17 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "axum-macros"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57d123550fa8d071b7255cb0cc04dc302baa6c8c4a79f55701552684d8399bce"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1738,6 +1813,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -2891,6 +2972,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3645,7 +3737,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "base64 0.22.1",
  "bytes",
  "h2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -33,10 +47,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "assert_cmd"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39bae1d3fa576f7c6519514180a72559268dd7d1fe104070956cb687bc6673bd"
+dependencies = [
+ "anstyle",
+ "bstr",
+ "libc",
+ "predicates",
+ "predicates-core",
+ "predicates-tree",
+ "wait-timeout",
+]
 
 [[package]]
 name = "async-trait"
@@ -120,6 +164,17 @@ version = "0.1.0"
 [[package]]
 name = "au-kpis-cache"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "au-kpis-error",
+ "fred",
+ "serde",
+ "serde_json",
+ "testcontainers",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "au-kpis-cli"
@@ -185,6 +240,13 @@ version = "0.1.0"
 [[package]]
 name = "au-kpis-openapi"
 version = "0.1.0"
+dependencies = [
+ "assert_cmd",
+ "jsonschema",
+ "serde",
+ "serde_json",
+ "utoipa",
+]
 
 [[package]]
 name = "au-kpis-pdf-client"
@@ -242,6 +304,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "axum"
@@ -305,6 +389,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -351,7 +450,7 @@ dependencies = [
  "log",
  "pin-project-lite",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -379,10 +478,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -403,12 +525,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -434,6 +568,15 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -492,6 +635,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "cookie-factory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "396de984970346b0d9e93d1415082923c679e5ae5c3ee3dcbd104f5610af126b"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +689,12 @@ name = "crc-catalog"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
+
+[[package]]
+name = "crc16"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "338089f42c427b86394a5ee60ff321da23a5c89c9d89514c829687b26359fcff"
 
 [[package]]
 name = "crc32fast"
@@ -631,6 +796,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "difflib"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,6 +831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -670,6 +847,15 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
@@ -710,6 +896,17 @@ dependencies = [
  "concurrent-queue",
  "parking",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -762,6 +959,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "float-cmp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98de4bbd547a563b716d8dfa9aad1cb19bfab00f4fa09a6a4ed21dbcf44ce9c4"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,6 +1009,64 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
+name = "fred"
+version = "9.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cdd5378252ea124b712e0ac55147d26ae3af575883b34b8423091a4c719606b"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "bytes-utils",
+ "crossbeam-queue",
+ "float-cmp",
+ "fred-macros",
+ "futures",
+ "log",
+ "parking_lot",
+ "rand 0.8.6",
+ "redis-protocol",
+ "rustls",
+ "rustls-native-certs 0.7.3",
+ "semver",
+ "sha-1",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-rustls",
+ "tokio-stream",
+ "tokio-util",
+ "url",
+ "urlencoding",
+]
+
+[[package]]
+name = "fred-macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1458c6e22d36d61507034d5afecc64f105c1d39712b7ac6ec3b352c423f715cc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1149,7 +1424,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -1182,7 +1457,7 @@ dependencies = [
  "hyper",
  "libc",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1330,6 +1605,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1339,6 +1624,31 @@ dependencies = [
  "futures-util",
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonschema"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "161c33c3ec738cfea3288c5c53dfcdb32fd4fc2954de86ea06f71b5a1a40bfcd"
+dependencies = [
+ "ahash",
+ "base64 0.22.1",
+ "bytecount",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex-syntax",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "uuid-simd",
 ]
 
 [[package]]
@@ -1501,6 +1811,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint-dig"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1514,6 +1848,21 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1538,6 +1887,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -1587,6 +1947,12 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-probe"
@@ -1671,6 +2037,12 @@ dependencies = [
  "tokio-stream",
  "tracing",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking"
@@ -1839,6 +2211,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "predicates"
+version = "3.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ada8f2932f28a27ee7b70dd6c1c39ea0675c55a36879ab92f3a715eaa1e63cfe"
+dependencies = [
+ "anstyle",
+ "difflib",
+ "predicates-core",
+]
+
+[[package]]
+name = "predicates-core"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cad38746f3166b4031b1a0d39ad9f954dd291e7854fcc0eed52ee41a0b50d144"
+
+[[package]]
+name = "predicates-tree"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0de1b847b39c8131db0467e9df1ff60e6d0562ab8e9a16e568ad0fdb372e2f2"
+dependencies = [
+ "predicates-core",
+ "termtree",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1948,7 +2347,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1985,7 +2384,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -2071,6 +2470,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "redis-protocol"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65deb7c9501fbb2b6f812a30d59c0253779480853545153a51d8e9e444ddc99f"
+dependencies = [
+ "bytes",
+ "bytes-utils",
+ "cookie-factory",
+ "crc16",
+ "log",
+ "nom",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2115,6 +2528,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "referencing"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40a64b3a635fad9000648b4d8a59c8710c523ab61a23d392a7d91d47683f5adc"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -2173,7 +2600,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
- "rustls-native-certs",
+ "rustls-native-certs 0.8.3",
  "rustls-pemfile",
  "rustls-pki-types",
  "serde",
@@ -2252,6 +2679,8 @@ version = "0.23.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -2262,14 +2691,27 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe 0.1.6",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
 dependencies = [
- "openssl-probe",
+ "openssl-probe 0.2.1",
  "rustls-pki-types",
  "schannel",
- "security-framework",
+ "security-framework 3.7.0",
 ]
 
 [[package]]
@@ -2297,6 +2739,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2364,12 +2807,25 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "security-framework"
+version = "2.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
 version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2499,6 +2955,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha-1"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2585,6 +3052,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2894,6 +3371,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "termtree"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
 name = "testcontainers"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3027,7 +3510,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -3174,7 +3657,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -3398,6 +3881,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3423,6 +3912,7 @@ checksum = "6d79d08d92ab8af4c5e8a6da20c47ae3f61a0f1dabc1997cdf2d082b757ca08b"
 dependencies = [
  "proc-macro2",
  "quote",
+ "regex",
  "syn",
 ]
 
@@ -3435,6 +3925,17 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
 ]
 
 [[package]]
@@ -3454,6 +3955,21 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/au-kpis-api-http/Cargo.toml
+++ b/crates/au-kpis-api-http/Cargo.toml
@@ -8,3 +8,10 @@ repository.workspace = true
 description = "axum routes + handlers (library)."
 
 [dependencies]
+axum = { version = "0.7", features = ["macros"] }
+serde = { version = "1", features = ["derive"] }
+utoipa = { version = "5", features = ["axum_extras"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tower = { version = "0.5", features = ["util"] }

--- a/crates/au-kpis-api-http/src/lib.rs
+++ b/crates/au-kpis-api-http/src/lib.rs
@@ -1,1 +1,78 @@
 //! axum routes + handlers (library).
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use axum::{Json, Router, routing::get};
+use serde::{Deserialize, Serialize};
+use utoipa::{OpenApi, ToSchema};
+
+/// Health endpoint response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct HealthResponse {
+    /// Current service health.
+    pub status: String,
+}
+
+/// `GET /v1/health`.
+#[utoipa::path(
+    get,
+    operation_id = "health",
+    path = "/v1/health",
+    responses(
+        (
+            status = 200,
+            description = "API is healthy.",
+            body = HealthResponse
+        )
+    )
+)]
+pub async fn health() -> Json<HealthResponse> {
+    Json(HealthResponse {
+        status: "ok".into(),
+    })
+}
+
+/// Root OpenAPI document for the API handlers in this crate.
+#[derive(Debug, OpenApi)]
+#[openapi(
+    info(
+        title = "Australian KPIs API",
+        version = "0.1.0",
+        description = "Unified API for Australian public economic data."
+    ),
+    paths(health),
+    components(schemas(HealthResponse))
+)]
+pub struct ApiDoc;
+
+/// Minimal application router for the currently implemented handlers.
+pub fn router() -> Router {
+    Router::new().route("/v1/health", get(health))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tower::ServiceExt;
+
+    use super::router;
+
+    #[tokio::test]
+    async fn health_route_returns_ok() {
+        let response = router()
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/health")
+                    .body(Body::empty())
+                    .expect("request"),
+            )
+            .await
+            .expect("response");
+
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+}

--- a/crates/au-kpis-cache/Cargo.toml
+++ b/crates/au-kpis-cache/Cargo.toml
@@ -8,3 +8,15 @@ repository.workspace = true
 description = "Redis cache abstraction."
 
 [dependencies]
+async-trait = "0.1"
+au-kpis-error = { workspace = true }
+fred = { version = "9", features = ["enable-rustls", "i-keys", "i-scripts", "sha-1"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+tokio = { version = "1", features = ["time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+testcontainers = "0.23"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }

--- a/crates/au-kpis-cache/src/lib.rs
+++ b/crates/au-kpis-cache/src/lib.rs
@@ -27,17 +27,20 @@ use tracing::instrument;
 const RATE_LIMIT_LUA: &str = r#"
 local key = KEYS[1]
 local capacity = tonumber(ARGV[1])
-local refill_per_second = tonumber(ARGV[2])
-local requested = tonumber(ARGV[3])
-local now_ms = tonumber(ARGV[4])
+local refill_tokens = tonumber(ARGV[2])
+local refill_interval_ms = tonumber(ARGV[3])
+local requested = tonumber(ARGV[4])
+local now_ms = tonumber(ARGV[5])
 
-local state = redis.call('HMGET', key, 'tokens_ms', 'last_ms')
-local capacity_ms = capacity * 1000
-local requested_ms = requested * 1000
+local state = redis.call('HMGET', key, 'tokens_scaled', 'last_ms')
+local scale = 1000
+local capacity_scaled = capacity * scale
+local refill_scaled = refill_tokens * scale
+local requested_scaled = requested * scale
 
-local tokens_ms = tonumber(state[1])
-if tokens_ms == nil then
-  tokens_ms = capacity_ms
+local tokens_scaled = tonumber(state[1])
+if tokens_scaled == nil then
+  tokens_scaled = capacity_scaled
 end
 
 local last_ms = tonumber(state[2])
@@ -50,24 +53,63 @@ if elapsed_ms < 0 then
   elapsed_ms = 0
 end
 
-local refill_ms = elapsed_ms * refill_per_second
-tokens_ms = math.min(capacity_ms, tokens_ms + refill_ms)
+local refill_delta = math.floor((elapsed_ms * refill_scaled) / refill_interval_ms)
+tokens_scaled = math.min(capacity_scaled, tokens_scaled + refill_delta)
 
 local allowed = 0
 local retry_after_ms = 0
-if tokens_ms >= requested_ms then
+if tokens_scaled >= requested_scaled then
   allowed = 1
-  tokens_ms = tokens_ms - requested_ms
+  tokens_scaled = tokens_scaled - requested_scaled
 else
-  retry_after_ms = math.ceil((requested_ms - tokens_ms) / refill_per_second)
+  retry_after_ms = math.ceil(((requested_scaled - tokens_scaled) * refill_interval_ms) / refill_scaled)
 end
 
-redis.call('HSET', key, 'tokens_ms', tokens_ms, 'last_ms', now_ms)
-local ttl_ms = math.max(1000, math.ceil(capacity_ms / refill_per_second))
+redis.call('HSET', key, 'tokens_scaled', tokens_scaled, 'last_ms', now_ms)
+local ttl_ms = math.max(refill_interval_ms, math.ceil((capacity_scaled * refill_interval_ms) / refill_scaled))
 redis.call('PEXPIRE', key, ttl_ms)
 
-return {allowed, math.floor(tokens_ms / 1000), retry_after_ms}
+return {allowed, math.floor(tokens_scaled / scale), retry_after_ms}
 "#;
+
+/// Token-bucket refill parameters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TokenBucketConfig {
+    capacity: u32,
+    refill_tokens: u32,
+    refill_interval: Duration,
+}
+
+impl TokenBucketConfig {
+    /// Create a token-bucket configuration.
+    ///
+    /// This model supports quotas below one token per second by describing
+    /// refill as `N tokens per interval` rather than `tokens/second`.
+    pub fn new(
+        capacity: u32,
+        refill_tokens: u32,
+        refill_interval: Duration,
+    ) -> Result<Self, CacheError> {
+        validate_bucket_args(capacity, refill_tokens, refill_interval)?;
+        Ok(Self {
+            capacity,
+            refill_tokens,
+            refill_interval,
+        })
+    }
+
+    fn capacity(self) -> u32 {
+        self.capacity
+    }
+
+    fn refill_tokens(self) -> u32 {
+        self.refill_tokens
+    }
+
+    fn refill_interval(self) -> Duration {
+        self.refill_interval
+    }
+}
 
 /// Result of a token-bucket rate-limit check.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -122,8 +164,7 @@ pub trait CacheBackend: Debug + Send + Sync {
     async fn take_token_bucket(
         &self,
         key: &str,
-        capacity: u32,
-        refill_per_second: u32,
+        config: TokenBucketConfig,
         requested: u32,
         now_ms: u64,
     ) -> Result<RateLimitDecision, CacheError>;
@@ -157,19 +198,20 @@ impl CacheBackend for FredBackend {
     async fn take_token_bucket(
         &self,
         key: &str,
-        capacity: u32,
-        refill_per_second: u32,
+        config: TokenBucketConfig,
         requested: u32,
         now_ms: u64,
     ) -> Result<RateLimitDecision, CacheError> {
+        let refill_interval_ms = duration_millis_i64(config.refill_interval())?;
         let result: Vec<i64> = self
             .pool
             .eval(
                 RATE_LIMIT_LUA,
                 vec![key],
                 vec![
-                    i64::from(capacity),
-                    i64::from(refill_per_second),
+                    i64::from(config.capacity()),
+                    i64::from(config.refill_tokens()),
+                    refill_interval_ms,
                     i64::from(requested),
                     i64::try_from(now_ms).map_err(|_| {
                         CacheError::Validation("current time exceeds Redis script range".into())
@@ -273,38 +315,40 @@ impl CacheClient {
     pub async fn take_token_bucket(
         &self,
         key: &str,
-        capacity: u32,
-        refill_per_second: u32,
+        config: TokenBucketConfig,
         requested: u32,
     ) -> Result<RateLimitDecision, CacheError> {
-        validate_bucket_args(capacity, refill_per_second, requested)?;
+        validate_request_size(config.capacity(), requested)?;
         self.backend
-            .take_token_bucket(
-                key,
-                capacity,
-                refill_per_second,
-                requested,
-                unix_time_millis()?,
-            )
+            .take_token_bucket(key, config, requested, unix_time_millis()?)
             .await
     }
 }
 
 fn validate_bucket_args(
     capacity: u32,
-    refill_per_second: u32,
-    requested: u32,
+    refill_tokens: u32,
+    refill_interval: Duration,
 ) -> Result<(), CacheError> {
     if capacity == 0 {
         return Err(CacheError::Validation(
             "token bucket capacity must be greater than zero".into(),
         ));
     }
-    if refill_per_second == 0 {
+    if refill_tokens == 0 {
         return Err(CacheError::Validation(
             "token bucket refill rate must be greater than zero".into(),
         ));
     }
+    if refill_interval.is_zero() {
+        return Err(CacheError::Validation(
+            "token bucket refill interval must be greater than zero".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_request_size(capacity: u32, requested: u32) -> Result<(), CacheError> {
     if requested == 0 {
         return Err(CacheError::Validation(
             "token bucket request size must be greater than zero".into(),
@@ -342,7 +386,7 @@ mod tests {
     use async_trait::async_trait;
     use serde::{Deserialize, Serialize};
 
-    use crate::{CacheBackend, CacheClient, CacheError, RateLimitDecision};
+    use crate::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
 
     #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
     struct Widget {
@@ -387,8 +431,7 @@ mod tests {
         async fn take_token_bucket(
             &self,
             _key: &str,
-            _capacity: u32,
-            _refill_per_second: u32,
+            _config: TokenBucketConfig,
             _requested: u32,
             _now_ms: u64,
         ) -> Result<RateLimitDecision, CacheError> {
@@ -444,7 +487,11 @@ mod tests {
         let client = CacheClient::from_backend(backend);
 
         let decision = client
-            .take_token_bucket("ratelimit:key", 3, 2, 1)
+            .take_token_bucket(
+                "ratelimit:key",
+                TokenBucketConfig::new(3, 2, Duration::from_secs(1)).expect("bucket config"),
+                1,
+            )
             .await
             .expect("rate limit");
 
@@ -458,16 +505,28 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn invalid_rate_limit_arguments_are_rejected() {
-        let client = CacheClient::from_backend(MockBackend::default());
-        let err = client
-            .take_token_bucket("ratelimit:key", 0, 1, 1)
-            .await
+    #[test]
+    fn invalid_rate_limit_arguments_are_rejected() {
+        let err = TokenBucketConfig::new(0, 1, Duration::from_secs(1))
             .expect_err("zero capacity should fail");
 
         assert!(
             err.to_string().contains("capacity"),
+            "expected validation message, got {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn request_larger_than_capacity_is_rejected() {
+        let client = CacheClient::from_backend(MockBackend::default());
+        let config = TokenBucketConfig::new(2, 1, Duration::from_secs(1)).expect("bucket config");
+        let err = client
+            .take_token_bucket("ratelimit:key", config, 3)
+            .await
+            .expect_err("oversized request should fail");
+
+        assert!(
+            err.to_string().contains("cannot exceed capacity"),
             "expected validation message, got {err}"
         );
     }

--- a/crates/au-kpis-cache/src/lib.rs
+++ b/crates/au-kpis-cache/src/lib.rs
@@ -1,1 +1,474 @@
 //! Redis cache abstraction.
+//!
+//! This crate owns two primitives from `Spec.md § Stack (locked)`:
+//!
+//! - a typed JSON key-value cache for small hot-path values
+//! - an atomic token-bucket rate limiter implemented as a Redis Lua script
+//!
+//! The public API stays intentionally small until downstream crates start
+//! using it.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::{
+    fmt::Debug,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use async_trait::async_trait;
+use au_kpis_error::{Classify, CoreError, ErrorClass};
+use fred::prelude::*;
+use serde::{Serialize, de::DeserializeOwned};
+use thiserror::Error;
+use tracing::instrument;
+
+const RATE_LIMIT_LUA: &str = r#"
+local key = KEYS[1]
+local capacity = tonumber(ARGV[1])
+local refill_per_second = tonumber(ARGV[2])
+local requested = tonumber(ARGV[3])
+local now_ms = tonumber(ARGV[4])
+
+local state = redis.call('HMGET', key, 'tokens_ms', 'last_ms')
+local capacity_ms = capacity * 1000
+local requested_ms = requested * 1000
+
+local tokens_ms = tonumber(state[1])
+if tokens_ms == nil then
+  tokens_ms = capacity_ms
+end
+
+local last_ms = tonumber(state[2])
+if last_ms == nil then
+  last_ms = now_ms
+end
+
+local elapsed_ms = now_ms - last_ms
+if elapsed_ms < 0 then
+  elapsed_ms = 0
+end
+
+local refill_ms = elapsed_ms * refill_per_second
+tokens_ms = math.min(capacity_ms, tokens_ms + refill_ms)
+
+local allowed = 0
+local retry_after_ms = 0
+if tokens_ms >= requested_ms then
+  allowed = 1
+  tokens_ms = tokens_ms - requested_ms
+else
+  retry_after_ms = math.ceil((requested_ms - tokens_ms) / refill_per_second)
+end
+
+redis.call('HSET', key, 'tokens_ms', tokens_ms, 'last_ms', now_ms)
+local ttl_ms = math.max(1000, math.ceil(capacity_ms / refill_per_second))
+redis.call('PEXPIRE', key, ttl_ms)
+
+return {allowed, math.floor(tokens_ms / 1000), retry_after_ms}
+"#;
+
+/// Result of a token-bucket rate-limit check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RateLimitDecision {
+    /// Whether the request can proceed immediately.
+    pub allowed: bool,
+    /// Whole tokens remaining after the decision.
+    pub remaining: u32,
+    /// Delay before retry when [`Self::allowed`] is `false`.
+    pub retry_after: Duration,
+}
+
+/// Errors returned by [`CacheClient`].
+#[derive(Debug, Error)]
+pub enum CacheError {
+    /// Redis command failure.
+    #[error("redis: {0}")]
+    Redis(#[from] fred::error::RedisError),
+
+    /// JSON serialization or deserialization failure.
+    #[error(transparent)]
+    Core(#[from] CoreError),
+
+    /// Caller-supplied arguments violated a precondition.
+    #[error("validation: {0}")]
+    Validation(String),
+}
+
+impl Classify for CacheError {
+    fn class(&self) -> ErrorClass {
+        match self {
+            CacheError::Redis(_) => ErrorClass::Transient,
+            CacheError::Core(err) => err.class(),
+            CacheError::Validation(_) => ErrorClass::Validation,
+        }
+    }
+}
+
+/// Backend abstraction used to keep unit tests fast and deterministic.
+#[async_trait]
+pub trait CacheBackend: Debug + Send + Sync {
+    /// Read a raw string value.
+    async fn get(&self, key: &str) -> Result<Option<String>, CacheError>;
+
+    /// Write a raw string value with a TTL.
+    async fn set(&self, key: &str, value: String, ttl: Duration) -> Result<(), CacheError>;
+
+    /// Delete a key, returning `true` when a value existed.
+    async fn delete(&self, key: &str) -> Result<bool, CacheError>;
+
+    /// Consume tokens from a bucket, atomically.
+    async fn take_token_bucket(
+        &self,
+        key: &str,
+        capacity: u32,
+        refill_per_second: u32,
+        requested: u32,
+        now_ms: u64,
+    ) -> Result<RateLimitDecision, CacheError>;
+}
+
+#[derive(Debug, Clone)]
+struct FredBackend {
+    pool: RedisPool,
+}
+
+#[async_trait]
+impl CacheBackend for FredBackend {
+    async fn get(&self, key: &str) -> Result<Option<String>, CacheError> {
+        Ok(self.pool.get(key).await?)
+    }
+
+    async fn set(&self, key: &str, value: String, ttl: Duration) -> Result<(), CacheError> {
+        let ttl_ms = duration_millis_i64(ttl)?;
+        let _: () = self
+            .pool
+            .set(key, value, Some(Expiration::PX(ttl_ms)), None, false)
+            .await?;
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<bool, CacheError> {
+        let deleted: i64 = self.pool.del(key).await?;
+        Ok(deleted > 0)
+    }
+
+    async fn take_token_bucket(
+        &self,
+        key: &str,
+        capacity: u32,
+        refill_per_second: u32,
+        requested: u32,
+        now_ms: u64,
+    ) -> Result<RateLimitDecision, CacheError> {
+        let result: Vec<i64> = self
+            .pool
+            .eval(
+                RATE_LIMIT_LUA,
+                vec![key],
+                vec![
+                    i64::from(capacity),
+                    i64::from(refill_per_second),
+                    i64::from(requested),
+                    i64::try_from(now_ms).map_err(|_| {
+                        CacheError::Validation("current time exceeds Redis script range".into())
+                    })?,
+                ],
+            )
+            .await?;
+
+        if result.len() != 3 {
+            return Err(CacheError::Validation(format!(
+                "rate-limit script returned {} values, expected 3",
+                result.len()
+            )));
+        }
+
+        Ok(RateLimitDecision {
+            allowed: result[0] == 1,
+            remaining: u32::try_from(result[1]).map_err(|_| {
+                CacheError::Validation(format!(
+                    "rate-limit script returned invalid remaining token count: {}",
+                    result[1]
+                ))
+            })?,
+            retry_after: Duration::from_millis(u64::try_from(result[2]).map_err(|_| {
+                CacheError::Validation(format!(
+                    "rate-limit script returned invalid retry delay: {}",
+                    result[2]
+                ))
+            })?),
+        })
+    }
+}
+
+/// Redis-backed typed cache + rate-limit client.
+#[derive(Debug, Clone)]
+pub struct CacheClient {
+    backend: Arc<dyn CacheBackend>,
+}
+
+impl CacheClient {
+    /// Connect to Redis using a small round-robin `fred` pool.
+    #[instrument(skip(url))]
+    pub async fn connect(url: &str) -> Result<Self, CacheError> {
+        let config = RedisConfig::from_url(url)?;
+        let pool = Builder::from_config(config).build_pool(2)?;
+        let _connection_task = pool.init().await?;
+        Ok(Self::from_backend(FredBackend { pool }))
+    }
+
+    /// Construct a cache client from a custom backend.
+    pub fn from_backend<B>(backend: B) -> Self
+    where
+        B: CacheBackend + 'static,
+    {
+        Self {
+            backend: Arc::new(backend),
+        }
+    }
+
+    /// Read a typed JSON value from Redis.
+    #[instrument(skip(self), fields(cache.key = key))]
+    pub async fn get_json<T>(&self, key: &str) -> Result<Option<T>, CacheError>
+    where
+        T: DeserializeOwned,
+    {
+        self.backend
+            .get(key)
+            .await?
+            .map(|raw| serde_json::from_str(&raw).map_err(CoreError::from))
+            .transpose()
+            .map_err(CacheError::from)
+    }
+
+    /// Store a typed JSON value with a TTL.
+    #[instrument(skip(self, value), fields(cache.key = key, cache.ttl_ms = ttl.as_millis()))]
+    pub async fn set_json<T>(&self, key: &str, value: &T, ttl: Duration) -> Result<(), CacheError>
+    where
+        T: Serialize,
+    {
+        if ttl.is_zero() {
+            return Err(CacheError::Validation(
+                "cache TTL must be greater than zero".into(),
+            ));
+        }
+
+        let payload = serde_json::to_string(value).map_err(CoreError::from)?;
+        self.backend.set(key, payload, ttl).await
+    }
+
+    /// Delete a cached value.
+    #[instrument(skip(self), fields(cache.key = key))]
+    pub async fn delete(&self, key: &str) -> Result<bool, CacheError> {
+        self.backend.delete(key).await
+    }
+
+    /// Atomically take tokens from a bucket keyed in Redis.
+    ///
+    /// `capacity`, `refill_per_second`, and `requested` must all be positive,
+    /// and `requested` cannot exceed `capacity`.
+    #[instrument(skip(self), fields(rate_limit.key = key))]
+    pub async fn take_token_bucket(
+        &self,
+        key: &str,
+        capacity: u32,
+        refill_per_second: u32,
+        requested: u32,
+    ) -> Result<RateLimitDecision, CacheError> {
+        validate_bucket_args(capacity, refill_per_second, requested)?;
+        self.backend
+            .take_token_bucket(
+                key,
+                capacity,
+                refill_per_second,
+                requested,
+                unix_time_millis()?,
+            )
+            .await
+    }
+}
+
+fn validate_bucket_args(
+    capacity: u32,
+    refill_per_second: u32,
+    requested: u32,
+) -> Result<(), CacheError> {
+    if capacity == 0 {
+        return Err(CacheError::Validation(
+            "token bucket capacity must be greater than zero".into(),
+        ));
+    }
+    if refill_per_second == 0 {
+        return Err(CacheError::Validation(
+            "token bucket refill rate must be greater than zero".into(),
+        ));
+    }
+    if requested == 0 {
+        return Err(CacheError::Validation(
+            "token bucket request size must be greater than zero".into(),
+        ));
+    }
+    if requested > capacity {
+        return Err(CacheError::Validation(
+            "token bucket request size cannot exceed capacity".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn unix_time_millis() -> Result<u64, CacheError> {
+    let elapsed = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map_err(|err| CacheError::Validation(format!("system clock before unix epoch: {err}")))?;
+    u64::try_from(elapsed.as_millis())
+        .map_err(|_| CacheError::Validation("current time exceeds u64 milliseconds".into()))
+}
+
+fn duration_millis_i64(duration: Duration) -> Result<i64, CacheError> {
+    i64::try_from(duration.as_millis())
+        .map_err(|_| CacheError::Validation("TTL exceeds Redis millisecond range".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        collections::{HashMap, VecDeque},
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+
+    use async_trait::async_trait;
+    use serde::{Deserialize, Serialize};
+
+    use crate::{CacheBackend, CacheClient, CacheError, RateLimitDecision};
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+    struct Widget {
+        id: u64,
+        label: String,
+    }
+
+    #[derive(Debug, Clone, Default)]
+    struct MockBackend {
+        values: Arc<Mutex<HashMap<String, String>>>,
+        deleted: Arc<Mutex<Vec<String>>>,
+        script_results: Arc<Mutex<VecDeque<(bool, u32, u64)>>>,
+    }
+
+    #[async_trait]
+    impl CacheBackend for MockBackend {
+        async fn get(&self, key: &str) -> Result<Option<String>, CacheError> {
+            Ok(self.values.lock().expect("values lock").get(key).cloned())
+        }
+
+        async fn set(&self, key: &str, value: String, _ttl: Duration) -> Result<(), CacheError> {
+            self.values
+                .lock()
+                .expect("values lock")
+                .insert(key.to_owned(), value);
+            Ok(())
+        }
+
+        async fn delete(&self, key: &str) -> Result<bool, CacheError> {
+            self.deleted
+                .lock()
+                .expect("deleted lock")
+                .push(key.to_owned());
+            Ok(self
+                .values
+                .lock()
+                .expect("values lock")
+                .remove(key)
+                .is_some())
+        }
+
+        async fn take_token_bucket(
+            &self,
+            _key: &str,
+            _capacity: u32,
+            _refill_per_second: u32,
+            _requested: u32,
+            _now_ms: u64,
+        ) -> Result<RateLimitDecision, CacheError> {
+            let (allowed, remaining, retry_after_ms) = self
+                .script_results
+                .lock()
+                .expect("script results lock")
+                .pop_front()
+                .expect("script result queued");
+            Ok(RateLimitDecision {
+                allowed,
+                remaining,
+                retry_after: Duration::from_millis(retry_after_ms),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn typed_cache_round_trip_serializes_json() {
+        let backend = MockBackend::default();
+        let client = CacheClient::from_backend(backend.clone());
+        let widget = Widget {
+            id: 42,
+            label: "cpi".into(),
+        };
+
+        client
+            .set_json("widgets:42", &widget, Duration::from_secs(30))
+            .await
+            .expect("set json");
+
+        let raw = backend
+            .values
+            .lock()
+            .expect("values lock")
+            .get("widgets:42")
+            .cloned()
+            .expect("cached raw value");
+        assert_eq!(raw, r#"{"id":42,"label":"cpi"}"#);
+
+        let got: Option<Widget> = client.get_json("widgets:42").await.expect("get json");
+        assert_eq!(got, Some(widget));
+    }
+
+    #[tokio::test]
+    async fn token_bucket_result_maps_backend_response() {
+        let backend = MockBackend::default();
+        backend
+            .script_results
+            .lock()
+            .expect("script results lock")
+            .push_back((false, 0, 250));
+        let client = CacheClient::from_backend(backend);
+
+        let decision = client
+            .take_token_bucket("ratelimit:key", 3, 2, 1)
+            .await
+            .expect("rate limit");
+
+        assert_eq!(
+            decision,
+            RateLimitDecision {
+                allowed: false,
+                remaining: 0,
+                retry_after: Duration::from_millis(250),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_rate_limit_arguments_are_rejected() {
+        let client = CacheClient::from_backend(MockBackend::default());
+        let err = client
+            .take_token_bucket("ratelimit:key", 0, 1, 1)
+            .await
+            .expect_err("zero capacity should fail");
+
+        assert!(
+            err.to_string().contains("capacity"),
+            "expected validation message, got {err}"
+        );
+    }
+}

--- a/crates/au-kpis-cache/tests/redis.rs
+++ b/crates/au-kpis-cache/tests/redis.rs
@@ -1,0 +1,151 @@
+use std::time::Duration;
+
+use au_kpis_cache::CacheClient;
+use serde::{Deserialize, Serialize};
+use testcontainers::{
+    ContainerAsync, GenericImage,
+    core::{ContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+const REDIS_IMAGE: &str = "redis";
+const REDIS_TAG: &str = "7.2-alpine";
+const REDIS_PORT: u16 = 6379;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+struct Session {
+    user_id: u64,
+    scopes: Vec<String>,
+}
+
+struct Harness {
+    _container: ContainerAsync<GenericImage>,
+    client: CacheClient,
+}
+
+async fn start_redis() -> Harness {
+    let container = GenericImage::new(REDIS_IMAGE, REDIS_TAG)
+        .with_exposed_port(ContainerPort::Tcp(REDIS_PORT))
+        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+        .start()
+        .await
+        .expect("start redis container");
+
+    let host = container.get_host().await.expect("container host");
+    let port = container
+        .get_host_port_ipv4(REDIS_PORT)
+        .await
+        .expect("host port");
+    let url = format!("redis://{host}:{port}");
+
+    let client = CacheClient::connect(&url).await.expect("connect cache");
+
+    Harness {
+        _container: container,
+        client,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn typed_round_trip_hits_real_redis() {
+    let harness = start_redis().await;
+    let key = "cache:test:session";
+    let value = Session {
+        user_id: 7,
+        scopes: vec!["read".into(), "write".into()],
+    };
+
+    harness
+        .client
+        .set_json(key, &value, Duration::from_secs(30))
+        .await
+        .expect("set session");
+
+    let got: Option<Session> = harness.client.get_json(key).await.expect("get session");
+    assert_eq!(got, Some(value));
+
+    let deleted = harness.client.delete(key).await.expect("delete session");
+    assert!(deleted, "delete should report an existing key");
+    assert!(
+        harness
+            .client
+            .get_json::<Session>(key)
+            .await
+            .expect("get deleted")
+            .is_none(),
+        "deleted key should miss",
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn token_bucket_denies_then_refills() {
+    let harness = start_redis().await;
+    let key = "cache:test:ratelimit:refill";
+
+    let first = harness
+        .client
+        .take_token_bucket(key, 2, 2, 1)
+        .await
+        .expect("first permit");
+    assert!(first.allowed);
+    assert_eq!(first.remaining, 1);
+
+    let second = harness
+        .client
+        .take_token_bucket(key, 2, 2, 1)
+        .await
+        .expect("second permit");
+    assert!(second.allowed);
+    assert_eq!(second.remaining, 0);
+
+    let denied = harness
+        .client
+        .take_token_bucket(key, 2, 2, 1)
+        .await
+        .expect("third permit");
+    assert!(
+        !denied.allowed,
+        "third request should be denied before the bucket refills"
+    );
+    assert_eq!(denied.remaining, 0);
+    assert!(
+        denied.retry_after >= Duration::from_millis(450)
+            && denied.retry_after <= Duration::from_millis(500),
+        "retry delay should be about half a second, got {:?}",
+        denied.retry_after,
+    );
+
+    tokio::time::sleep(Duration::from_millis(550)).await;
+
+    let after_refill = harness
+        .client
+        .take_token_bucket(key, 2, 2, 1)
+        .await
+        .expect("refilled permit");
+    assert!(after_refill.allowed, "bucket should refill after waiting");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn token_bucket_is_atomic_under_contention() {
+    let harness = start_redis().await;
+    let key = "cache:test:ratelimit:atomic";
+    let client = harness.client.clone();
+
+    let mut tasks = Vec::new();
+    for _ in 0..10 {
+        let client = client.clone();
+        tasks.push(tokio::spawn(async move {
+            client.take_token_bucket(key, 3, 1, 1).await
+        }));
+    }
+
+    let mut granted = 0;
+    for task in tasks {
+        let decision = task.await.expect("join").expect("rate limit decision");
+        if decision.allowed {
+            granted += 1;
+        }
+    }
+
+    assert_eq!(granted, 3, "only bucket capacity should be granted");
+}

--- a/crates/au-kpis-cache/tests/redis.rs
+++ b/crates/au-kpis-cache/tests/redis.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use au_kpis_cache::CacheClient;
+use au_kpis_cache::{CacheClient, TokenBucketConfig};
 use serde::{Deserialize, Serialize};
 use testcontainers::{
     ContainerAsync, GenericImage,
@@ -81,10 +81,11 @@ async fn typed_round_trip_hits_real_redis() {
 async fn token_bucket_denies_then_refills() {
     let harness = start_redis().await;
     let key = "cache:test:ratelimit:refill";
+    let config = TokenBucketConfig::new(2, 2, Duration::from_secs(1)).expect("bucket config");
 
     let first = harness
         .client
-        .take_token_bucket(key, 2, 2, 1)
+        .take_token_bucket(key, config, 1)
         .await
         .expect("first permit");
     assert!(first.allowed);
@@ -92,7 +93,7 @@ async fn token_bucket_denies_then_refills() {
 
     let second = harness
         .client
-        .take_token_bucket(key, 2, 2, 1)
+        .take_token_bucket(key, config, 1)
         .await
         .expect("second permit");
     assert!(second.allowed);
@@ -100,7 +101,7 @@ async fn token_bucket_denies_then_refills() {
 
     let denied = harness
         .client
-        .take_token_bucket(key, 2, 2, 1)
+        .take_token_bucket(key, config, 1)
         .await
         .expect("third permit");
     assert!(
@@ -108,21 +109,62 @@ async fn token_bucket_denies_then_refills() {
         "third request should be denied before the bucket refills"
     );
     assert_eq!(denied.remaining, 0);
-    assert!(
-        denied.retry_after >= Duration::from_millis(450)
-            && denied.retry_after <= Duration::from_millis(500),
-        "retry delay should be about half a second, got {:?}",
-        denied.retry_after,
-    );
+    assert!(denied.retry_after > Duration::ZERO);
 
-    tokio::time::sleep(Duration::from_millis(550)).await;
-
-    let after_refill = harness
-        .client
-        .take_token_bucket(key, 2, 2, 1)
-        .await
-        .expect("refilled permit");
+    let after_refill = tokio::time::timeout(Duration::from_secs(2), async {
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            let decision = harness
+                .client
+                .take_token_bucket(key, config, 1)
+                .await
+                .expect("refill probe");
+            if decision.allowed {
+                return decision;
+            }
+        }
+    })
+    .await
+    .expect("bucket should refill within timeout");
     assert!(after_refill.allowed, "bucket should refill after waiting");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn token_bucket_supports_sub_one_token_per_second_refill() {
+    let harness = start_redis().await;
+    let key = "cache:test:ratelimit:hourly-shape";
+    let config = TokenBucketConfig::new(1, 1, Duration::from_secs(2)).expect("bucket config");
+
+    let first = harness
+        .client
+        .take_token_bucket(key, config, 1)
+        .await
+        .expect("first permit");
+    assert!(first.allowed);
+
+    let denied = harness
+        .client
+        .take_token_bucket(key, config, 1)
+        .await
+        .expect("second permit");
+    assert!(!denied.allowed);
+
+    let refilled = tokio::time::timeout(Duration::from_secs(4), async {
+        loop {
+            tokio::time::sleep(Duration::from_millis(200)).await;
+            let decision = harness
+                .client
+                .take_token_bucket(key, config, 1)
+                .await
+                .expect("refill probe");
+            if decision.allowed {
+                return decision;
+            }
+        }
+    })
+    .await
+    .expect("sub-one-token-per-second bucket should refill");
+    assert!(refilled.allowed);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -134,8 +176,9 @@ async fn token_bucket_is_atomic_under_contention() {
     let mut tasks = Vec::new();
     for _ in 0..10 {
         let client = client.clone();
+        let config = TokenBucketConfig::new(3, 1, Duration::from_secs(1)).expect("bucket config");
         tasks.push(tokio::spawn(async move {
-            client.take_token_bucket(key, 3, 1, 1).await
+            client.take_token_bucket(key, config, 1).await
         }));
     }
 

--- a/crates/au-kpis-openapi/Cargo.toml
+++ b/crates/au-kpis-openapi/Cargo.toml
@@ -8,3 +8,10 @@ repository.workspace = true
 description = "OpenAPI spec emitter."
 
 [dependencies]
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+utoipa = { version = "5", features = ["axum_extras"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+jsonschema = "0.29"

--- a/crates/au-kpis-openapi/Cargo.toml
+++ b/crates/au-kpis-openapi/Cargo.toml
@@ -8,8 +8,9 @@ repository.workspace = true
 description = "OpenAPI spec emitter."
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
+au-kpis-api-http = { workspace = true }
 serde_json = "1"
+thiserror = "2"
 utoipa = { version = "5", features = ["axum_extras"] }
 
 [dev-dependencies]

--- a/crates/au-kpis-openapi/src/lib.rs
+++ b/crates/au-kpis-openapi/src/lib.rs
@@ -1,1 +1,53 @@
 //! OpenAPI spec emitter.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use serde::{Deserialize, Serialize};
+use utoipa::{OpenApi, ToSchema};
+
+/// Minimal health response exposed by the API skeleton.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct HealthResponse {
+    /// Service status.
+    pub status: String,
+}
+
+/// Documented health handler signature used by the generated spec.
+#[utoipa::path(
+    get,
+    operation_id = "health",
+    path = "/v1/health",
+    responses(
+        (
+            status = 200,
+            description = "API is healthy.",
+            body = HealthResponse
+        )
+    )
+)]
+pub fn health() -> HealthResponse {
+    HealthResponse {
+        status: "ok".into(),
+    }
+}
+
+/// Root OpenAPI document for the API.
+#[derive(Debug, OpenApi)]
+#[openapi(
+    info(
+        title = "Australian KPIs API",
+        version = "0.1.0",
+        description = "Unified API for Australian public economic data."
+    ),
+    paths(health),
+    components(schemas(HealthResponse))
+)]
+pub struct ApiDoc;
+
+/// Emit the current OpenAPI document as OpenAPI 3.1 JSON.
+pub fn emit() -> String {
+    ApiDoc::openapi()
+        .to_pretty_json()
+        .expect("OpenAPI document should serialize to JSON")
+}

--- a/crates/au-kpis-openapi/src/lib.rs
+++ b/crates/au-kpis-openapi/src/lib.rs
@@ -3,51 +3,19 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs, missing_debug_implementations)]
 
-use serde::{Deserialize, Serialize};
-use utoipa::{OpenApi, ToSchema};
+pub use au_kpis_api_http::ApiDoc;
+use thiserror::Error;
+use utoipa::OpenApi;
 
-/// Minimal health response exposed by the API skeleton.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
-pub struct HealthResponse {
-    /// Service status.
-    pub status: String,
+/// Errors returned by the OpenAPI emitter.
+#[derive(Debug, Error)]
+pub enum OpenApiError {
+    /// Serializing the generated spec failed.
+    #[error("openapi serialization: {0}")]
+    Serialize(#[from] serde_json::Error),
 }
-
-/// Documented health handler signature used by the generated spec.
-#[utoipa::path(
-    get,
-    operation_id = "health",
-    path = "/v1/health",
-    responses(
-        (
-            status = 200,
-            description = "API is healthy.",
-            body = HealthResponse
-        )
-    )
-)]
-pub fn health() -> HealthResponse {
-    HealthResponse {
-        status: "ok".into(),
-    }
-}
-
-/// Root OpenAPI document for the API.
-#[derive(Debug, OpenApi)]
-#[openapi(
-    info(
-        title = "Australian KPIs API",
-        version = "0.1.0",
-        description = "Unified API for Australian public economic data."
-    ),
-    paths(health),
-    components(schemas(HealthResponse))
-)]
-pub struct ApiDoc;
 
 /// Emit the current OpenAPI document as OpenAPI 3.1 JSON.
-pub fn emit() -> String {
-    ApiDoc::openapi()
-        .to_pretty_json()
-        .expect("OpenAPI document should serialize to JSON")
+pub fn emit() -> Result<String, OpenApiError> {
+    Ok(ApiDoc::openapi().to_pretty_json()?)
 }

--- a/crates/au-kpis-openapi/src/main.rs
+++ b/crates/au-kpis-openapi/src/main.rs
@@ -1,3 +1,9 @@
 fn main() {
-    print!("{}", au_kpis_openapi::emit());
+    match au_kpis_openapi::emit() {
+        Ok(doc) => print!("{doc}"),
+        Err(err) => {
+            eprintln!("{err}");
+            std::process::exit(1);
+        }
+    }
 }

--- a/crates/au-kpis-openapi/src/main.rs
+++ b/crates/au-kpis-openapi/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    print!("{}", au_kpis_openapi::emit());
+}

--- a/crates/au-kpis-openapi/tests/emitter.rs
+++ b/crates/au-kpis-openapi/tests/emitter.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 use utoipa::OpenApi;
 
 fn emitted_spec() -> Value {
-    serde_json::from_str(&emit()).expect("emitted spec should be JSON")
+    serde_json::from_str(&emit().expect("emitted spec should be JSON")).expect("valid json")
 }
 
 #[test]
@@ -43,5 +43,5 @@ fn cli_prints_same_document_as_emit() {
     );
 
     let stdout = String::from_utf8(output.stdout).expect("stdout utf-8");
-    assert_eq!(stdout, emit());
+    assert_eq!(stdout, emit().expect("emit should succeed"));
 }

--- a/crates/au-kpis-openapi/tests/emitter.rs
+++ b/crates/au-kpis-openapi/tests/emitter.rs
@@ -1,0 +1,47 @@
+use std::process::Command;
+
+use assert_cmd::cargo::cargo_bin;
+use au_kpis_openapi::{ApiDoc, emit};
+use jsonschema::draft202012;
+use serde_json::Value;
+use utoipa::OpenApi;
+
+fn emitted_spec() -> Value {
+    serde_json::from_str(&emit()).expect("emitted spec should be JSON")
+}
+
+#[test]
+fn apidoc_derives_openapi() {
+    let openapi = ApiDoc::openapi();
+    let value = serde_json::to_value(&openapi).expect("serialize openapi");
+    assert_eq!(value["openapi"], "3.1.0");
+}
+
+#[test]
+fn emit_produces_document_valid_against_official_schema() {
+    let schema: Value = serde_json::from_str(include_str!("fixtures/openapi-3.1-schema.json"))
+        .expect("schema fixture should parse");
+    let doc = emitted_spec();
+    let validator = draft202012::new(&schema).expect("compile schema");
+    let output = validator.validate(&doc);
+
+    assert!(
+        output.is_ok(),
+        "expected emitted spec to validate, got {output:?}"
+    );
+    assert_eq!(doc["paths"]["/v1/health"]["get"]["operationId"], "health");
+}
+
+#[test]
+fn cli_prints_same_document_as_emit() {
+    let output = Command::new(cargo_bin("au-kpis-openapi"))
+        .output()
+        .expect("run au-kpis-openapi binary");
+    assert!(
+        output.status.success(),
+        "binary should exit successfully: {output:?}"
+    );
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout utf-8");
+    assert_eq!(stdout, emit());
+}

--- a/crates/au-kpis-openapi/tests/fixtures/openapi-3.1-schema.json
+++ b/crates/au-kpis-openapi/tests/fixtures/openapi-3.1-schema.json
@@ -1,0 +1,1408 @@
+{
+  "$id": "https://spec.openapis.org/oas/3.1/schema/2025-02-13",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "The description of OpenAPI v3.1.x Documents without Schema Object validation",
+  "type": "object",
+  "properties": {
+    "openapi": {
+      "type": "string",
+      "pattern": "^3\\.1\\.\\d+(-.+)?$"
+    },
+    "info": {
+      "$ref": "#/$defs/info"
+    },
+    "jsonSchemaDialect": {
+      "type": "string",
+      "format": "uri-reference",
+      "default": "https://spec.openapis.org/oas/3.1/dialect/2024-11-10"
+    },
+    "servers": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/server"
+      },
+      "default": [
+        {
+          "url": "/"
+        }
+      ]
+    },
+    "paths": {
+      "$ref": "#/$defs/paths"
+    },
+    "webhooks": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item"
+      }
+    },
+    "components": {
+      "$ref": "#/$defs/components"
+    },
+    "security": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/security-requirement"
+      }
+    },
+    "tags": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/tag"
+      }
+    },
+    "externalDocs": {
+      "$ref": "#/$defs/external-documentation"
+    }
+  },
+  "required": [
+    "openapi",
+    "info"
+  ],
+  "anyOf": [
+    {
+      "required": [
+        "paths"
+      ]
+    },
+    {
+      "required": [
+        "components"
+      ]
+    },
+    {
+      "required": [
+        "webhooks"
+      ]
+    }
+  ],
+  "$ref": "#/$defs/specification-extensions",
+  "unevaluatedProperties": false,
+  "$defs": {
+    "info": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#info-object",
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "termsOfService": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "contact": {
+          "$ref": "#/$defs/contact"
+        },
+        "license": {
+          "$ref": "#/$defs/license"
+        },
+        "version": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "title",
+        "version"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "contact": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#contact-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "email": {
+          "type": "string",
+          "format": "email"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "license": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#license-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "identifier": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "dependentSchemas": {
+        "identifier": {
+          "not": {
+            "required": [
+              "url"
+            ]
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#server-object",
+      "type": "object",
+      "properties": {
+        "url": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "variables": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/server-variable"
+          }
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "server-variable": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#server-variable-object",
+      "type": "object",
+      "properties": {
+        "enum": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1
+        },
+        "default": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "default"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "components": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#components-object",
+      "type": "object",
+      "properties": {
+        "schemas": {
+          "type": "object",
+          "additionalProperties": {
+            "$dynamicRef": "#meta"
+          }
+        },
+        "responses": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/response-or-reference"
+          }
+        },
+        "parameters": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        },
+        "requestBodies": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/request-body-or-reference"
+          }
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "securitySchemes": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/security-scheme-or-reference"
+          }
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "pathItems": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/path-item"
+          }
+        }
+      },
+      "patternProperties": {
+        "^(schemas|responses|parameters|examples|requestBodies|headers|securitySchemes|links|callbacks|pathItems)$": {
+          "$comment": "Enumerating all of the property names in the regex above is necessary for unevaluatedProperties to work as expected",
+          "propertyNames": {
+            "pattern": "^[a-zA-Z0-9._-]+$"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "paths": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#paths-object",
+      "type": "object",
+      "patternProperties": {
+        "^/": {
+          "$ref": "#/$defs/path-item"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "path-item": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#path-item-object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "get": {
+          "$ref": "#/$defs/operation"
+        },
+        "put": {
+          "$ref": "#/$defs/operation"
+        },
+        "post": {
+          "$ref": "#/$defs/operation"
+        },
+        "delete": {
+          "$ref": "#/$defs/operation"
+        },
+        "options": {
+          "$ref": "#/$defs/operation"
+        },
+        "head": {
+          "$ref": "#/$defs/operation"
+        },
+        "patch": {
+          "$ref": "#/$defs/operation"
+        },
+        "trace": {
+          "$ref": "#/$defs/operation"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "operation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#operation-object",
+      "type": "object",
+      "properties": {
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/parameter-or-reference"
+          }
+        },
+        "requestBody": {
+          "$ref": "#/$defs/request-body-or-reference"
+        },
+        "responses": {
+          "$ref": "#/$defs/responses"
+        },
+        "callbacks": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/callbacks-or-reference"
+          }
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "security": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/security-requirement"
+          }
+        },
+        "servers": {
+          "type": "array",
+          "items": {
+            "$ref": "#/$defs/server"
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "external-documentation": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#external-documentation-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "url": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "required": [
+        "url"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#parameter-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "in": {
+          "enum": [
+            "query",
+            "header",
+            "path",
+            "cookie"
+          ]
+        },
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "required": [
+        "name",
+        "in"
+      ],
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "if": {
+        "properties": {
+          "in": {
+            "const": "query"
+          }
+        },
+        "required": [
+          "in"
+        ]
+      },
+      "then": {
+        "properties": {
+          "allowEmptyValue": {
+            "default": false,
+            "type": "boolean"
+          }
+        }
+      },
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "type": "string"
+            },
+            "explode": {
+              "type": "boolean"
+            }
+          },
+          "allOf": [
+            {
+              "$ref": "#/$defs/examples"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-path"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-header"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-query"
+            },
+            {
+              "$ref": "#/$defs/parameter/dependentSchemas/schema/$defs/styles-for-cookie"
+            },
+            {
+              "$ref": "#/$defs/styles-for-form"
+            }
+          ],
+          "$defs": {
+            "styles-for-path": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "path"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "simple",
+                    "enum": [
+                      "matrix",
+                      "label",
+                      "simple"
+                    ]
+                  },
+                  "required": {
+                    "const": true
+                  }
+                },
+                "required": [
+                  "required"
+                ]
+              }
+            },
+            "styles-for-header": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "header"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "simple",
+                    "const": "simple"
+                  }
+                }
+              }
+            },
+            "styles-for-query": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "query"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "enum": [
+                      "form",
+                      "spaceDelimited",
+                      "pipeDelimited",
+                      "deepObject"
+                    ]
+                  },
+                  "allowReserved": {
+                    "default": false,
+                    "type": "boolean"
+                  }
+                }
+              }
+            },
+            "styles-for-cookie": {
+              "if": {
+                "properties": {
+                  "in": {
+                    "const": "cookie"
+                  }
+                },
+                "required": [
+                  "in"
+                ]
+              },
+              "then": {
+                "properties": {
+                  "style": {
+                    "default": "form",
+                    "const": "form"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "parameter-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/parameter"
+      }
+    },
+    "request-body": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#request-body-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "content"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "request-body-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/request-body"
+      }
+    },
+    "content": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#fixed-fields-10",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/media-type"
+      },
+      "propertyNames": {
+        "format": "media-range"
+      }
+    },
+    "media-type": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#media-type-object",
+      "type": "object",
+      "properties": {
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "encoding": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/encoding"
+          }
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/examples"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "encoding": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#encoding-object",
+      "type": "object",
+      "properties": {
+        "contentType": {
+          "type": "string",
+          "format": "media-range"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "style": {
+          "default": "form",
+          "enum": [
+            "form",
+            "spaceDelimited",
+            "pipeDelimited",
+            "deepObject"
+          ]
+        },
+        "explode": {
+          "type": "boolean"
+        },
+        "allowReserved": {
+          "default": false,
+          "type": "boolean"
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/styles-for-form"
+        }
+      ],
+      "unevaluatedProperties": false
+    },
+    "responses": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#responses-object",
+      "type": "object",
+      "properties": {
+        "default": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "patternProperties": {
+        "^[1-5](?:[0-9]{2}|XX)$": {
+          "$ref": "#/$defs/response-or-reference"
+        }
+      },
+      "minProperties": 1,
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "if": {
+        "$comment": "either default, or at least one response code property must exist",
+        "patternProperties": {
+          "^[1-5](?:[0-9]{2}|XX)$": false
+        }
+      },
+      "then": {
+        "required": [
+          "default"
+        ]
+      }
+    },
+    "response": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#response-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "headers": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/header-or-reference"
+          }
+        },
+        "content": {
+          "$ref": "#/$defs/content"
+        },
+        "links": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/link-or-reference"
+          }
+        }
+      },
+      "required": [
+        "description"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "response-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/response"
+      }
+    },
+    "callbacks": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#callback-object",
+      "type": "object",
+      "$ref": "#/$defs/specification-extensions",
+      "additionalProperties": {
+        "$ref": "#/$defs/path-item"
+      }
+    },
+    "callbacks-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/callbacks"
+      }
+    },
+    "example": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#example-object",
+      "type": "object",
+      "properties": {
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "value": true,
+        "externalValue": {
+          "type": "string",
+          "format": "uri-reference"
+        }
+      },
+      "not": {
+        "required": [
+          "value",
+          "externalValue"
+        ]
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "example-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/example"
+      }
+    },
+    "link": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#link-object",
+      "type": "object",
+      "properties": {
+        "operationRef": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "operationId": {
+          "type": "string"
+        },
+        "parameters": {
+          "$ref": "#/$defs/map-of-strings"
+        },
+        "requestBody": true,
+        "description": {
+          "type": "string"
+        },
+        "body": {
+          "$ref": "#/$defs/server"
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "operationRef"
+          ]
+        },
+        {
+          "required": [
+            "operationId"
+          ]
+        }
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "link-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/link"
+      }
+    },
+    "header": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#header-object",
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string"
+        },
+        "required": {
+          "default": false,
+          "type": "boolean"
+        },
+        "deprecated": {
+          "default": false,
+          "type": "boolean"
+        },
+        "schema": {
+          "$dynamicRef": "#meta"
+        },
+        "content": {
+          "$ref": "#/$defs/content",
+          "minProperties": 1,
+          "maxProperties": 1
+        }
+      },
+      "oneOf": [
+        {
+          "required": [
+            "schema"
+          ]
+        },
+        {
+          "required": [
+            "content"
+          ]
+        }
+      ],
+      "dependentSchemas": {
+        "schema": {
+          "properties": {
+            "style": {
+              "default": "simple",
+              "const": "simple"
+            },
+            "explode": {
+              "default": false,
+              "type": "boolean"
+            }
+          },
+          "$ref": "#/$defs/examples"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "header-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/header"
+      }
+    },
+    "tag": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#tag-object",
+      "type": "object",
+      "properties": {
+        "name": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        },
+        "externalDocs": {
+          "$ref": "#/$defs/external-documentation"
+        }
+      },
+      "required": [
+        "name"
+      ],
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false
+    },
+    "reference": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#reference-object",
+      "type": "object",
+      "properties": {
+        "$ref": {
+          "type": "string",
+          "format": "uri-reference"
+        },
+        "summary": {
+          "type": "string"
+        },
+        "description": {
+          "type": "string"
+        }
+      }
+    },
+    "schema": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#schema-object",
+      "$dynamicAnchor": "meta",
+      "type": [
+        "object",
+        "boolean"
+      ]
+    },
+    "security-scheme": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#security-scheme-object",
+      "type": "object",
+      "properties": {
+        "type": {
+          "enum": [
+            "apiKey",
+            "http",
+            "mutualTLS",
+            "oauth2",
+            "openIdConnect"
+          ]
+        },
+        "description": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ],
+      "allOf": [
+        {
+          "$ref": "#/$defs/specification-extensions"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-apikey"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-http-bearer"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oauth2"
+        },
+        {
+          "$ref": "#/$defs/security-scheme/$defs/type-oidc"
+        }
+      ],
+      "unevaluatedProperties": false,
+      "$defs": {
+        "type-apikey": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "apiKey"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "in": {
+                "enum": [
+                  "query",
+                  "header",
+                  "cookie"
+                ]
+              }
+            },
+            "required": [
+              "name",
+              "in"
+            ]
+          }
+        },
+        "type-http": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "scheme": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "scheme"
+            ]
+          }
+        },
+        "type-http-bearer": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "http"
+              },
+              "scheme": {
+                "type": "string",
+                "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
+              }
+            },
+            "required": [
+              "type",
+              "scheme"
+            ]
+          },
+          "then": {
+            "properties": {
+              "bearerFormat": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "type-oauth2": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "oauth2"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "flows": {
+                "$ref": "#/$defs/oauth-flows"
+              }
+            },
+            "required": [
+              "flows"
+            ]
+          }
+        },
+        "type-oidc": {
+          "if": {
+            "properties": {
+              "type": {
+                "const": "openIdConnect"
+              }
+            },
+            "required": [
+              "type"
+            ]
+          },
+          "then": {
+            "properties": {
+              "openIdConnectUrl": {
+                "type": "string",
+                "format": "uri-reference"
+              }
+            },
+            "required": [
+              "openIdConnectUrl"
+            ]
+          }
+        }
+      }
+    },
+    "security-scheme-or-reference": {
+      "if": {
+        "type": "object",
+        "required": [
+          "$ref"
+        ]
+      },
+      "then": {
+        "$ref": "#/$defs/reference"
+      },
+      "else": {
+        "$ref": "#/$defs/security-scheme"
+      }
+    },
+    "oauth-flows": {
+      "type": "object",
+      "properties": {
+        "implicit": {
+          "$ref": "#/$defs/oauth-flows/$defs/implicit"
+        },
+        "password": {
+          "$ref": "#/$defs/oauth-flows/$defs/password"
+        },
+        "clientCredentials": {
+          "$ref": "#/$defs/oauth-flows/$defs/client-credentials"
+        },
+        "authorizationCode": {
+          "$ref": "#/$defs/oauth-flows/$defs/authorization-code"
+        }
+      },
+      "$ref": "#/$defs/specification-extensions",
+      "unevaluatedProperties": false,
+      "$defs": {
+        "implicit": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "password": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "client-credentials": {
+          "type": "object",
+          "properties": {
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        },
+        "authorization-code": {
+          "type": "object",
+          "properties": {
+            "authorizationUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "tokenUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "refreshUrl": {
+              "type": "string",
+              "format": "uri-reference"
+            },
+            "scopes": {
+              "$ref": "#/$defs/map-of-strings"
+            }
+          },
+          "required": [
+            "authorizationUrl",
+            "tokenUrl",
+            "scopes"
+          ],
+          "$ref": "#/$defs/specification-extensions",
+          "unevaluatedProperties": false
+        }
+      }
+    },
+    "security-requirement": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#security-requirement-object",
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "specification-extensions": {
+      "$comment": "https://spec.openapis.org/oas/v3.1#specification-extensions",
+      "patternProperties": {
+        "^x-": true
+      }
+    },
+    "examples": {
+      "properties": {
+        "example": true,
+        "examples": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/$defs/example-or-reference"
+          }
+        }
+      }
+    },
+    "map-of-strings": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "styles-for-form": {
+      "if": {
+        "properties": {
+          "style": {
+            "const": "form"
+          }
+        },
+        "required": [
+          "style"
+        ]
+      },
+      "then": {
+        "properties": {
+          "explode": {
+            "default": true
+          }
+        }
+      },
+      "else": {
+        "properties": {
+          "explode": {
+            "default": false
+          }
+        }
+      }
+    }
+  }
+}

--- a/crates/au-kpis-openapi/tests/fixtures/openapi-3.1-schema.json
+++ b/crates/au-kpis-openapi/tests/fixtures/openapi-3.1-schema.json
@@ -55,25 +55,16 @@
       "$ref": "#/$defs/external-documentation"
     }
   },
-  "required": [
-    "openapi",
-    "info"
-  ],
+  "required": ["openapi", "info"],
   "anyOf": [
     {
-      "required": [
-        "paths"
-      ]
+      "required": ["paths"]
     },
     {
-      "required": [
-        "components"
-      ]
+      "required": ["components"]
     },
     {
-      "required": [
-        "webhooks"
-      ]
+      "required": ["webhooks"]
     }
   ],
   "$ref": "#/$defs/specification-extensions",
@@ -106,10 +97,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "title",
-        "version"
-      ],
+      "required": ["title", "version"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
@@ -147,15 +135,11 @@
           "format": "uri-reference"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "dependentSchemas": {
         "identifier": {
           "not": {
-            "required": [
-              "url"
-            ]
+            "required": ["url"]
           }
         }
       },
@@ -179,9 +163,7 @@
           }
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
@@ -203,9 +185,7 @@
           "type": "string"
         }
       },
-      "required": [
-        "default"
-      ],
+      "required": ["default"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
@@ -422,9 +402,7 @@
           "format": "uri-reference"
         }
       },
-      "required": [
-        "url"
-      ],
+      "required": ["url"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
@@ -436,12 +414,7 @@
           "type": "string"
         },
         "in": {
-          "enum": [
-            "query",
-            "header",
-            "path",
-            "cookie"
-          ]
+          "enum": ["query", "header", "path", "cookie"]
         },
         "description": {
           "type": "string"
@@ -463,20 +436,13 @@
           "maxProperties": 1
         }
       },
-      "required": [
-        "name",
-        "in"
-      ],
+      "required": ["name", "in"],
       "oneOf": [
         {
-          "required": [
-            "schema"
-          ]
+          "required": ["schema"]
         },
         {
-          "required": [
-            "content"
-          ]
+          "required": ["content"]
         }
       ],
       "if": {
@@ -485,9 +451,7 @@
             "const": "query"
           }
         },
-        "required": [
-          "in"
-        ]
+        "required": ["in"]
       },
       "then": {
         "properties": {
@@ -535,27 +499,19 @@
                     "const": "path"
                   }
                 },
-                "required": [
-                  "in"
-                ]
+                "required": ["in"]
               },
               "then": {
                 "properties": {
                   "style": {
                     "default": "simple",
-                    "enum": [
-                      "matrix",
-                      "label",
-                      "simple"
-                    ]
+                    "enum": ["matrix", "label", "simple"]
                   },
                   "required": {
                     "const": true
                   }
                 },
-                "required": [
-                  "required"
-                ]
+                "required": ["required"]
               }
             },
             "styles-for-header": {
@@ -565,9 +521,7 @@
                     "const": "header"
                   }
                 },
-                "required": [
-                  "in"
-                ]
+                "required": ["in"]
               },
               "then": {
                 "properties": {
@@ -585,20 +539,13 @@
                     "const": "query"
                   }
                 },
-                "required": [
-                  "in"
-                ]
+                "required": ["in"]
               },
               "then": {
                 "properties": {
                   "style": {
                     "default": "form",
-                    "enum": [
-                      "form",
-                      "spaceDelimited",
-                      "pipeDelimited",
-                      "deepObject"
-                    ]
+                    "enum": ["form", "spaceDelimited", "pipeDelimited", "deepObject"]
                   },
                   "allowReserved": {
                     "default": false,
@@ -614,9 +561,7 @@
                     "const": "cookie"
                   }
                 },
-                "required": [
-                  "in"
-                ]
+                "required": ["in"]
               },
               "then": {
                 "properties": {
@@ -636,9 +581,7 @@
     "parameter-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -662,18 +605,14 @@
           "type": "boolean"
         }
       },
-      "required": [
-        "content"
-      ],
+      "required": ["content"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
     "request-body-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -732,12 +671,7 @@
         },
         "style": {
           "default": "form",
-          "enum": [
-            "form",
-            "spaceDelimited",
-            "pipeDelimited",
-            "deepObject"
-          ]
+          "enum": ["form", "spaceDelimited", "pipeDelimited", "deepObject"]
         },
         "explode": {
           "type": "boolean"
@@ -780,9 +714,7 @@
         }
       },
       "then": {
-        "required": [
-          "default"
-        ]
+        "required": ["default"]
       }
     },
     "response": {
@@ -808,18 +740,14 @@
           }
         }
       },
-      "required": [
-        "description"
-      ],
+      "required": ["description"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
     "response-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -839,9 +767,7 @@
     "callbacks-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -867,10 +793,7 @@
         }
       },
       "not": {
-        "required": [
-          "value",
-          "externalValue"
-        ]
+        "required": ["value", "externalValue"]
       },
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
@@ -878,9 +801,7 @@
     "example-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -913,14 +834,10 @@
       },
       "oneOf": [
         {
-          "required": [
-            "operationRef"
-          ]
+          "required": ["operationRef"]
         },
         {
-          "required": [
-            "operationId"
-          ]
+          "required": ["operationId"]
         }
       ],
       "$ref": "#/$defs/specification-extensions",
@@ -929,9 +846,7 @@
     "link-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -966,14 +881,10 @@
       },
       "oneOf": [
         {
-          "required": [
-            "schema"
-          ]
+          "required": ["schema"]
         },
         {
-          "required": [
-            "content"
-          ]
+          "required": ["content"]
         }
       ],
       "dependentSchemas": {
@@ -997,9 +908,7 @@
     "header-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -1022,9 +931,7 @@
           "$ref": "#/$defs/external-documentation"
         }
       },
-      "required": [
-        "name"
-      ],
+      "required": ["name"],
       "$ref": "#/$defs/specification-extensions",
       "unevaluatedProperties": false
     },
@@ -1047,31 +954,20 @@
     "schema": {
       "$comment": "https://spec.openapis.org/oas/v3.1#schema-object",
       "$dynamicAnchor": "meta",
-      "type": [
-        "object",
-        "boolean"
-      ]
+      "type": ["object", "boolean"]
     },
     "security-scheme": {
       "$comment": "https://spec.openapis.org/oas/v3.1#security-scheme-object",
       "type": "object",
       "properties": {
         "type": {
-          "enum": [
-            "apiKey",
-            "http",
-            "mutualTLS",
-            "oauth2",
-            "openIdConnect"
-          ]
+          "enum": ["apiKey", "http", "mutualTLS", "oauth2", "openIdConnect"]
         },
         "description": {
           "type": "string"
         }
       },
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "allOf": [
         {
           "$ref": "#/$defs/specification-extensions"
@@ -1101,9 +997,7 @@
                 "const": "apiKey"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "properties": {
@@ -1111,17 +1005,10 @@
                 "type": "string"
               },
               "in": {
-                "enum": [
-                  "query",
-                  "header",
-                  "cookie"
-                ]
+                "enum": ["query", "header", "cookie"]
               }
             },
-            "required": [
-              "name",
-              "in"
-            ]
+            "required": ["name", "in"]
           }
         },
         "type-http": {
@@ -1131,9 +1018,7 @@
                 "const": "http"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "properties": {
@@ -1141,9 +1026,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "scheme"
-            ]
+            "required": ["scheme"]
           }
         },
         "type-http-bearer": {
@@ -1157,10 +1040,7 @@
                 "pattern": "^[Bb][Ee][Aa][Rr][Ee][Rr]$"
               }
             },
-            "required": [
-              "type",
-              "scheme"
-            ]
+            "required": ["type", "scheme"]
           },
           "then": {
             "properties": {
@@ -1177,9 +1057,7 @@
                 "const": "oauth2"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "properties": {
@@ -1187,9 +1065,7 @@
                 "$ref": "#/$defs/oauth-flows"
               }
             },
-            "required": [
-              "flows"
-            ]
+            "required": ["flows"]
           }
         },
         "type-oidc": {
@@ -1199,9 +1075,7 @@
                 "const": "openIdConnect"
               }
             },
-            "required": [
-              "type"
-            ]
+            "required": ["type"]
           },
           "then": {
             "properties": {
@@ -1210,9 +1084,7 @@
                 "format": "uri-reference"
               }
             },
-            "required": [
-              "openIdConnectUrl"
-            ]
+            "required": ["openIdConnectUrl"]
           }
         }
       }
@@ -1220,9 +1092,7 @@
     "security-scheme-or-reference": {
       "if": {
         "type": "object",
-        "required": [
-          "$ref"
-        ]
+        "required": ["$ref"]
       },
       "then": {
         "$ref": "#/$defs/reference"
@@ -1265,10 +1135,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "authorizationUrl",
-            "scopes"
-          ],
+          "required": ["authorizationUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions",
           "unevaluatedProperties": false
         },
@@ -1287,10 +1154,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "tokenUrl",
-            "scopes"
-          ],
+          "required": ["tokenUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions",
           "unevaluatedProperties": false
         },
@@ -1309,10 +1173,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "tokenUrl",
-            "scopes"
-          ],
+          "required": ["tokenUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions",
           "unevaluatedProperties": false
         },
@@ -1335,11 +1196,7 @@
               "$ref": "#/$defs/map-of-strings"
             }
           },
-          "required": [
-            "authorizationUrl",
-            "tokenUrl",
-            "scopes"
-          ],
+          "required": ["authorizationUrl", "tokenUrl", "scopes"],
           "$ref": "#/$defs/specification-extensions",
           "unevaluatedProperties": false
         }
@@ -1385,9 +1242,7 @@
             "const": "form"
           }
         },
-        "required": [
-          "style"
-        ]
+        "required": ["style"]
       },
       "then": {
         "properties": {

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,41 @@
+pre-commit:
+  parallel: true
+  commands:
+    cargo-fmt:
+      run: cargo fmt --all --check
+    biome-format:
+      run: pnpm exec biome format --check .
+    gitleaks:
+      run: gitleaks protect --staged
+    large-files:
+      run: |
+        python3 - <<'PY'
+        import subprocess
+        import sys
+
+        limit_bytes = 5 * 1024 * 1024
+        output = subprocess.check_output(
+            ["git", "diff", "--cached", "--name-only", "--diff-filter=AM", "-z"],
+        )
+        paths = [path for path in output.decode().split("\0") if path]
+
+        oversized = []
+        for path in paths:
+            try:
+                size = int(
+                    subprocess.check_output(["git", "cat-file", "-s", f":{path}"]).decode().strip()
+                )
+            except subprocess.CalledProcessError:
+                continue
+
+            if size > limit_bytes:
+                oversized.append((path, size))
+
+        if oversized:
+            for path, size in oversized:
+                print(
+                    f"staged file exceeds 5 MB: {path} ({size} bytes)",
+                    file=sys.stderr,
+                )
+            sys.exit(1)
+        PY


### PR DESCRIPTION
<!--
Thanks for contributing! Before submitting, confirm:
- CI gates pass locally (nextest, clippy, biome, typecheck)
- Pass requirements from the linked issue are all ticked
- Any new public API is reflected in Spec.md
-->

## Summary

- Implement `au-kpis-cache` with typed JSON helpers and a config-based Redis token bucket that supports quotas like `1000/hour` as well as short-burst limits.
- Define the health handler and `ApiDoc` in `au-kpis-api-http`, and make `au-kpis-openapi` a fallible emitter/CLI over the real HTTP contract.
- Add `lefthook.yml`, document the pre-commit hooks in `CONTRIBUTING.md`, and cover the new scaffolding with unit and integration tests.

## Linked issue

Closes #9
Closes #10
Closes #19

## Pass requirements

### #9 `au-kpis-cache`

- [x] `fred` Redis pool wrapper
- [x] Token-bucket rate-limit primitive (atomic Lua script)
- [x] Generic KV cache with typed (de)serialization
- [x] Unit tests (mocked) + integration tests (testcontainers Redis)

### #10 `au-kpis-openapi`

- [x] `ApiDoc` struct with `#[derive(OpenApi)]`
- [x] `emit() -> String` produces valid OpenAPI 3.1 JSON
- [x] Test validates output against the official OpenAPI 3.1 schema
- [x] Example CLI: `cargo run -p au-kpis-openapi > openapi.json`

### #19 `Pre-commit hooks via lefthook`

- [x] `lefthook.yml` committed
- [x] Hooks: `cargo fmt --check`, `biome format --check`, `gitleaks protect --staged`, large-file (>5 MB) block
- [x] `lefthook install` documented in `CONTRIBUTING.md`
- [x] Works on macOS + Linux

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p au-kpis-cache -p au-kpis-api-http -p au-kpis-openapi --all-targets -- -D warnings`
- [x] `cargo test -p au-kpis-cache -p au-kpis-api-http -p au-kpis-openapi`
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm exec biome format .`

## Spec / docs impact

- [x] No Spec changes required
- [ ] Spec amended in this PR
- [ ] Spec amendment filed separately (#)

## Checklist

- [x] Conventional commit title
- [x] No secrets committed
- [x] Tests added/updated
- [x] `cargo fmt` + `biome format` clean
- [x] Clippy / Biome warnings resolved
