### PR TITLE
test(infra): add testing infrastructure (#17)

### DIFF
--- a/.config/insta.yaml
+++ b/.config/insta.yaml
@@ -1,0 +1,3 @@
+behavior:
+  output: diff
+  update: no

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,21 @@
+[profile.default]
+fail-fast = false
+failure-output = "immediate-final"
+final-status-level = "flaky"
+slow-timeout = { period = "60s", terminate-after = 4 }
+status-level = "pass"
+
+[profile.ci]
+fail-fast = false
+failure-output = "immediate-final"
+final-status-level = "flaky"
+retries = { backoff = "fixed", count = 2, delay = "1s" }
+slow-timeout = { period = "60s", terminate-after = 4 }
+status-level = "retry"
+success-output = "never"
+
+[profile.ci.junit]
+path = "junit.xml"
+report-name = "au-kpis-ci"
+store-failure-output = true
+store-success-output = false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: PR Review
+name: Pull Request
 
 on:
   pull_request:
@@ -13,6 +13,93 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  nextest:
+    name: Rust Tests (nextest)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --locked
+
+      - name: Run workspace tests with CI profile
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/nextest
+          cargo nextest run --workspace --profile ci 2>&1 | tee target/nextest/ci-run.log
+          if grep -n "FLAKY" target/nextest/ci-run.log; then
+            echo "Flaky retries are not allowed in CI." >&2
+            exit 1
+          fi
+
+  coverage:
+    name: Rust Coverage
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-llvm-cov
+        run: cargo install cargo-llvm-cov --locked
+
+      - name: Generate LCOV report
+        run: cargo llvm-cov nextest --workspace --profile ci --lcov --output-path target/llvm-cov/lcov.info
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: target/llvm-cov/lcov.info
+          flags: rust
+          name: rust-nextest
+          use_oidc: true
+          fail_ci_if_error: false
+
+  snapshots:
+    name: Snapshot Check
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Install cargo-insta
+        run: cargo install cargo-insta --locked
+
+      - name: Verify committed snapshots
+        run: cargo insta test --workspace --check
+
   codex-review:
     name: Codex Structured Review
     runs-on: ubuntu-latest

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Install cargo-llvm-cov
         run: cargo install cargo-llvm-cov --version 0.6.21 --locked
 
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --version 0.9.100 --locked
+
       - name: Generate LCOV report
         run: cargo llvm-cov nextest --workspace --profile ci --lcov --output-path target/llvm-cov/lcov.info
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,6 +65,9 @@ jobs:
         with:
           toolchain: 1.85
 
+      - name: Install nightly Rust toolchain
+        run: rustup toolchain install nightly --profile minimal --no-self-update
+
       - name: Cache Rust build artifacts
         uses: Swatinem/rust-cache@v2
 
@@ -79,7 +82,40 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p target/llvm-cov
-          cargo llvm-cov nextest --workspace --profile ci --lcov --output-path target/llvm-cov/lcov.info
+          cargo +nightly llvm-cov nextest \
+            --workspace \
+            --profile ci \
+            --branch \
+            --lcov \
+            --output-path target/llvm-cov/lcov.info \
+            --fail-under-lines 80
+
+      - name: Enforce branch coverage floor
+        shell: bash
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+
+          brf = 0
+          brh = 0
+
+          for line in Path("target/llvm-cov/lcov.info").read_text().splitlines():
+              if line.startswith("BRF:"):
+                  brf += int(line[4:])
+              elif line.startswith("BRH:"):
+                  brh += int(line[4:])
+
+          if brf == 0:
+              raise SystemExit("No branch coverage data found in LCOV output")
+
+          branch_coverage = (brh / brf) * 100
+          print(f"Total branch coverage: {branch_coverage:.2f}% ({brh}/{brf})")
+          if branch_coverage < 70:
+              raise SystemExit(
+                  f"Branch coverage below threshold: {branch_coverage:.2f}% < 70.00%"
+              )
+          PY
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
@@ -88,7 +124,80 @@ jobs:
           flags: rust
           name: rust-nextest
           use_oidc: true
-          fail_ci_if_error: false
+          fail_ci_if_error: true
+
+  contract:
+    name: Contract (schemathesis)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      RUSTC_WRAPPER: ""
+      CARGO_BUILD_RUSTC_WRAPPER: ""
+      AU_KPIS_CONTRACT_ADDR: 127.0.0.1:38080
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.85
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install Schemathesis
+        run: python -m pip install "schemathesis==4.15.2"
+
+      - name: Start contract server
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/contract
+          cargo run -p au-kpis-api-http --example contract_server > target/contract/server.log 2>&1 &
+          echo $! > target/contract/server.pid
+
+      - name: Wait for API readiness
+        shell: bash
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 120); do
+            if curl -fsS "http://${AU_KPIS_CONTRACT_ADDR}/v1/health" >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "Contract server did not become ready" >&2
+          cat target/contract/server.log >&2 || true
+          exit 1
+
+      - name: Export OpenAPI schema
+        run: cargo run -p au-kpis-openapi > target/contract/openapi.json
+
+      - name: Run Schemathesis
+        run: |
+          schemathesis run \
+            --checks all \
+            --request-timeout 5 \
+            --max-examples 16 \
+            --include-path /v1/health \
+            --url "http://${AU_KPIS_CONTRACT_ADDR}" \
+            target/contract/openapi.json
+
+      - name: Stop contract server
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -f target/contract/server.pid ]; then
+            kill "$(cat target/contract/server.pid)" || true
+          fi
 
   snapshots:
     name: Snapshot Check
