### PR TITLE
feat(api): finish API binary runtime (#12)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+target/
+.git/
+.context/
+node_modules/
+**/.DS_Store

--- a/crates/au-kpis-config/src/lib.rs
+++ b/crates/au-kpis-config/src/lib.rs
@@ -106,7 +106,7 @@ pub struct HttpConfig {
 impl Default for HttpConfig {
     fn default() -> Self {
         Self {
-            bind: "0.0.0.0:8080".into(),
+            bind: "0.0.0.0:3000".into(),
             cors_allowed_origins: Vec::new(),
             shutdown_grace_period_secs: 30,
         }
@@ -240,7 +240,7 @@ mod tests {
             let cfg = load(None).expect("env supplies required fields");
             assert_eq!(cfg.database.url, "postgres://env/db");
             assert_eq!(cfg.cache.url, "redis://env:6379");
-            assert_eq!(cfg.http.bind, "0.0.0.0:8080");
+            assert_eq!(cfg.http.bind, "0.0.0.0:3000");
             assert!(cfg.http.cors_allowed_origins.is_empty());
             assert_eq!(cfg.http.shutdown_grace_period_secs, 30);
             assert_eq!(cfg.telemetry.service_name, "au-kpis");

--- a/crates/bins/au-kpis-api/tests/sigterm.rs
+++ b/crates/bins/au-kpis-api/tests/sigterm.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::Write,
+    io::{Read, Write},
     net::TcpStream,
     path::PathBuf,
     process::{Child, Command, Stdio},
@@ -25,6 +25,21 @@ async fn api_binary_honors_sigterm() {
 
     harness.send_sigterm();
     harness.wait_for_exit(Duration::from_secs(5));
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn api_binary_serves_health_route() {
+    let _harness = ApiProcess::start("au_kpis_api_health", None).await;
+    let response = http_get(&(_harness.addr), "/v1/health");
+
+    assert!(
+        response.starts_with("HTTP/1.1 200 OK"),
+        "unexpected health response: {response}"
+    );
+    assert!(
+        response.contains(r#""status":"ok""#),
+        "health body did not include ok status: {response}"
+    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
@@ -182,4 +197,19 @@ fn wait_for_startup_file(path: &PathBuf, child: &mut std::process::Child) -> Str
     }
 
     panic!("au-kpis-api never reported its bound address");
+}
+
+fn http_get(addr: &str, path: &str) -> String {
+    let mut stream = TcpStream::connect(addr).expect("connect to API");
+    write!(
+        stream,
+        "GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+    )
+    .expect("write HTTP request");
+
+    let mut response = String::new();
+    stream
+        .read_to_string(&mut response)
+        .expect("read HTTP response");
+    response
 }

--- a/infra/docker/au-kpis-api.Dockerfile
+++ b/infra/docker/au-kpis-api.Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1.7
+
+FROM rust:1.85-bookworm AS builder
+WORKDIR /app
+ENV RUSTC_WRAPPER=""
+COPY . .
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/usr/local/cargo/git \
+    --mount=type=cache,target=/app/target \
+    cargo build --release --locked --bin au-kpis-api \
+    && cp target/release/au-kpis-api /tmp/au-kpis-api
+
+FROM gcr.io/distroless/cc-debian12:nonroot
+WORKDIR /app
+COPY --from=builder /tmp/au-kpis-api /usr/local/bin/au-kpis-api
+EXPOSE 3000
+USER nonroot:nonroot
+ENTRYPOINT ["/usr/local/bin/au-kpis-api"]


### PR DESCRIPTION
## Summary

- Set the API binary/config default bind address to `0.0.0.0:3000`.
- Add binary-level health-route coverage and distroless non-root Docker packaging for `au-kpis-api`.

## Linked issue

Closes #12

## Pass requirements

- [x] `cargo run --bin au-kpis-api` binds `0.0.0.0:3000`
- [x] Reads config via `au-kpis-config`
- [x] `curl localhost:3000/v1/health` returns 200
- [x] Dockerfile (distroless, non-root) builds image <100MB

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test -p au-kpis-config`
- [x] `cargo test -p au-kpis-api`
- [x] `cargo clippy -p au-kpis-config -p au-kpis-api --all-targets -- -D warnings`
- [x] `cargo nextest run -p au-kpis-config -p au-kpis-api`
- [x] `cargo build --release --bin au-kpis-api`
- [x] `docker build -f infra/docker/au-kpis-api.Dockerfile -t au-kpis-api:issue-12 .` (13.6 MB image)

## Spec / docs impact

- [x] No Spec changes required
- [ ] Spec amended in this PR
- [ ] Spec amendment filed separately (#)

## Checklist

- [x] Conventional commit title
- [x] No secrets committed
- [x] Tests added/updated
- [x] `cargo fmt` clean; Biome not applicable
- [x] Clippy warnings resolved; Biome not applicable
