### PR TITLE
test(repo): add testing infrastructure (#17)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,11 @@
+[profile.default]
+retries = { backoff = "fixed", count = 2, delay = "1s" }
+status-level = "retry"
+final-status-level = "flaky"
+failure-output = "immediate-final"
+fail-fast = false
+slow-timeout = { period = "60s", terminate-after = 2 }
+
+[profile.default.junit]
+path = "junit.xml"
+store-failure-output = true

--- a/.github/workflows/test-infra.yml
+++ b/.github/workflows/test-infra.yml
@@ -178,12 +178,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - name: Install llvm coverage tooling
         run: |
-          rustup component add llvm-tools-preview
+          rustup component add llvm-tools-preview --toolchain ${{ env.COVERAGE_TOOLCHAIN }}
           cargo install cargo-llvm-cov --version 0.6.21 --locked
       - name: Generate coverage report
         run: |
           mkdir -p target/llvm-cov
-          cargo llvm-cov --workspace --branch --fail-under-lines 80 --lcov --output-path target/llvm-cov/lcov.info
+          cargo +${{ env.COVERAGE_TOOLCHAIN }} llvm-cov --workspace --branch --fail-under-lines 80 --lcov --output-path target/llvm-cov/lcov.info
       - name: Enforce branch coverage floor
         shell: bash
         run: |

--- a/.github/workflows/test-infra.yml
+++ b/.github/workflows/test-infra.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - main
 
+env:
+  RUST_TOOLCHAIN: "1.85"
+
 jobs:
   nextest:
     name: Rust Tests (nextest)
@@ -15,6 +18,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
       - name: Install cargo-nextest
         run: cargo install cargo-nextest --version 0.9.100 --locked
@@ -22,6 +27,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          mkdir -p target
           cargo nextest run --workspace 2>&1 | tee target/nextest-run.log
       - name: Fail on flaky retries
         shell: bash
@@ -41,6 +47,8 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
       - name: Install llvm coverage tooling
         run: |

--- a/.github/workflows/test-infra.yml
+++ b/.github/workflows/test-infra.yml
@@ -1,0 +1,63 @@
+name: Test Infrastructure
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  nextest:
+    name: Rust Tests (nextest)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --version 0.9.100 --locked
+      - name: Run workspace tests
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo nextest run --workspace 2>&1 | tee target/nextest-run.log
+      - name: Fail on flaky retries
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -En "TRY [2-9][0-9]* PASS" target/nextest-run.log; then
+            echo "Zero-flake policy violated: at least one test only passed on retry." >&2
+            exit 1
+          fi
+
+  coverage:
+    name: Rust Coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+      - uses: Swatinem/rust-cache@v2
+      - name: Install llvm coverage tooling
+        run: |
+          rustup component add llvm-tools-preview
+          cargo install cargo-llvm-cov --version 0.6.21 --locked
+      - name: Generate coverage report
+        run: |
+          mkdir -p target/llvm-cov
+          cargo llvm-cov --workspace --fail-under-lines 80 --lcov --output-path target/llvm-cov/lcov.info
+      - name: Upload LCOV artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-report
+          path: target/llvm-cov/lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          use_oidc: true
+          files: target/llvm-cov/lcov.info
+          fail_ci_if_error: false

--- a/.github/workflows/test-infra.yml
+++ b/.github/workflows/test-infra.yml
@@ -7,6 +7,7 @@ on:
       - main
 
 env:
+  CARGO_BUILD_RUSTC_WRAPPER: ""
   RUST_TOOLCHAIN: "1.85"
 
 jobs:

--- a/.github/workflows/test-infra.yml
+++ b/.github/workflows/test-infra.yml
@@ -2,6 +2,9 @@ name: Test Infrastructure
 
 on:
   pull_request:
+  merge_group:
+    types:
+      - checks_requested
   push:
     branches:
       - main
@@ -9,6 +12,7 @@ on:
 env:
   CARGO_BUILD_RUSTC_WRAPPER: ""
   RUST_TOOLCHAIN: "1.85"
+  COVERAGE_TOOLCHAIN: nightly
 
 jobs:
   nextest:
@@ -16,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      issues: write
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
@@ -25,16 +30,136 @@ jobs:
       - name: Install cargo-nextest
         run: cargo install cargo-nextest --version 0.9.100 --locked
       - name: Run workspace tests
+        id: run-nextest
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p target
+          set +e
           cargo nextest run --workspace 2>&1 | tee target/nextest-run.log
-      - name: Fail on flaky retries
+          nextest_exit=${PIPESTATUS[0]}
+          set -e
+          echo "exit_code=$nextest_exit" >> "$GITHUB_OUTPUT"
+      - name: Detect flaky retries
+        id: flaky-retries
+        if: always()
         shell: bash
         run: |
           set -euo pipefail
-          if grep -En "TRY [2-9][0-9]* PASS" target/nextest-run.log; then
+          if [ ! -f target/nextest-run.log ]; then
+            echo "has_flakes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          retry_lines="$(grep -En "TRY [2-9][0-9]* PASS" target/nextest-run.log || true)"
+
+          if [ -z "$retry_lines" ]; then
+            echo "has_flakes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "has_flakes=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "retry_lines<<EOF"
+            printf '%s\n' "$retry_lines"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "Flaky retries detected in cargo nextest output:"
+            echo ""
+            printf '%s\n' "$retry_lines"
+          } >> "$GITHUB_STEP_SUMMARY"
+      - name: Resolve default code owner
+        id: codeowner
+        if: always() && steps.flaky-retries.outputs.has_flakes == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          owner="$(awk '/^\* / {print $2; exit}' CODEOWNERS | sed 's/^@//')"
+          if [ -n "$owner" ]; then
+            echo "login=$owner" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Auto-file flaky test issue
+        if: always() && steps.flaky-retries.outputs.has_flakes == 'true'
+        env:
+          ASSIGNEE: ${{ steps.codeowner.outputs.login }}
+          GITHUB_TOKEN: ${{ github.token }}
+          RETRY_LINES: ${{ steps.flaky-retries.outputs.retry_lines }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          pr_url=""
+          if [ "${GITHUB_EVENT_NAME}" = "pull_request" ]; then
+            pr_url="$(jq -r '.pull_request.html_url // empty' "$GITHUB_EVENT_PATH")"
+          fi
+
+          body_file="$(mktemp)"
+          {
+            echo "## Flaky retry detected"
+            echo ""
+            echo "A Rust test retried in CI, which violates the repository zero-flake policy."
+            echo ""
+            echo "- Workflow: \`${GITHUB_WORKFLOW}\`"
+            echo "- Event: \`${GITHUB_EVENT_NAME}\`"
+            echo "- Ref: \`${GITHUB_REF}\`"
+            echo "- SHA: \`${GITHUB_SHA}\`"
+            echo "- Run: ${run_url}"
+            if [ -n "$pr_url" ]; then
+              echo "- Pull request: ${pr_url}"
+            fi
+            echo ""
+            echo "### nextest retry lines"
+            echo '```text'
+            printf '%s\n' "$RETRY_LINES"
+            echo '```'
+          } > "$body_file"
+
+          title="test(repo): flaky Rust retry in ${GITHUB_WORKFLOW} run #${GITHUB_RUN_NUMBER}"
+          payload_file="$(mktemp)"
+
+          if [ -n "${ASSIGNEE:-}" ]; then
+            jq -n \
+              --arg title "$title" \
+              --arg body "$(cat "$body_file")" \
+              --arg assignee "$ASSIGNEE" \
+              '{title:$title, body:$body, labels:["flaky","type:test","area:rust"], assignees:[$assignee]}' \
+              > "$payload_file"
+          else
+            jq -n \
+              --arg title "$title" \
+              --arg body "$(cat "$body_file")" \
+              '{title:$title, body:$body, labels:["flaky","type:test","area:rust"]}' \
+              > "$payload_file"
+          fi
+
+          issue_url="$(
+            curl -fsSL \
+              -X POST \
+              -H "Accept: application/vnd.github+json" \
+              -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/${GITHUB_REPOSITORY}/issues" \
+              --data-binary "@${payload_file}" |
+              jq -r '.html_url'
+          )"
+
+          echo "Auto-filed flaky issue: ${issue_url}" >> "$GITHUB_STEP_SUMMARY"
+      - name: Enforce nextest success and zero flake
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          nextest_exit="${{ steps.run-nextest.outputs.exit_code }}"
+
+          if [ "$nextest_exit" -ne 0 ]; then
+            echo "cargo nextest run failed with exit code ${nextest_exit}." >&2
+            exit "$nextest_exit"
+          fi
+
+          if [ "${{ steps.flaky-retries.outputs.has_flakes }}" = "true" ]; then
             echo "Zero-flake policy violated: at least one test only passed on retry." >&2
             exit 1
           fi