@@ -560,6 +669,10 @@ jobs:
     name: CI OK
     runs-on: ubuntu-latest
     needs:
+      - nextest
+      - coverage
+      - contract
+      - snapshots
       - codex-review
     if: always()
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,6 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      RUSTC_WRAPPER: ""
+      CARGO_BUILD_RUSTC_WRAPPER: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -31,7 +34,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-nextest
-        run: cargo install cargo-nextest --locked
+        run: cargo install cargo-nextest --version 0.9.100 --locked
 
       - name: Run workspace tests with CI profile
         shell: bash
@@ -50,6 +53,9 @@ jobs:
     permissions:
       contents: read
       id-token: write
+    env:
+      RUSTC_WRAPPER: ""
+      CARGO_BUILD_RUSTC_WRAPPER: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -63,7 +69,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-llvm-cov
-        run: cargo install cargo-llvm-cov --locked
+        run: cargo install cargo-llvm-cov --version 0.6.21 --locked
 
       - name: Generate LCOV report
         run: cargo llvm-cov nextest --workspace --profile ci --lcov --output-path target/llvm-cov/lcov.info
@@ -82,6 +88,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    env:
+      RUSTC_WRAPPER: ""
+      CARGO_BUILD_RUSTC_WRAPPER: ""
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -95,7 +104,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Install cargo-insta
-        run: cargo install cargo-insta --locked
+        run: cargo install cargo-insta --version 1.47.2 --locked
 
       - name: Verify committed snapshots
         run: cargo insta test --workspace --check

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -75,7 +75,11 @@ jobs:
         run: cargo install cargo-nextest --version 0.9.100 --locked
 
       - name: Generate LCOV report
-        run: cargo llvm-cov nextest --workspace --profile ci --lcov --output-path target/llvm-cov/lcov.info
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p target/llvm-cov
+          cargo llvm-cov nextest --workspace --profile ci --lcov --output-path target/llvm-cov/lcov.info
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,10 +174,10 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "au-kpis-error",
+ "au-kpis-testing",
  "fred",
  "serde",
  "serde_json",
- "testcontainers",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -204,8 +204,8 @@ dependencies = [
  "au-kpis-config",
  "au-kpis-domain",
  "au-kpis-error",
+ "au-kpis-testing",
  "sqlx",
- "testcontainers",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -217,6 +217,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "hex",
+ "proptest",
  "serde",
  "serde_json",
  "sha2",
@@ -250,6 +251,7 @@ version = "0.1.0"
 dependencies = [
  "assert_cmd",
  "au-kpis-api-http",
+ "insta",
  "jsonschema",
  "serde_json",
  "thiserror 2.0.18",
@@ -278,11 +280,11 @@ version = "0.1.0"
 dependencies = [
  "au-kpis-domain",
  "au-kpis-error",
+ "au-kpis-testing",
  "bytes",
  "futures",
  "object_store",
  "sha2",
- "testcontainers",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -305,6 +307,13 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "au-kpis-testing"
+version = "0.1.0"
+dependencies = [
+ "testcontainers",
 ]
 
 [[package]]
@@ -664,6 +673,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "console-api"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +954,12 @@ checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "equivalent"
@@ -1650,6 +1676,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "once_cell",
+ "serde",
+ "similar",
+ "tempfile",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2351,6 +2390,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
+dependencies = [
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.11.1",
+ "num-traits",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
+ "rand_xorshift",
+ "regex-syntax",
+ "rusty-fork",
+ "tempfile",
+ "unarray",
+]
+
+[[package]]
 name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2404,6 +2462,12 @@ checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
  "prost 0.14.3",
 ]
+
+[[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
@@ -2548,6 +2612,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rand_xorshift"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+dependencies = [
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2833,6 +2906,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "rusty-fork"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc6bf79ff24e648f6da1f8d1f011e9cac26491b619e6b9280f2b47f1774e6ee2"
+dependencies = [
+ "fnv",
+ "quick-error",
+ "tempfile",
+ "wait-timeout",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3109,6 +3194,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "slab"
@@ -3905,6 +3996,12 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "unarray"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "uncased"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "crates/testing",
     "crates/au-kpis-domain",
     "crates/au-kpis-error",
     "crates/au-kpis-config",
@@ -37,6 +38,7 @@ license = "Apache-2.0"
 repository = "https://github.com/ponderingdemocritus/australian-kpis"
 
 [workspace.dependencies]
+au-kpis-testing = { path = "crates/testing" }
 au-kpis-domain = { path = "crates/au-kpis-domain" }
 au-kpis-error = { path = "crates/au-kpis-error" }
 au-kpis-config = { path = "crates/au-kpis-config" }

--- a/crates/au-kpis-api-http/examples/contract_server.rs
+++ b/crates/au-kpis-api-http/examples/contract_server.rs
@@ -1,0 +1,33 @@
+use std::net::SocketAddr;
+
+use au_kpis_api_http::{ApiDoc, router};
+use axum::{Router, http::header::CONTENT_TYPE, response::IntoResponse, routing::get};
+use utoipa::OpenApi;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() {
+    let addr = std::env::var("AU_KPIS_CONTRACT_ADDR")
+        .ok()
+        .and_then(|raw| raw.parse::<SocketAddr>().ok())
+        .unwrap_or_else(|| SocketAddr::from(([127, 0, 0, 1], 38080)));
+
+    let app = Router::new()
+        .merge(router())
+        .route("/v1/openapi.json", get(openapi));
+
+    let listener = tokio::net::TcpListener::bind(addr)
+        .await
+        .expect("bind contract server listener");
+    axum::serve(listener, app)
+        .await
+        .expect("serve contract server");
+}
+
+async fn openapi() -> impl IntoResponse {
+    (
+        [(CONTENT_TYPE, "application/json")],
+        ApiDoc::openapi()
+            .to_pretty_json()
+            .expect("serialize OpenAPI document"),
+    )
+}

--- a/crates/au-kpis-cache/Cargo.toml
+++ b/crates/au-kpis-cache/Cargo.toml
@@ -18,5 +18,5 @@ tokio = { version = "1", features = ["time"] }
 tracing = "0.1"
 
 [dev-dependencies]
-testcontainers = "0.23"
+au-kpis-testing = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }

--- a/crates/au-kpis-cache/tests/redis.rs
+++ b/crates/au-kpis-cache/tests/redis.rs
@@ -1,16 +1,8 @@
 use std::time::Duration;
 
 use au_kpis_cache::{CacheClient, TokenBucketConfig};
+use au_kpis_testing::redis::start_redis;
 use serde::{Deserialize, Serialize};
-use testcontainers::{
-    ContainerAsync, GenericImage,
-    core::{ContainerPort, WaitFor},
-    runners::AsyncRunner,
-};
-
-const REDIS_IMAGE: &str = "redis";
-const REDIS_TAG: &str = "7.2-alpine";
-const REDIS_PORT: u16 = 6379;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 struct Session {
@@ -18,57 +10,30 @@ struct Session {
     scopes: Vec<String>,
 }
 
-struct Harness {
-    _container: ContainerAsync<GenericImage>,
-    client: CacheClient,
-}
-
-async fn start_redis() -> Harness {
-    let container = GenericImage::new(REDIS_IMAGE, REDIS_TAG)
-        .with_exposed_port(ContainerPort::Tcp(REDIS_PORT))
-        .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
-        .start()
-        .await
-        .expect("start redis container");
-
-    let host = container.get_host().await.expect("container host");
-    let port = container
-        .get_host_port_ipv4(REDIS_PORT)
-        .await
-        .expect("host port");
-    let url = format!("redis://{host}:{port}");
-
-    let client = CacheClient::connect(&url).await.expect("connect cache");
-
-    Harness {
-        _container: container,
-        client,
-    }
-}
-
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn typed_round_trip_hits_real_redis() {
-    let harness = start_redis().await;
+    let redis = start_redis().await.expect("start redis container");
+    let client = CacheClient::connect(redis.url())
+        .await
+        .expect("connect cache");
     let key = "cache:test:session";
     let value = Session {
         user_id: 7,
         scopes: vec!["read".into(), "write".into()],
     };
 
-    harness
-        .client
+    client
         .set_json(key, &value, Duration::from_secs(30))
         .await
         .expect("set session");
 
-    let got: Option<Session> = harness.client.get_json(key).await.expect("get session");
+    let got: Option<Session> = client.get_json(key).await.expect("get session");
     assert_eq!(got, Some(value));
 
-    let deleted = harness.client.delete(key).await.expect("delete session");
+    let deleted = client.delete(key).await.expect("delete session");
     assert!(deleted, "delete should report an existing key");
     assert!(
-        harness
-            .client
+        client
             .get_json::<Session>(key)
             .await
             .expect("get deleted")
@@ -79,28 +44,28 @@ async fn typed_round_trip_hits_real_redis() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn token_bucket_denies_then_refills() {
-    let harness = start_redis().await;
+    let redis = start_redis().await.expect("start redis container");
+    let client = CacheClient::connect(redis.url())
+        .await
+        .expect("connect cache");
     let key = "cache:test:ratelimit:refill";
     let config = TokenBucketConfig::new(2, 2, Duration::from_secs(1)).expect("bucket config");
 
-    let first = harness
-        .client
+    let first = client
         .take_token_bucket(key, config, 1)
         .await
         .expect("first permit");
     assert!(first.allowed);
     assert_eq!(first.remaining, 1);
 
-    let second = harness
-        .client
+    let second = client
         .take_token_bucket(key, config, 1)
         .await
         .expect("second permit");
     assert!(second.allowed);
     assert_eq!(second.remaining, 0);
 
-    let denied = harness
-        .client
+    let denied = client
         .take_token_bucket(key, config, 1)
         .await
         .expect("third permit");
@@ -114,8 +79,7 @@ async fn token_bucket_denies_then_refills() {
     let after_refill = tokio::time::timeout(Duration::from_secs(2), async {
         loop {
             tokio::time::sleep(Duration::from_millis(100)).await;
-            let decision = harness
-                .client
+            let decision = client
                 .take_token_bucket(key, config, 1)
                 .await
                 .expect("refill probe");
@@ -131,19 +95,20 @@ async fn token_bucket_denies_then_refills() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn token_bucket_supports_sub_one_token_per_second_refill() {
-    let harness = start_redis().await;
+    let redis = start_redis().await.expect("start redis container");
+    let client = CacheClient::connect(redis.url())
+        .await
+        .expect("connect cache");
     let key = "cache:test:ratelimit:hourly-shape";
     let config = TokenBucketConfig::new(1, 1, Duration::from_secs(2)).expect("bucket config");
 
-    let first = harness
-        .client
+    let first = client
         .take_token_bucket(key, config, 1)
         .await
         .expect("first permit");
     assert!(first.allowed);
 
-    let denied = harness
-        .client
+    let denied = client
         .take_token_bucket(key, config, 1)
         .await
         .expect("second permit");
@@ -152,8 +117,7 @@ async fn token_bucket_supports_sub_one_token_per_second_refill() {
     let refilled = tokio::time::timeout(Duration::from_secs(4), async {
         loop {
             tokio::time::sleep(Duration::from_millis(200)).await;
-            let decision = harness
-                .client
+            let decision = client
                 .take_token_bucket(key, config, 1)
                 .await
                 .expect("refill probe");
@@ -169,9 +133,12 @@ async fn token_bucket_supports_sub_one_token_per_second_refill() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn token_bucket_is_atomic_under_contention() {
-    let harness = start_redis().await;
+    let redis = start_redis().await.expect("start redis container");
+    let client = CacheClient::connect(redis.url())
+        .await
+        .expect("connect cache");
     let key = "cache:test:ratelimit:atomic";
-    let client = harness.client.clone();
+    let client = client.clone();
 
     let mut tasks = Vec::new();
     for _ in 0..10 {

--- a/crates/au-kpis-db/Cargo.toml
+++ b/crates/au-kpis-db/Cargo.toml
@@ -25,8 +25,8 @@ thiserror = "2"
 tracing = "0.1"
 
 [dev-dependencies]
+au-kpis-testing = { workspace = true }
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
-testcontainers = "0.23"
 sqlx = { version = "0.8", default-features = false, features = [
     "runtime-tokio",
     "tls-rustls",

--- a/crates/au-kpis-db/tests/migrations.rs
+++ b/crates/au-kpis-db/tests/migrations.rs
@@ -16,52 +16,8 @@ use std::time::Duration;
 
 use au_kpis_config::DatabaseConfig;
 use au_kpis_db::{connect, ensure_timescale, migrate, revert_latest, timescale_version};
+use au_kpis_testing::timescale::start_timescale;
 use sqlx::{PgPool, Row};
-use testcontainers::{
-    ContainerAsync, GenericImage, ImageExt,
-    core::{ContainerPort, WaitFor},
-    runners::AsyncRunner,
-};
-
-const IMAGE_NAME: &str = "timescale/timescaledb";
-const IMAGE_TAG: &str = "latest-pg16";
-const POSTGRES_PORT: u16 = 5432;
-
-struct Harness {
-    // Holds the container alive for the lifetime of the test.
-    _container: ContainerAsync<GenericImage>,
-    pool: PgPool,
-}
-
-async fn start_timescale() -> Harness {
-    let container = GenericImage::new(IMAGE_NAME, IMAGE_TAG)
-        .with_exposed_port(ContainerPort::Tcp(POSTGRES_PORT))
-        .with_wait_for(WaitFor::message_on_stderr(
-            "database system is ready to accept connections",
-        ))
-        .with_env_var("POSTGRES_PASSWORD", "postgres")
-        .with_env_var("POSTGRES_DB", "au_kpis_test")
-        .start()
-        .await
-        .expect("start timescaledb container");
-
-    let host = container.get_host().await.expect("container host");
-    let port = container
-        .get_host_port_ipv4(POSTGRES_PORT)
-        .await
-        .expect("host port");
-    let url = format!("postgres://postgres:postgres@{host}:{port}/au_kpis_test");
-    let cfg = DatabaseConfig { url };
-
-    // Some images take a beat between "ready" log line and accepting
-    // TCP connections under load. Small retry loop avoids flakes.
-    let pool = connect_with_retry(&cfg).await;
-
-    Harness {
-        _container: container,
-        pool,
-    }
-}
 
 async fn connect_with_retry(cfg: &DatabaseConfig) -> PgPool {
     let mut last_err = None;
@@ -135,11 +91,17 @@ async fn schema_fingerprint(pool: &PgPool) -> Vec<(String, String)> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn migration_creates_hypertable_and_compression_policy() {
-    let harness = start_timescale().await;
+    let timescale = start_timescale("au_kpis_test")
+        .await
+        .expect("start timescaledb container");
+    let cfg = DatabaseConfig {
+        url: timescale.url().to_string(),
+    };
+    let pool = connect_with_retry(&cfg).await;
 
     // `connect` already enables the extension; prove that the
     // compile-checked query resolves the version.
-    let version = timescale_version(&harness.pool)
+    let version = timescale_version(&pool)
         .await
         .expect("timescale version query")
         .expect("timescale extension should be installed after connect");
@@ -148,14 +110,14 @@ async fn migration_creates_hypertable_and_compression_policy() {
         "timescale extension version should be non-empty"
     );
 
-    migrate(&harness.pool).await.expect("apply migrations");
+    migrate(&pool).await.expect("apply migrations");
 
     assert!(
-        hypertable_exists(&harness.pool, "observations").await,
+        hypertable_exists(&pool, "observations").await,
         "observations should be registered as a hypertable"
     );
     assert!(
-        has_compression_policy(&harness.pool, "observations").await,
+        has_compression_policy(&pool, "observations").await,
         "observations should have a compression policy installed"
     );
 
@@ -164,7 +126,7 @@ async fn migration_creates_hypertable_and_compression_policy() {
         "SELECT table_name FROM information_schema.tables
          WHERE table_schema = 'public' ORDER BY table_name",
     )
-    .fetch_all(&harness.pool)
+    .fetch_all(&pool)
     .await
     .expect("list tables");
     let table_names: Vec<&str> = tables.iter().map(|t| t.0.as_str()).collect();
@@ -191,14 +153,20 @@ async fn migration_creates_hypertable_and_compression_policy() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn revert_then_run_is_idempotent() {
-    let harness = start_timescale().await;
+    let timescale = start_timescale("au_kpis_test")
+        .await
+        .expect("start timescaledb container");
+    let cfg = DatabaseConfig {
+        url: timescale.url().to_string(),
+    };
+    let pool = connect_with_retry(&cfg).await;
 
-    migrate(&harness.pool).await.expect("initial migrate");
-    let first = schema_fingerprint(&harness.pool).await;
+    migrate(&pool).await.expect("initial migrate");
+    let first = schema_fingerprint(&pool).await;
     assert!(!first.is_empty(), "migration produced no tables");
 
-    revert_latest(&harness.pool).await.expect("revert");
-    let after_revert = schema_fingerprint(&harness.pool).await;
+    revert_latest(&pool).await.expect("revert");
+    let after_revert = schema_fingerprint(&pool).await;
     assert!(
         after_revert.is_empty(),
         "revert should leave no public tables behind; found {after_revert:?}"
@@ -207,12 +175,10 @@ async fn revert_then_run_is_idempotent() {
     // Extension is instance-level; down migration does not drop it.
     // Re-assert it so the second `run` works even if a stray pool
     // session landed on a different connection.
-    ensure_timescale(&harness.pool)
-        .await
-        .expect("re-ensure timescale");
+    ensure_timescale(&pool).await.expect("re-ensure timescale");
 
-    migrate(&harness.pool).await.expect("re-run migrate");
-    let second = schema_fingerprint(&harness.pool).await;
+    migrate(&pool).await.expect("re-run migrate");
+    let second = schema_fingerprint(&pool).await;
     assert_eq!(
         first, second,
         "schema after revert→run must match initial run"

--- a/crates/au-kpis-domain/Cargo.toml
+++ b/crates/au-kpis-domain/Cargo.toml
@@ -15,3 +15,6 @@ utoipa = { version = "5", features = ["chrono"] }
 sha2 = "0.10"
 hex = "0.4"
 thiserror = "2"
+
+[dev-dependencies]
+proptest = "1"

--- a/crates/au-kpis-domain/src/ids.rs
+++ b/crates/au-kpis-domain/src/ids.rs
@@ -379,6 +379,10 @@ impl ObservationId {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::BTreeMap;
+
+    use proptest::prelude::*;
+
     use super::*;
     use utoipa::{PartialSchema, ToSchema};
 
@@ -508,5 +512,30 @@ mod tests {
         let back: IdError = serde_json::from_str(&json).unwrap();
         assert_eq!(err, back);
         assert_eq!(IdError::name(), "IdError");
+    }
+
+    proptest! {
+        #[test]
+        fn series_key_derivation_is_order_independent(
+            dataflow in "[a-z0-9.]{1,16}",
+            region in "[A-Z]{3}",
+            measure in "[a-z]{1,12}",
+        ) {
+            let dataflow = DataflowId::new(dataflow).unwrap();
+            let mut reversed = BTreeMap::new();
+            reversed.insert("measure", measure.as_str());
+            reversed.insert("region", region.as_str());
+
+            let forward = SeriesKey::derive(
+                &dataflow,
+                [("region", region.as_str()), ("measure", measure.as_str())],
+            );
+            let backward = SeriesKey::derive(
+                &dataflow,
+                reversed.iter().map(|(key, value)| (*key, *value)),
+            );
+
+            prop_assert_eq!(forward, backward);
+        }
     }
 }

--- a/crates/au-kpis-openapi/Cargo.toml
+++ b/crates/au-kpis-openapi/Cargo.toml
@@ -15,4 +15,5 @@ utoipa = { version = "5", features = ["axum_extras"] }
 
 [dev-dependencies]
 assert_cmd = "2"
+insta = { version = "1", features = ["json"] }
 jsonschema = "0.29"

--- a/crates/au-kpis-openapi/tests/emitter.rs
+++ b/crates/au-kpis-openapi/tests/emitter.rs
@@ -45,3 +45,8 @@ fn cli_prints_same_document_as_emit() {
     let stdout = String::from_utf8(output.stdout).expect("stdout utf-8");
     assert_eq!(stdout, emit().expect("emit should succeed"));
 }
+
+#[test]
+fn emitted_openapi_matches_snapshot() {
+    insta::assert_json_snapshot!("openapi", emitted_spec());
+}

--- a/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
+++ b/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
@@ -1,0 +1,54 @@
+---
+source: crates/au-kpis-openapi/tests/emitter.rs
+expression: emitted_spec()
+---
+{
+  "components": {
+    "schemas": {
+      "HealthResponse": {
+        "description": "Health endpoint response.",
+        "properties": {
+          "status": {
+            "description": "Current service health.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "status"
+        ],
+        "type": "object"
+      }
+    }
+  },
+  "info": {
+    "description": "Unified API for Australian public economic data.",
+    "license": {
+      "identifier": "Apache-2.0",
+      "name": "Apache-2.0"
+    },
+    "title": "Australian KPIs API",
+    "version": "0.1.0"
+  },
+  "openapi": "3.1.0",
+  "paths": {
+    "/v1/health": {
+      "get": {
+        "operationId": "health",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HealthResponse"
+                }
+              }
+            },
+            "description": "API is healthy."
+          }
+        },
+        "summary": "`GET /v1/health`.",
+        "tags": []
+      }
+    }
+  }
+}

--- a/crates/au-kpis-storage/Cargo.toml
+++ b/crates/au-kpis-storage/Cargo.toml
@@ -20,6 +20,6 @@ tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
+au-kpis-testing = { workspace = true }
 futures = "0.3"
-testcontainers = "0.23"
 tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/au-kpis-storage/tests/minio.rs
+++ b/crates/au-kpis-storage/tests/minio.rs
@@ -14,57 +14,25 @@ use std::{sync::Arc, time::Duration};
 
 use au_kpis_domain::ids::ArtifactId;
 use au_kpis_storage::{BlobStore, StorageError, StorageKey};
+use au_kpis_testing::minio::{MinioHarness, start_minio};
 use bytes::Bytes;
 use futures::{StreamExt, stream};
 use object_store::{ObjectStore, aws::AmazonS3Builder};
-use testcontainers::{
-    ContainerAsync, GenericImage, ImageExt,
-    core::{ContainerPort, WaitFor},
-    runners::AsyncRunner,
-};
-
-const MINIO_IMAGE: &str = "minio/minio";
-const MINIO_TAG: &str = "RELEASE.2024-10-02T17-50-41Z";
-const MINIO_PORT: u16 = 9000;
 const BUCKET: &str = "au-kpis-test";
-const ACCESS_KEY: &str = "minioadmin";
-const SECRET_KEY: &str = "minioadmin";
 
 struct Harness {
-    // Holds the container alive for the lifetime of the test.
-    _container: ContainerAsync<GenericImage>,
+    _minio: MinioHarness,
     store: Arc<dyn ObjectStore>,
 }
 
-async fn start_minio() -> Harness {
-    // MinIO's official image does not offer an env-var bucket
-    // bootstrap; overriding the entrypoint to `sh -c` lets us
-    // pre-create the bucket directory (MinIO treats top-level dirs
-    // under the data path as buckets) before starting the server.
-    let start_script = format!(
-        "mkdir -p /data/{BUCKET} && exec minio server /data --address :{MINIO_PORT} --console-address :9001"
+async fn test_store() -> Harness {
+    let minio = start_minio(BUCKET).await.expect("start minio container");
+    let store = build_store(
+        minio.endpoint(),
+        minio.bucket(),
+        minio.access_key(),
+        minio.secret_key(),
     );
-    let container = GenericImage::new(MINIO_IMAGE, MINIO_TAG)
-        .with_exposed_port(ContainerPort::Tcp(MINIO_PORT))
-        // MinIO writes all its startup banner to stderr (including the
-        // "API:" line), so that's the only stream worth watching.
-        .with_wait_for(WaitFor::message_on_stderr("API:"))
-        .with_entrypoint("sh")
-        .with_env_var("MINIO_ROOT_USER", ACCESS_KEY)
-        .with_env_var("MINIO_ROOT_PASSWORD", SECRET_KEY)
-        .with_cmd(["-c", start_script.as_str()])
-        .start()
-        .await
-        .expect("start minio container");
-
-    let host = container.get_host().await.expect("container host");
-    let port = container
-        .get_host_port_ipv4(MINIO_PORT)
-        .await
-        .expect("host port");
-    let endpoint = format!("http://{host}:{port}");
-
-    let store = build_store(&endpoint);
     let store: Arc<dyn ObjectStore> = Arc::new(store);
 
     // MinIO is ready the moment it logs the API line, but the first
@@ -73,18 +41,23 @@ async fn start_minio() -> Harness {
     wait_for_ready(&store).await;
 
     Harness {
-        _container: container,
+        _minio: minio,
         store,
     }
 }
 
-fn build_store(endpoint: &str) -> object_store::aws::AmazonS3 {
+fn build_store(
+    endpoint: &str,
+    bucket: &str,
+    access_key: &str,
+    secret_key: &str,
+) -> object_store::aws::AmazonS3 {
     AmazonS3Builder::new()
         .with_endpoint(endpoint)
         .with_region("us-east-1")
-        .with_bucket_name(BUCKET)
-        .with_access_key_id(ACCESS_KEY)
-        .with_secret_access_key(SECRET_KEY)
+        .with_bucket_name(bucket)
+        .with_access_key_id(access_key)
+        .with_secret_access_key(secret_key)
         .with_allow_http(true)
         .with_virtual_hosted_style_request(false)
         .build()
@@ -108,7 +81,7 @@ async fn wait_for_ready(store: &Arc<dyn ObjectStore>) {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn put_artifact_is_content_addressed() {
-    let h = start_minio().await;
+    let h = test_store().await;
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
     let content = Bytes::from_static(b"the quick brown fox");
@@ -126,7 +99,7 @@ async fn put_artifact_is_content_addressed() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn put_artifact_is_idempotent_and_does_not_rewrite() {
-    let h = start_minio().await;
+    let h = test_store().await;
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
     let content = Bytes::from_static(b"idempotent payload");
@@ -166,7 +139,7 @@ async fn put_artifact_is_idempotent_and_does_not_rewrite() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn get_artifact_streams_full_payload() {
-    let h = start_minio().await;
+    let h = test_store().await;
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
     // A payload comfortably larger than a single chunk so the stream
@@ -186,7 +159,7 @@ async fn get_artifact_streams_full_payload() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn missing_artifact_surfaces_not_found() {
-    let h = start_minio().await;
+    let h = test_store().await;
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
     let ghost_id = ArtifactId::of_content(b"never written");
@@ -217,7 +190,7 @@ async fn missing_artifact_surfaces_not_found() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn put_artifact_stream_matches_single_shot_id() {
-    let h = start_minio().await;
+    let h = test_store().await;
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
     // Payload sized to genuinely cross S3's multipart boundary:
@@ -266,7 +239,7 @@ async fn put_artifact_stream_matches_single_shot_id() {
 async fn put_artifact_stream_is_idempotent_and_cleans_staging() {
     use object_store::path::Path;
 
-    let h = start_minio().await;
+    let h = test_store().await;
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
     let content = b"streamed-idempotent".to_vec();
@@ -313,7 +286,7 @@ async fn put_artifact_stream_handles_empty_source() {
     // `CompleteMultipartUpload` with zero parts, so the streaming
     // writer must special-case that and still produce the canonical
     // empty-content id.
-    let h = start_minio().await;
+    let h = test_store().await;
     let blob = BlobStore::from_arc(Arc::clone(&h.store));
 
     let empty: Vec<Result<Bytes, std::io::Error>> = Vec::new();

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "au-kpis-testing"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Shared testcontainers harnesses for integration tests."
+
+[dependencies]
+testcontainers = "0.23"

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -1,0 +1,198 @@
+//! Shared test harnesses for Docker-backed integration tests.
+//!
+//! The repository leans on `testcontainers` for real Postgres/Timescale,
+//! Redis, and MinIO coverage. This crate centralizes container startup so
+//! tests share the same image tags and connection-string conventions.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::fmt;
+
+use testcontainers::{
+    ContainerAsync, GenericImage, ImageExt, TestcontainersError,
+    core::{ContainerPort, WaitFor},
+    runners::AsyncRunner,
+};
+
+/// Redis helpers.
+pub mod redis {
+    use super::*;
+
+    const REDIS_IMAGE: &str = "redis";
+    const REDIS_TAG: &str = "7.2-alpine";
+    const REDIS_PORT: u16 = 6379;
+
+    /// Running Redis test container.
+    pub struct RedisHarness {
+        _container: ContainerAsync<GenericImage>,
+        url: String,
+    }
+
+    impl fmt::Debug for RedisHarness {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("RedisHarness")
+                .field("url", &self.url)
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl RedisHarness {
+        /// Borrow the Redis connection URL.
+        pub fn url(&self) -> &str {
+            &self.url
+        }
+    }
+
+    /// Start a disposable Redis container and return its connection URL.
+    pub async fn start_redis() -> Result<RedisHarness, TestcontainersError> {
+        let container = GenericImage::new(REDIS_IMAGE, REDIS_TAG)
+            .with_exposed_port(ContainerPort::Tcp(REDIS_PORT))
+            .with_wait_for(WaitFor::message_on_stdout("Ready to accept connections"))
+            .start()
+            .await?;
+
+        let host = container.get_host().await?;
+        let port = container.get_host_port_ipv4(REDIS_PORT).await?;
+        let url = format!("redis://{host}:{port}");
+
+        Ok(RedisHarness {
+            _container: container,
+            url,
+        })
+    }
+}
+
+/// Timescale/Postgres helpers.
+pub mod timescale {
+    use super::*;
+
+    const IMAGE_NAME: &str = "timescale/timescaledb";
+    const IMAGE_TAG: &str = "latest-pg16";
+    const POSTGRES_PORT: u16 = 5432;
+    const POSTGRES_USER: &str = "postgres";
+    const POSTGRES_PASSWORD: &str = "postgres";
+
+    /// Running TimescaleDB test container.
+    pub struct TimescaleHarness {
+        _container: ContainerAsync<GenericImage>,
+        url: String,
+    }
+
+    impl fmt::Debug for TimescaleHarness {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("TimescaleHarness")
+                .field("url", &self.url)
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl TimescaleHarness {
+        /// Borrow the Postgres connection URL.
+        pub fn url(&self) -> &str {
+            &self.url
+        }
+    }
+
+    /// Start a disposable TimescaleDB container for the provided database name.
+    pub async fn start_timescale(database: &str) -> Result<TimescaleHarness, TestcontainersError> {
+        let container = GenericImage::new(IMAGE_NAME, IMAGE_TAG)
+            .with_exposed_port(ContainerPort::Tcp(POSTGRES_PORT))
+            .with_wait_for(WaitFor::message_on_stderr(
+                "database system is ready to accept connections",
+            ))
+            .with_env_var("POSTGRES_PASSWORD", POSTGRES_PASSWORD)
+            .with_env_var("POSTGRES_DB", database)
+            .start()
+            .await?;
+
+        let host = container.get_host().await?;
+        let port = container.get_host_port_ipv4(POSTGRES_PORT).await?;
+        let url =
+            format!("postgres://{POSTGRES_USER}:{POSTGRES_PASSWORD}@{host}:{port}/{database}");
+
+        Ok(TimescaleHarness {
+            _container: container,
+            url,
+        })
+    }
+}
+
+/// MinIO helpers.
+pub mod minio {
+    use super::*;
+
+    const MINIO_IMAGE: &str = "minio/minio";
+    const MINIO_TAG: &str = "RELEASE.2024-10-02T17-50-41Z";
+    const MINIO_PORT: u16 = 9000;
+    const ACCESS_KEY: &str = "minioadmin";
+    const SECRET_KEY: &str = "minioadmin";
+
+    /// Running MinIO test container.
+    pub struct MinioHarness {
+        _container: ContainerAsync<GenericImage>,
+        endpoint: String,
+        bucket: String,
+    }
+
+    impl fmt::Debug for MinioHarness {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            f.debug_struct("MinioHarness")
+                .field("endpoint", &self.endpoint)
+                .field("bucket", &self.bucket)
+                .finish_non_exhaustive()
+        }
+    }
+
+    impl MinioHarness {
+        /// Borrow the base HTTP endpoint.
+        pub fn endpoint(&self) -> &str {
+            &self.endpoint
+        }
+
+        /// Borrow the pre-created bucket name.
+        pub fn bucket(&self) -> &str {
+            &self.bucket
+        }
+
+        /// Borrow the access key.
+        pub fn access_key(&self) -> &str {
+            ACCESS_KEY
+        }
+
+        /// Borrow the secret key.
+        pub fn secret_key(&self) -> &str {
+            SECRET_KEY
+        }
+    }
+
+    /// Start a disposable MinIO container and pre-create the requested bucket.
+    pub async fn start_minio(
+        bucket: impl Into<String>,
+    ) -> Result<MinioHarness, TestcontainersError> {
+        let bucket = bucket.into();
+        let start_script = format!(
+            "mkdir -p /data/{bucket} && exec minio server /data --address :{MINIO_PORT} --console-address :9001"
+        );
+
+        let container = GenericImage::new(MINIO_IMAGE, MINIO_TAG)
+            .with_exposed_port(ContainerPort::Tcp(MINIO_PORT))
+            .with_wait_for(WaitFor::message_on_stderr("API:"))
+            .with_entrypoint("sh")
+            .with_env_var("MINIO_ROOT_USER", ACCESS_KEY)
+            .with_env_var("MINIO_ROOT_PASSWORD", SECRET_KEY)
+            .with_cmd(["-c", start_script.as_str()])
+            .start()
+            .await?;
+
+        let host = container.get_host().await?;
+        let port = container.get_host_port_ipv4(MINIO_PORT).await?;
+        let endpoint = format!("http://{host}:{port}");
+
+        Ok(MinioHarness {
+            _container: container,
+            endpoint,
+            bucket,
+        })
+    }
+}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,53 @@
+# Testing Infrastructure
+
+This repository uses a layered test stack from `Spec.md § Testing strategy`.
+
+## Local commands
+
+```bash
+# Fast Rust suite with repo-shared scheduling and timeouts
+cargo nextest run --workspace
+
+# CI-equivalent Rust suite: retries capped at 2 and any flaky retry fails the run
+cargo nextest run --workspace --profile ci
+
+# Coverage for Codecov / local inspection
+cargo llvm-cov nextest --workspace --profile ci --lcov --output-path target/llvm-cov/lcov.info
+
+# Snapshot verification
+cargo insta test --workspace --check
+
+# Contract fuzzing against a running API
+schemathesis --config-file tests/contract/schemathesis.toml run http://127.0.0.1:3000/v1/openapi.json
+```
+
+## Shared Docker harnesses
+
+`crates/testing/` owns the shared `testcontainers` harnesses used by integration
+tests. Today it provides:
+
+- Redis via `au_kpis_testing::redis::start_redis`
+- Timescale/Postgres via `au_kpis_testing::timescale::start_timescale`
+- MinIO via `au_kpis_testing::minio::start_minio`
+
+Use these helpers instead of duplicating image tags, startup waits, or URL
+construction in individual test files.
+
+## Snapshot policy
+
+Repo-level Insta defaults live in `.config/insta.yaml`:
+
+- snapshot updates are disabled by default in normal test runs
+- diffs are shown when snapshots drift
+
+Accept intentional snapshot changes explicitly with `cargo insta accept`.
+
+## Flake policy
+
+CI uses the `ci` nextest profile from `.config/nextest.toml`:
+
+- retries are capped at 2 attempts after the initial failure
+- the PR workflow fails if the nextest log reports any `FLAKY` retries
+- JUnit output is written to `target/nextest/ci/junit.xml` for reporting
+
+This matches the repository's zero-flake policy: fix flaky tests or delete them.

--- a/tests/contract/schemathesis.toml
+++ b/tests/contract/schemathesis.toml
@@ -1,0 +1,10 @@
+base-url = "http://127.0.0.1:3000"
+generation.max-examples = 64
+request-timeout = 5.0
+
+[phases]
+stateful.enabled = false
+
+[[operations]]
+include-path = "/v1/health"
+generation.max-examples = 16


### PR DESCRIPTION
## Summary

This PR lands issue #17, the shared testing infrastructure scaffold for M1.

- adds `au-kpis-testing`, a shared `testcontainers` helper crate for Redis, Timescale, and MinIO
- refactors the existing cache, DB, and storage integration tests to use the shared harnesses
- adds repo-level testing config for `nextest`, `insta`, and `schemathesis`, plus a dedicated testing guide in `docs/testing.md`
- extends the PR workflow with `nextest`, coverage upload, and snapshot verification jobs
- adds one property test (`SeriesKey` order independence) and one OpenAPI snapshot test

## Pass requirements

- [x] `nextest` config + CI integration
- [x] `cargo-llvm-cov` + Codecov upload
- [x] `testcontainers` helper in `crates/testing/`
- [x] `insta` snapshot config + example test
- [x] `proptest` config + one sample property test
- [x] `schemathesis` config committed
- [x] Zero-flake policy enforced via retry cap
- [x] Docs in `docs/testing.md`

## Test plan

- `cargo fmt --all --check`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo nextest run --workspace --profile ci`
- `cargo insta test --workspace --check`
- `cargo llvm-cov nextest --workspace --profile ci --summary-only`
- `cargo test -p au-kpis-cache --test redis`
- `cargo test -p au-kpis-db --test migrations`
- `cargo test -p au-kpis-storage --test minio`

## Spec impact

No Spec changes required.

## Notes

- `cargo deny check` currently fails at the repo level because there is no allowlist/config committed yet; that work is already tracked by `#20`.
- `cargo audit` currently reports existing workspace advisories (`RUSTSEC-2023-0071`, `RUSTSEC-2025-0111`, `RUSTSEC-2025-0134`) that also belong to `#20`; this branch does not add a new advisory class beyond the repo's current baseline.

Closes #17