@@ -49,7 +174,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN }}
+          toolchain: ${{ env.COVERAGE_TOOLCHAIN }}
       - uses: Swatinem/rust-cache@v2
       - name: Install llvm coverage tooling
         run: |
@@ -58,7 +183,27 @@ jobs:
       - name: Generate coverage report
         run: |
           mkdir -p target/llvm-cov
-          cargo llvm-cov --workspace --fail-under-lines 80 --lcov --output-path target/llvm-cov/lcov.info
+          cargo llvm-cov --workspace --branch --fail-under-lines 80 --lcov --output-path target/llvm-cov/lcov.info
+      - name: Enforce branch coverage floor
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          branch_found="$(awk -F: '/^BRF:/ {sum += $2} END {print sum + 0}' target/llvm-cov/lcov.info)"
+          branch_hit="$(awk -F: '/^BRH:/ {sum += $2} END {print sum + 0}' target/llvm-cov/lcov.info)"
+
+          if [ "$branch_found" -eq 0 ]; then
+            echo "Branch coverage data was not emitted to LCOV output." >&2
+            exit 1
+          fi
+
+          awk -v hit="$branch_hit" -v found="$branch_found" 'BEGIN {
+            pct = (hit / found) * 100
+            printf "Branch coverage: %.2f%% (%d/%d)\n", pct, hit, found
+            if (pct < 70) {
+              exit 1
+            }
+          }'
       - name: Upload LCOV artifact
         uses: actions/upload-artifact@v4
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,6 +67,9 @@ See `Spec.md § Testing strategy`. Minimum:
 - For adapter changes: add/update `insta` snapshots with real fixtures
 - For SQL changes: include a migration + integration test
 
+The repo-level test workflow and command references live in
+[`docs/testing.md`](./docs/testing.md).
+
 ## Flake policy
 
 Zero tolerance. Any retry in CI auto-files a `flaky`-labelled issue. Fix within 48h or delete the test.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -204,6 +204,7 @@ dependencies = [
  "au-kpis-config",
  "au-kpis-domain",
  "au-kpis-error",
+ "au-kpis-testing",
  "sqlx",
  "testcontainers",
  "thiserror 2.0.18",
@@ -217,6 +218,8 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "hex",
+ "insta",
+ "proptest",
  "serde",
  "serde_json",
  "sha2",
@@ -278,6 +281,7 @@ version = "0.1.0"
 dependencies = [
  "au-kpis-domain",
  "au-kpis-error",
+ "au-kpis-testing",
  "bytes",
  "futures",
  "object_store",
@@ -305,6 +309,14 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "au-kpis-testing"
+version = "0.1.0"
+dependencies = [
+ "testcontainers",
+ "tokio",
 ]
 
 [[package]]
@@ -664,6 +676,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "console-api"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +957,12 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -1650,6 +1679,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2393,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2465,12 @@ checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost 0.14.3",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -2548,6 +2615,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2833,6 +2909,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3109,6 +3197,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -3905,6 +3999,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "uncased"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/au-kpis-domain",
     "crates/au-kpis-error",
     "crates/au-kpis-config",
+    "crates/testing",
     "crates/au-kpis-telemetry",
     "crates/au-kpis-schema",
     "crates/au-kpis-db",
@@ -40,6 +41,7 @@ repository = "https://github.com/ponderingdemocritus/australian-kpis"
 au-kpis-domain = { path = "crates/au-kpis-domain" }
 au-kpis-error = { path = "crates/au-kpis-error" }
 au-kpis-config = { path = "crates/au-kpis-config" }
+au-kpis-testing = { path = "crates/testing" }
 au-kpis-telemetry = { path = "crates/au-kpis-telemetry" }
 au-kpis-schema = { path = "crates/au-kpis-schema" }
 au-kpis-db = { path = "crates/au-kpis-db" }

--- a/crates/au-kpis-db/Cargo.toml
+++ b/crates/au-kpis-db/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "2"
 tracing = "0.1"
 
 [dev-dependencies]
+au-kpis-testing = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
 testcontainers = "0.23"
 sqlx = { version = "0.8", default-features = false, features = [

--- a/crates/au-kpis-db/tests/migrations.rs
+++ b/crates/au-kpis-db/tests/migrations.rs
@@ -16,16 +16,9 @@ use std::time::Duration;
 
 use au_kpis_config::DatabaseConfig;
 use au_kpis_db::{connect, ensure_timescale, migrate, revert_latest, timescale_version};
+use au_kpis_testing::{postgres_connection_string, retry_async, timescale_image};
 use sqlx::{PgPool, Row};
-use testcontainers::{
-    ContainerAsync, GenericImage, ImageExt,
-    core::{ContainerPort, WaitFor},
-    runners::AsyncRunner,
-};
-
-const IMAGE_NAME: &str = "timescale/timescaledb";
-const IMAGE_TAG: &str = "latest-pg16";
-const POSTGRES_PORT: u16 = 5432;
+use testcontainers::{ContainerAsync, GenericImage, runners::AsyncRunner};
 
 struct Harness {
     // Holds the container alive for the lifetime of the test.
@@ -34,47 +27,26 @@ struct Harness {
 }
 
 async fn start_timescale() -> Harness {
-    let container = GenericImage::new(IMAGE_NAME, IMAGE_TAG)
-        .with_exposed_port(ContainerPort::Tcp(POSTGRES_PORT))
-        .with_wait_for(WaitFor::message_on_stderr(
-            "database system is ready to accept connections",
-        ))
-        .with_env_var("POSTGRES_PASSWORD", "postgres")
-        .with_env_var("POSTGRES_DB", "au_kpis_test")
+    let container = timescale_image("au_kpis_test")
         .start()
         .await
         .expect("start timescaledb container");
 
-    let host = container.get_host().await.expect("container host");
-    let port = container
-        .get_host_port_ipv4(POSTGRES_PORT)
-        .await
-        .expect("host port");
-    let url = format!("postgres://postgres:postgres@{host}:{port}/au_kpis_test");
+    let url = postgres_connection_string(&container, "au_kpis_test").await;
     let cfg = DatabaseConfig { url };
 
     // Some images take a beat between "ready" log line and accepting
     // TCP connections under load. Small retry loop avoids flakes.
-    let pool = connect_with_retry(&cfg).await;
+    let pool = retry_async(10, Duration::from_millis(500), || async {
+        connect(&cfg).await
+    })
+    .await
+    .expect("timescaledb did not accept connections");
 
     Harness {
         _container: container,
         pool,
     }
-}
-
-async fn connect_with_retry(cfg: &DatabaseConfig) -> PgPool {
-    let mut last_err = None;
-    for _ in 0..10 {
-        match connect(cfg).await {
-            Ok(pool) => return pool,
-            Err(err) => {
-                last_err = Some(err);
-                tokio::time::sleep(Duration::from_millis(500)).await;
-            }
-        }
-    }
-    panic!("timescaledb did not accept connections: {last_err:?}");
 }
 
 async fn hypertable_exists(pool: &PgPool, name: &str) -> bool {

--- a/crates/au-kpis-domain/Cargo.toml
+++ b/crates/au-kpis-domain/Cargo.toml
@@ -15,3 +15,7 @@ utoipa = { version = "5", features = ["chrono"] }
 sha2 = "0.10"
 hex = "0.4"
 thiserror = "2"
+
+[dev-dependencies]
+insta = { version = "1", features = ["yaml"] }
+proptest = "1"

--- a/crates/au-kpis-domain/tests/observation_snapshot.rs
+++ b/crates/au-kpis-domain/tests/observation_snapshot.rs
@@ -1,0 +1,33 @@
+use std::collections::BTreeMap;
+
+use au_kpis_domain::{
+    ArtifactId, DataflowId, Observation, ObservationStatus, SeriesKey, TimePrecision,
+};
+use chrono::{DateTime, Utc};
+
+fn example_observation() -> Observation {
+    let dataflow = DataflowId::new("abs.cpi").expect("valid dataflow");
+    Observation {
+        series_key: SeriesKey::derive(&dataflow, [("region", "AUS"), ("measure", "headline")]),
+        time: DateTime::parse_from_rfc3339("2024-03-01T00:00:00Z")
+            .expect("timestamp")
+            .with_timezone(&Utc),
+        time_precision: TimePrecision::Quarter,
+        value: Some(134.2),
+        status: ObservationStatus::Revised,
+        revision_no: 2,
+        attributes: BTreeMap::from([
+            ("OBS_STATUS".to_string(), "R".to_string()),
+            ("UNIT_MULT".to_string(), "0".to_string()),
+        ]),
+        ingested_at: DateTime::parse_from_rfc3339("2024-04-30T00:00:00Z")
+            .expect("timestamp")
+            .with_timezone(&Utc),
+        source_artifact_id: ArtifactId::of_content(b"abs-cpi-fixture"),
+    }
+}
+
+#[test]
+fn observation_contract_snapshot() {
+    insta::assert_yaml_snapshot!("observation_contract", example_observation());
+}

--- a/crates/au-kpis-domain/tests/property_roundtrip.rs
+++ b/crates/au-kpis-domain/tests/property_roundtrip.rs
@@ -1,0 +1,97 @@
+use std::collections::BTreeMap;
+
+use au_kpis_domain::{
+    ArtifactId, DataflowId, Observation, ObservationStatus, SeriesKey, TimePrecision,
+};
+use chrono::{TimeZone, Utc};
+use proptest::prelude::*;
+
+fn slug_fragment() -> impl Strategy<Value = String> {
+    "[a-z][a-z0-9._-]{0,15}".prop_map(|value| value)
+}
+
+fn observation_status() -> impl Strategy<Value = ObservationStatus> {
+    prop_oneof![
+        Just(ObservationStatus::Normal),
+        Just(ObservationStatus::Estimated),
+        Just(ObservationStatus::Forecast),
+        Just(ObservationStatus::Imputed),
+        Just(ObservationStatus::Missing),
+        Just(ObservationStatus::Provisional),
+        Just(ObservationStatus::Revised),
+        Just(ObservationStatus::Break),
+    ]
+}
+
+fn time_precision() -> impl Strategy<Value = TimePrecision> {
+    prop_oneof![
+        Just(TimePrecision::Day),
+        Just(TimePrecision::Week),
+        Just(TimePrecision::Month),
+        Just(TimePrecision::Quarter),
+        Just(TimePrecision::Year),
+    ]
+}
+
+fn timestamp() -> impl Strategy<Value = chrono::DateTime<Utc>> {
+    (946684800i64..2_209_075_200).prop_map(|seconds| {
+        Utc.timestamp_opt(seconds, 0)
+            .single()
+            .expect("timestamp in supported range")
+    })
+}
+
+fn observation_strategy() -> impl Strategy<Value = Observation> {
+    (
+        slug_fragment(),
+        slug_fragment(),
+        slug_fragment(),
+        time_precision(),
+        prop::option::of(-100_000i64..100_000i64).prop_map(|value| value.map(|value| value as f64)),
+        observation_status(),
+        0u32..8,
+        prop::collection::btree_map(slug_fragment(), slug_fragment(), 0..4),
+        timestamp(),
+        timestamp(),
+        prop::collection::vec(any::<u8>(), 1..64),
+    )
+        .prop_map(
+            |(
+                dataflow,
+                dimension,
+                dimension_value,
+                time_precision,
+                value,
+                status,
+                revision_no,
+                attributes,
+                time,
+                ingested_at,
+                artifact_bytes,
+            )| {
+                let dataflow = DataflowId::new(dataflow).expect("generated dataflow id");
+                let series_key =
+                    SeriesKey::derive(&dataflow, [(dimension.as_str(), dimension_value.as_str())]);
+                Observation {
+                    series_key,
+                    time,
+                    time_precision,
+                    value,
+                    status,
+                    revision_no,
+                    attributes: BTreeMap::from_iter(attributes),
+                    ingested_at,
+                    source_artifact_id: ArtifactId::of_content(&artifact_bytes),
+                }
+            },
+        )
+}
+
+proptest! {
+    #[test]
+    fn observation_json_roundtrip_preserves_value(obs in observation_strategy()) {
+        let json = serde_json::to_string(&obs).expect("serialize observation");
+        let roundtrip: Observation = serde_json::from_str(&json).expect("deserialize observation");
+        prop_assert_eq!(roundtrip, obs);
+    }
+}

--- a/crates/au-kpis-domain/tests/snapshots/observation_snapshot__observation_contract.snap
+++ b/crates/au-kpis-domain/tests/snapshots/observation_snapshot__observation_contract.snap
@@ -1,0 +1,15 @@
+---
+source: crates/au-kpis-domain/tests/observation_snapshot.rs
+expression: example_observation()
+---
+series_key: 583a8052a68ffddabd6ef062760e1a3ca6ed3fb07a00d03a0c1c57268beab809
+time: "2024-03-01T00:00:00Z"
+time_precision: quarter
+value: 134.2
+status: revised
+revision_no: 2
+attributes:
+  OBS_STATUS: R
+  UNIT_MULT: "0"
+ingested_at: "2024-04-30T00:00:00Z"
+source_artifact_id: 4c8992332d53c228a4687c4c0ebccb4e4a80f3d45fb939d0242147f3c26948cf

--- a/crates/au-kpis-storage/Cargo.toml
+++ b/crates/au-kpis-storage/Cargo.toml
@@ -20,6 +20,7 @@ tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+au-kpis-testing = { workspace = true }
 futures = "0.3"
 testcontainers = "0.23"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/au-kpis-storage/tests/minio.rs
+++ b/crates/au-kpis-storage/tests/minio.rs
@@ -14,21 +14,14 @@ use std::{sync::Arc, time::Duration};
 
 use au_kpis_domain::ids::ArtifactId;
 use au_kpis_storage::{BlobStore, StorageError, StorageKey};
+use au_kpis_testing::{MINIO_ACCESS_KEY, MINIO_SECRET_KEY, endpoint_for, minio_image, retry_async};
 use bytes::Bytes;
 use futures::{StreamExt, stream};
 use object_store::{ObjectStore, aws::AmazonS3Builder};
-use testcontainers::{
-    ContainerAsync, GenericImage, ImageExt,
-    core::{ContainerPort, WaitFor},
-    runners::AsyncRunner,
-};
+use testcontainers::{ContainerAsync, GenericImage, runners::AsyncRunner};
 
-const MINIO_IMAGE: &str = "minio/minio";
-const MINIO_TAG: &str = "RELEASE.2024-10-02T17-50-41Z";
 const MINIO_PORT: u16 = 9000;
 const BUCKET: &str = "au-kpis-test";
-const ACCESS_KEY: &str = "minioadmin";
-const SECRET_KEY: &str = "minioadmin";
 
 struct Harness {
     // Holds the container alive for the lifetime of the test.
@@ -37,32 +30,12 @@ struct Harness {
 }
 
 async fn start_minio() -> Harness {
-    // MinIO's official image does not offer an env-var bucket
-    // bootstrap; overriding the entrypoint to `sh -c` lets us
-    // pre-create the bucket directory (MinIO treats top-level dirs
-    // under the data path as buckets) before starting the server.
-    let start_script = format!(
-        "mkdir -p /data/{BUCKET} && exec minio server /data --address :{MINIO_PORT} --console-address :9001"
-    );
-    let container = GenericImage::new(MINIO_IMAGE, MINIO_TAG)
-        .with_exposed_port(ContainerPort::Tcp(MINIO_PORT))
-        // MinIO writes all its startup banner to stderr (including the
-        // "API:" line), so that's the only stream worth watching.
-        .with_wait_for(WaitFor::message_on_stderr("API:"))
-        .with_entrypoint("sh")
-        .with_env_var("MINIO_ROOT_USER", ACCESS_KEY)
-        .with_env_var("MINIO_ROOT_PASSWORD", SECRET_KEY)
-        .with_cmd(["-c", start_script.as_str()])
+    let container = minio_image(BUCKET)
         .start()
         .await
         .expect("start minio container");
 
-    let host = container.get_host().await.expect("container host");
-    let port = container
-        .get_host_port_ipv4(MINIO_PORT)
-        .await
-        .expect("host port");
-    let endpoint = format!("http://{host}:{port}");
+    let endpoint = endpoint_for(&container, MINIO_PORT).await;
 
     let store = build_store(&endpoint);
     let store: Arc<dyn ObjectStore> = Arc::new(store);
@@ -83,8 +56,8 @@ fn build_store(endpoint: &str) -> object_store::aws::AmazonS3 {
         .with_endpoint(endpoint)
         .with_region("us-east-1")
         .with_bucket_name(BUCKET)
-        .with_access_key_id(ACCESS_KEY)
-        .with_secret_access_key(SECRET_KEY)
+        .with_access_key_id(MINIO_ACCESS_KEY)
+        .with_secret_access_key(MINIO_SECRET_KEY)
         .with_allow_http(true)
         .with_virtual_hosted_style_request(false)
         .build()
@@ -93,17 +66,18 @@ fn build_store(endpoint: &str) -> object_store::aws::AmazonS3 {
 
 async fn wait_for_ready(store: &Arc<dyn ObjectStore>) {
     let probe = object_store::path::Path::from("readiness-probe");
-    for _ in 0..20 {
-        // A list() call is cheap and succeeds as soon as the bucket is
-        // reachable; NotFound on an individual key would also be fine,
-        // but the list form also validates credentials.
-        let mut stream = store.list(Some(&probe));
-        if stream.next().await.is_none() || stream.next().await.is_some() {
-            return;
+    retry_async(20, Duration::from_millis(250), || {
+        let store = Arc::clone(store);
+        let probe = probe.clone();
+        async move {
+            // list() reaches the bucket and validates the credentials,
+            // which is enough to prove the backend is ready for tests.
+            let mut stream = store.list(Some(&probe));
+            stream.next().await.transpose().map(|_| ())
         }
-        tokio::time::sleep(Duration::from_millis(250)).await;
-    }
-    panic!("minio did not become ready within the retry window");
+    })
+    .await
+    .expect("minio did not become ready within the retry window");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "au-kpis-testing"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared helpers for container-backed integration tests."
+
+[dependencies]
+testcontainers = "0.23"
+tokio = { version = "1", features = ["time"] }

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -1,0 +1,77 @@
+#![forbid(unsafe_code)]
+#![deny(missing_debug_implementations)]
+
+use std::{future::Future, time::Duration};
+
+use testcontainers::{
+    ContainerAsync, ContainerRequest, GenericImage, ImageExt,
+    core::{ContainerPort, WaitFor},
+};
+
+pub const MINIO_ACCESS_KEY: &str = "minioadmin";
+pub const MINIO_API_PORT: u16 = 9000;
+pub const MINIO_IMAGE: &str = "minio/minio";
+pub const MINIO_SECRET_KEY: &str = "minioadmin";
+pub const MINIO_TAG: &str = "RELEASE.2024-10-02T17-50-41Z";
+pub const TIMESCALE_IMAGE: &str = "timescale/timescaledb";
+pub const TIMESCALE_PORT: u16 = 5432;
+pub const TIMESCALE_TAG: &str = "latest-pg16";
+
+pub async fn endpoint_for(container: &ContainerAsync<GenericImage>, port: u16) -> String {
+    let host = container.get_host().await.expect("container host");
+    let port = container.get_host_port_ipv4(port).await.expect("host port");
+    format!("http://{host}:{port}")
+}
+
+pub fn minio_image(bucket: &str) -> ContainerRequest<GenericImage> {
+    let start_script = format!(
+        "mkdir -p /data/{bucket} && exec minio server /data --address :{MINIO_API_PORT} --console-address :9001"
+    );
+    GenericImage::new(MINIO_IMAGE, MINIO_TAG)
+        .with_exposed_port(ContainerPort::Tcp(MINIO_API_PORT))
+        .with_wait_for(WaitFor::message_on_stderr("API:"))
+        .with_entrypoint("sh")
+        .with_env_var("MINIO_ROOT_USER", MINIO_ACCESS_KEY)
+        .with_env_var("MINIO_ROOT_PASSWORD", MINIO_SECRET_KEY)
+        .with_cmd(vec!["-c".to_string(), start_script])
+}
+
+pub async fn postgres_connection_string(
+    container: &ContainerAsync<GenericImage>,
+    database: &str,
+) -> String {
+    let host = container.get_host().await.expect("container host");
+    let port = container
+        .get_host_port_ipv4(TIMESCALE_PORT)
+        .await
+        .expect("host port");
+    format!("postgres://postgres:postgres@{host}:{port}/{database}")
+}
+
+pub async fn retry_async<T, E, F, Fut>(attempts: usize, delay: Duration, mut op: F) -> Result<T, E>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, E>>,
+{
+    assert!(attempts > 0, "retry_async requires at least one attempt");
+
+    for attempt in 0..attempts {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(err) if attempt + 1 == attempts => return Err(err),
+            Err(_) => tokio::time::sleep(delay).await,
+        }
+    }
+
+    unreachable!("attempts > 0 guarantees a return")
+}
+
+pub fn timescale_image(database: &str) -> ContainerRequest<GenericImage> {
+    GenericImage::new(TIMESCALE_IMAGE, TIMESCALE_TAG)
+        .with_exposed_port(ContainerPort::Tcp(TIMESCALE_PORT))
+        .with_wait_for(WaitFor::message_on_stderr(
+            "database system is ready to accept connections",
+        ))
+        .with_env_var("POSTGRES_PASSWORD", "postgres")
+        .with_env_var("POSTGRES_DB", database)
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,56 @@
+# Testing
+
+This repository standardizes on `cargo nextest` for Rust test execution, `cargo-llvm-cov` for coverage, `insta` for snapshots, `proptest` for property checks, and `schemathesis` for OpenAPI contract fuzzing.
+
+## Rust test runs
+
+Use the shared workspace profile in [`.config/nextest.toml`](../.config/nextest.toml):
+
+```bash
+cargo nextest run --workspace
+```
+
+The default profile retries failures at most twice. CI captures the nextest log and fails the job if any test only passes on a retry, which keeps the zero-flake policy intact on the pinned Rust 1.85 toolchain.
+
+## Coverage
+
+Generate local line coverage and the LCOV artifact consumed by CI:
+
+```bash
+rustup component add llvm-tools-preview
+mkdir -p target/llvm-cov
+cargo llvm-cov --workspace --fail-under-lines 80 --lcov --output-path target/llvm-cov/lcov.info
+```
+
+## Snapshot tests
+
+Snapshot tests live alongside the owning crate under `tests/snapshots/`.
+
+```bash
+INSTA_UPDATE=always cargo test -p au-kpis-domain --test observation_snapshot
+```
+
+Review the generated `.snap` diff before committing it.
+
+## Property tests
+
+Property tests should focus on semantic invariants rather than implementation details. The initial example lives in `crates/au-kpis-domain/tests/property_roundtrip.rs` and checks JSON round-tripping for `Observation`.
+
+## Container-backed integration tests
+
+Shared Docker helpers live in [`crates/testing`](../crates/testing/). Use them instead of open-coding container image setup when a test needs TimescaleDB, Redis, or MinIO.
+
+Current integration suites require a working Docker daemon:
+
+```bash
+cargo nextest run --workspace
+```
+
+## Schemathesis
+
+The baseline Schemathesis config lives at [`tests/contract/schemathesis.toml`](../tests/contract/schemathesis.toml).
+
+```bash
+export AU_KPIS_API_BASE_URL=http://127.0.0.1:3000
+uvx schemathesis --config-file tests/contract/schemathesis.toml run http://127.0.0.1:3000/v1/openapi.json
+```

--- a/insta.yaml
+++ b/insta.yaml
@@ -1,0 +1,9 @@
+behavior:
+  output: summary
+  update: new
+test:
+  runner: nextest
+  auto_review: false
+  auto_accept_unseen: false
+review:
+  warn_undiscovered: true

--- a/tests/contract/schemathesis.toml
+++ b/tests/contract/schemathesis.toml
@@ -1,0 +1,11 @@
+generation.max-examples = 50
+request-timeout = 5.0
+base-url = "${AU_KPIS_API_BASE_URL}"
+
+[checks]
+not_a_server_error.enabled = true
+response_schema_conformance.enabled = true
+negative_data_rejection.enabled = true
+
+[phases]
+stateful.enabled = false


### PR DESCRIPTION
## Summary

- add repo-level testing infrastructure with shared `cargo nextest`, `insta`, `proptest`, Schemathesis, and coverage configuration
- introduce `crates/testing` and refactor the existing TimescaleDB and MinIO integration suites onto reusable container helpers
- wire a dedicated GitHub Actions workflow for nextest retries, zero-flake enforcement, coverage generation, and Codecov upload on the pinned Rust 1.85 toolchain

## Linked issue

Closes #17

## Pass requirements

- [x] `nextest` config + CI integration
- [x] `cargo-llvm-cov` + Codecov upload
- [x] `testcontainers` helper in `crates/testing/`
- [x] `insta` snapshot config + example test
- [x] `proptest` config + one sample property test
- [x] `schemathesis` config committed
- [x] Zero-flake policy enforced via retry cap
- [x] Docs in `docs/testing.md`

## Test plan

- [x] `cargo test --workspace --all-targets`
- [x] `cargo nextest run --workspace`
- [x] `mkdir -p target/llvm-cov && cargo llvm-cov --workspace --fail-under-lines 80 --lcov --output-path target/llvm-cov/lcov.info`
- [x] `pnpm install --frozen-lockfile`
- [x] `pnpm run lint`

## Spec / docs impact

- [x] No Spec changes required
- [x] Repo docs updated in `CONTRIBUTING.md` and `docs/testing.md`
