### PR TITLE
feat(adapter): add source adapter registry (#21)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,6 +147,21 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "au-kpis-adapter"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "au-kpis-domain",
+ "au-kpis-error",
+ "au-kpis-storage",
+ "bytes",
+ "chrono",
+ "futures",
+ "object_store",
+ "reqwest",
+ "serde",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "au-kpis-adapter-abs"
@@ -1626,6 +1641,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots 1.0.7",
 ]
 
 [[package]]
@@ -2024,7 +2040,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2830,6 +2846,7 @@ version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
+ "async-compression",
  "base64 0.22.1",
  "bytes",
  "futures-channel",
@@ -2868,6 +2885,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+ "webpki-roots 0.26.11",
  "windows-registry",
 ]
 
@@ -3657,7 +3675,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/au-kpis-adapter/Cargo.toml
+++ b/crates/au-kpis-adapter/Cargo.toml
@@ -8,3 +8,22 @@ repository.workspace = true
 description = "Adapter trait + base helpers (discover/fetch/parse)."
 
 [dependencies]
+async-trait = "0.1"
+au-kpis-domain = { workspace = true }
+au-kpis-error = { workspace = true }
+au-kpis-storage = { workspace = true }
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+futures = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream", "gzip", "brotli", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+thiserror = "2"
+tokio = { version = "1", features = ["sync", "time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+bytes = "1"
+object_store = "0.11"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "sync", "time"] }
+
+[lints]
+workspace = true

--- a/crates/au-kpis-adapter/src/lib.rs
+++ b/crates/au-kpis-adapter/src/lib.rs
@@ -1,1 +1,515 @@
 //! Adapter trait + base helpers (discover/fetch/parse).
+//!
+//! Source-specific crates implement [`SourceAdapter`] and register values in an
+//! [`Adapters`] registry. The ingestion pipeline can then dispatch discovery,
+//! fetch, and streaming parse work by source id without depending on any
+//! concrete adapter crate.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::{
+    collections::BTreeMap,
+    fmt,
+    sync::Arc,
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use au_kpis_domain::{
+    Artifact, DataflowId, Observation, SeriesDescriptor, SourceId, ids::ArtifactId,
+};
+use au_kpis_error::{Classify, CoreError, ErrorClass};
+use au_kpis_storage::{BlobStore, StorageError};
+use chrono::{DateTime, Utc};
+use futures::stream::BoxStream;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+use tokio::{sync::Mutex, time::sleep};
+
+/// Streaming observation payload emitted by adapters during parse.
+pub type ObservationStream<'a> =
+    BoxStream<'a, Result<(SeriesDescriptor, Observation), AdapterError>>;
+
+/// Per-source HTTP rate-limit declaration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RateLimit {
+    /// Maximum requests allowed during [`Self::per`].
+    pub max_requests: u32,
+    /// Window over which [`Self::max_requests`] is measured.
+    #[serde(with = "duration_millis")]
+    pub per: Duration,
+}
+
+impl RateLimit {
+    /// Construct a validated rate limit.
+    pub fn new(max_requests: u32, per: Duration) -> Result<Self, AdapterError> {
+        if max_requests == 0 {
+            return Err(AdapterError::Validation(
+                "rate-limit max_requests must be greater than zero".into(),
+            ));
+        }
+        if per.is_zero() {
+            return Err(AdapterError::Validation(
+                "rate-limit window must be greater than zero".into(),
+            ));
+        }
+        Ok(Self { max_requests, per })
+    }
+
+    fn spacing(self) -> Duration {
+        let per_nanos = self.per.as_nanos();
+        let spacing_nanos = (per_nanos / u128::from(self.max_requests)).max(1);
+        let capped = spacing_nanos.min(u128::from(u64::MAX));
+        Duration::from_nanos(capped as u64)
+    }
+}
+
+/// Static metadata and operational policy for an adapter.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AdapterManifest {
+    /// Stable source id, e.g. `abs`.
+    pub source_id: SourceId,
+    /// Human-readable source name.
+    pub name: String,
+    /// Adapter crate version or upstream parser version.
+    pub version: String,
+    /// Default source rate limit enforced by [`AdapterHttpClient`].
+    pub rate_limit: RateLimit,
+    /// Dataflows this adapter can emit.
+    pub dataflows: Vec<DataflowId>,
+}
+
+/// Rate-limited HTTP client shared by adapter contexts.
+#[derive(Clone)]
+pub struct AdapterHttpClient {
+    client: reqwest::Client,
+    limiter: Arc<RateLimiter>,
+}
+
+impl fmt::Debug for AdapterHttpClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("AdapterHttpClient")
+            .field("rate_limit", &self.limiter.limit)
+            .finish_non_exhaustive()
+    }
+}
+
+impl AdapterHttpClient {
+    /// Build a client with the source's declared rate limit.
+    pub fn new(rate_limit: RateLimit) -> Self {
+        Self::from_client(reqwest::Client::new(), rate_limit)
+    }
+
+    /// Wrap an existing `reqwest` client with the source's declared rate limit.
+    pub fn from_client(client: reqwest::Client, rate_limit: RateLimit) -> Self {
+        Self {
+            client,
+            limiter: Arc::new(RateLimiter::new(rate_limit)),
+        }
+    }
+
+    /// Borrow the underlying client for request builders not covered by helpers.
+    #[must_use]
+    pub fn raw(&self) -> &reqwest::Client {
+        &self.client
+    }
+
+    /// Send a request after waiting for a rate-limit permit.
+    #[tracing::instrument(skip(self, request))]
+    pub async fn execute(
+        &self,
+        request: reqwest::RequestBuilder,
+    ) -> Result<reqwest::Response, AdapterError> {
+        self.limiter.wait_for_permit().await;
+        Ok(request.send().await?)
+    }
+
+    /// Convenience `GET` helper using the shared rate limiter.
+    #[tracing::instrument(skip(self), fields(url = %url))]
+    pub async fn get(&self, url: &str) -> Result<reqwest::Response, AdapterError> {
+        self.execute(self.client.get(url)).await
+    }
+}
+
+#[derive(Debug)]
+struct RateLimiter {
+    limit: RateLimit,
+    next_permit: Mutex<Instant>,
+}
+
+impl RateLimiter {
+    fn new(limit: RateLimit) -> Self {
+        Self {
+            limit,
+            next_permit: Mutex::new(Instant::now()),
+        }
+    }
+
+    #[tracing::instrument(skip(self), fields(max_requests = self.limit.max_requests))]
+    async fn wait_for_permit(&self) {
+        loop {
+            let now = Instant::now();
+            let wait = {
+                let mut next = self.next_permit.lock().await;
+                if now >= *next {
+                    *next = now + self.limit.spacing();
+                    None
+                } else {
+                    Some(*next - now)
+                }
+            };
+
+            match wait {
+                Some(delay) => sleep(delay).await,
+                None => return,
+            }
+        }
+    }
+}
+
+/// Context supplied to adapter discovery.
+#[derive(Debug, Clone)]
+pub struct DiscoveryCtx {
+    /// Rate-limited HTTP client for upstream metadata requests.
+    pub http: AdapterHttpClient,
+    /// Timestamp captured by the scheduler when discovery started.
+    pub started_at: DateTime<Utc>,
+}
+
+impl DiscoveryCtx {
+    /// Construct a discovery context.
+    #[must_use]
+    pub fn new(http: AdapterHttpClient, started_at: DateTime<Utc>) -> Self {
+        Self { http, started_at }
+    }
+}
+
+/// Context supplied to adapter fetch jobs.
+#[derive(Debug, Clone)]
+pub struct FetchCtx {
+    /// Rate-limited HTTP client for upstream artifact downloads.
+    pub http: AdapterHttpClient,
+    /// Content-addressed blob store for raw source artifacts.
+    pub blob_store: BlobStore,
+    /// Timestamp captured by the worker when fetch started.
+    pub started_at: DateTime<Utc>,
+}
+
+impl FetchCtx {
+    /// Construct a fetch context.
+    #[must_use]
+    pub fn new(http: AdapterHttpClient, blob_store: BlobStore, started_at: DateTime<Utc>) -> Self {
+        Self {
+            http,
+            blob_store,
+            started_at,
+        }
+    }
+}
+
+/// Context supplied to streaming parsers.
+#[derive(Debug, Clone)]
+pub struct ParseCtx {
+    /// Rate-limited HTTP client for parser-side follow-up requests.
+    pub http: AdapterHttpClient,
+    /// Blob store used to read persisted artifacts.
+    pub blob_store: BlobStore,
+    /// Timestamp captured by the worker when parse started.
+    pub started_at: DateTime<Utc>,
+}
+
+impl ParseCtx {
+    /// Construct a parse context.
+    #[must_use]
+    pub fn new(http: AdapterHttpClient, blob_store: BlobStore, started_at: DateTime<Utc>) -> Self {
+        Self {
+            http,
+            blob_store,
+            started_at,
+        }
+    }
+}
+
+/// Unit of work emitted by discovery and consumed by fetch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DiscoveredJob {
+    /// Stable source-local job id.
+    pub id: String,
+    /// Source that emitted the job.
+    pub source_id: SourceId,
+    /// Dataflow expected from the fetched artifact.
+    pub dataflow_id: DataflowId,
+    /// Canonical upstream URL or locator.
+    pub source_url: String,
+    /// Adapter-specific metadata needed by fetch/parse.
+    pub metadata: BTreeMap<String, String>,
+}
+
+/// Lightweight reference to a fetched artifact used by parse jobs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ArtifactRef {
+    /// Content-addressed artifact id.
+    pub id: ArtifactId,
+    /// Source that produced the artifact.
+    pub source_id: SourceId,
+    /// Canonical upstream URL.
+    pub source_url: String,
+    /// MIME-style content type.
+    pub content_type: String,
+    /// Persisted storage key.
+    pub storage_key: String,
+    /// On-wire size in bytes.
+    pub size_bytes: u64,
+    /// Fetch completion timestamp.
+    pub fetched_at: DateTime<Utc>,
+}
+
+impl From<Artifact> for ArtifactRef {
+    fn from(artifact: Artifact) -> Self {
+        Self {
+            id: artifact.id,
+            source_id: artifact.source_id,
+            source_url: artifact.source_url,
+            content_type: artifact.content_type,
+            size_bytes: artifact.size_bytes,
+            storage_key: artifact.storage_key,
+            fetched_at: artifact.fetched_at,
+        }
+    }
+}
+
+impl From<ArtifactRef> for Artifact {
+    fn from(reference: ArtifactRef) -> Self {
+        Self {
+            id: reference.id,
+            source_id: reference.source_id,
+            source_url: reference.source_url,
+            content_type: reference.content_type,
+            size_bytes: reference.size_bytes,
+            storage_key: reference.storage_key,
+            fetched_at: reference.fetched_at,
+        }
+    }
+}
+
+/// Source adapter contract implemented by each source-specific crate.
+#[async_trait]
+pub trait SourceAdapter: fmt::Debug + Send + Sync + 'static {
+    /// Stable source id, matching [`AdapterManifest::source_id`].
+    fn id(&self) -> &'static str;
+
+    /// Static adapter metadata and operational policy.
+    fn manifest(&self) -> &AdapterManifest;
+
+    /// Discover upstream work items that should be fetched.
+    async fn discover(&self, ctx: &DiscoveryCtx) -> Result<Vec<DiscoveredJob>, AdapterError>;
+
+    /// Fetch and persist a discovered artifact.
+    async fn fetch(&self, job: DiscoveredJob, ctx: &FetchCtx) -> Result<ArtifactRef, AdapterError>;
+
+    /// Stream parsed observations without buffering a full artifact in memory.
+    fn parse<'a>(&'a self, artifact: ArtifactRef, ctx: &'a ParseCtx) -> ObservationStream<'a>;
+}
+
+/// Immutable registry of source adapters.
+#[derive(Clone)]
+pub struct Adapters {
+    by_id: Arc<BTreeMap<String, Arc<dyn SourceAdapter>>>,
+}
+
+impl fmt::Debug for Adapters {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Adapters")
+            .field("ids", &self.by_id.keys().collect::<Vec<_>>())
+            .finish()
+    }
+}
+
+impl Adapters {
+    /// Start building a registry.
+    #[must_use]
+    pub fn builder() -> AdaptersBuilder {
+        AdaptersBuilder::default()
+    }
+
+    /// Return an adapter by id.
+    pub fn get(&self, id: &str) -> Result<Arc<dyn SourceAdapter>, AdapterError> {
+        self.by_id
+            .get(id)
+            .cloned()
+            .ok_or_else(|| AdapterError::UnknownAdapter(id.to_string()))
+    }
+
+    /// Dispatch discovery by source id.
+    #[tracing::instrument(skip(self, ctx), fields(source = source_id))]
+    pub async fn discover(
+        &self,
+        source_id: &str,
+        ctx: &DiscoveryCtx,
+    ) -> Result<Vec<DiscoveredJob>, AdapterError> {
+        self.get(source_id)?.discover(ctx).await
+    }
+
+    /// Dispatch fetch by source id.
+    #[tracing::instrument(skip(self, ctx), fields(source = source_id, job_id = %job.id))]
+    pub async fn fetch(
+        &self,
+        source_id: &str,
+        job: DiscoveredJob,
+        ctx: &FetchCtx,
+    ) -> Result<ArtifactRef, AdapterError> {
+        self.get(source_id)?.fetch(job, ctx).await
+    }
+
+    /// Dispatch parse by source id.
+    pub fn parse<'a>(
+        &'a self,
+        source_id: &str,
+        artifact: ArtifactRef,
+        ctx: &'a ParseCtx,
+    ) -> Result<ObservationStream<'a>, AdapterError> {
+        let adapter = self
+            .by_id
+            .get(source_id)
+            .ok_or_else(|| AdapterError::UnknownAdapter(source_id.to_string()))?;
+        Ok(adapter.parse(artifact, ctx))
+    }
+
+    /// Number of registered adapters.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.by_id.len()
+    }
+
+    /// `true` when no adapters are registered.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_id.is_empty()
+    }
+}
+
+/// Builder for [`Adapters`].
+#[derive(Debug, Default)]
+pub struct AdaptersBuilder {
+    by_id: BTreeMap<String, Arc<dyn SourceAdapter>>,
+}
+
+impl AdaptersBuilder {
+    /// Register a concrete adapter value.
+    pub fn register<A>(&mut self, adapter: A) -> Result<&mut Self, AdapterError>
+    where
+        A: SourceAdapter,
+    {
+        self.register_arc(Arc::new(adapter))
+    }
+
+    /// Register an already shared adapter.
+    pub fn register_arc(
+        &mut self,
+        adapter: Arc<dyn SourceAdapter>,
+    ) -> Result<&mut Self, AdapterError> {
+        let id = adapter.id();
+        let manifest_id = adapter.manifest().source_id.as_str();
+        if id != manifest_id {
+            return Err(AdapterError::Validation(format!(
+                "adapter id `{id}` does not match manifest source id `{manifest_id}`"
+            )));
+        }
+
+        if self.by_id.contains_key(id) {
+            return Err(AdapterError::DuplicateAdapter(id.to_string()));
+        }
+
+        self.by_id.insert(id.to_string(), adapter);
+        Ok(self)
+    }
+
+    /// Build an immutable registry.
+    #[must_use]
+    pub fn build(self) -> Adapters {
+        Adapters {
+            by_id: Arc::new(self.by_id),
+        }
+    }
+}
+
+/// Errors returned by adapter discovery, fetch, parse, and registry dispatch.
+#[derive(Debug, Error)]
+pub enum AdapterError {
+    /// Shared I/O, JSON, or validation failure.
+    #[error(transparent)]
+    Core(#[from] CoreError),
+
+    /// HTTP client failure.
+    #[error("http: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// Object-storage failure.
+    #[error(transparent)]
+    Storage(#[from] StorageError),
+
+    /// Source-specific adapter was not registered.
+    #[error("unknown adapter: {0}")]
+    UnknownAdapter(String),
+
+    /// Registry contains more than one adapter for the same source.
+    #[error("duplicate adapter: {0}")]
+    DuplicateAdapter(String),
+
+    /// Upstream source format changed or failed parser expectations.
+    #[error("format drift: {0}")]
+    FormatDrift(String),
+
+    /// Caller-supplied or adapter-produced data violated a precondition.
+    #[error("validation: {0}")]
+    Validation(String),
+}
+
+impl Classify for AdapterError {
+    fn class(&self) -> ErrorClass {
+        match self {
+            AdapterError::Core(err) => err.class(),
+            AdapterError::Http(err) => {
+                if err.is_timeout() || err.is_connect() {
+                    ErrorClass::Transient
+                } else if err.is_decode() {
+                    ErrorClass::Permanent
+                } else {
+                    ErrorClass::Transient
+                }
+            }
+            AdapterError::Storage(err) => err.class(),
+            AdapterError::UnknownAdapter(_)
+            | AdapterError::DuplicateAdapter(_)
+            | AdapterError::FormatDrift(_) => ErrorClass::Permanent,
+            AdapterError::Validation(_) => ErrorClass::Validation,
+        }
+    }
+}
+
+mod duration_millis {
+    use std::time::Duration;
+
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S>(duration: &Duration, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_u64(
+            duration
+                .as_millis()
+                .try_into()
+                .map_err(serde::ser::Error::custom)?,
+        )
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Duration, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let millis = u64::deserialize(deserializer)?;
+        Ok(Duration::from_millis(millis))
+    }
+}

--- a/crates/au-kpis-adapter/tests/registry_dispatch.rs
+++ b/crates/au-kpis-adapter/tests/registry_dispatch.rs
@@ -6,11 +6,13 @@ use au_kpis_adapter::{
     DiscoveryCtx, FetchCtx, ObservationStream, ParseCtx, RateLimit, SourceAdapter,
 };
 use au_kpis_domain::{
-    ArtifactId, DataflowId, MeasureId, Observation, ObservationStatus, SeriesDescriptor, SourceId,
-    TimePrecision,
+    Artifact, ArtifactId, DataflowId, MeasureId, Observation, ObservationStatus, SeriesDescriptor,
+    SourceId, TimePrecision,
     ids::{CodeId, DimensionId, SeriesKey},
 };
+use au_kpis_error::{Classify, CoreError, ErrorClass};
 use au_kpis_storage::BlobStore;
+use au_kpis_storage::StorageError;
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
 use futures::{StreamExt, stream};
@@ -211,4 +213,92 @@ fn register_arc_supports_shared_adapter_values() {
     let mut builder = Adapters::builder();
     builder.register_arc(adapter).unwrap();
     assert_eq!(builder.build().len(), 1);
+}
+
+#[test]
+fn rate_limit_rejects_invalid_configurations() {
+    let zero_requests = RateLimit::new(0, Duration::from_secs(1)).unwrap_err();
+    assert!(
+        matches!(zero_requests, AdapterError::Validation(message) if message.contains("max_requests"))
+    );
+
+    let zero_window = RateLimit::new(1, Duration::ZERO).unwrap_err();
+    assert!(matches!(zero_window, AdapterError::Validation(message) if message.contains("window")));
+}
+
+#[test]
+fn adapter_error_classification_matches_retry_policy() {
+    let core = AdapterError::Core(CoreError::Validation("bad input".into()));
+    assert_eq!(core.class(), ErrorClass::Validation);
+
+    let storage = AdapterError::Storage(StorageError::Source("upstream reset".into()));
+    assert_eq!(storage.class(), ErrorClass::Transient);
+
+    assert_eq!(
+        AdapterError::UnknownAdapter("missing".into()).class(),
+        ErrorClass::Permanent
+    );
+    assert_eq!(
+        AdapterError::DuplicateAdapter("stub".into()).class(),
+        ErrorClass::Permanent
+    );
+    assert_eq!(
+        AdapterError::FormatDrift("schema hash changed".into()).class(),
+        ErrorClass::Permanent
+    );
+    assert_eq!(
+        AdapterError::Validation("missing source_url".into()).class(),
+        ErrorClass::Validation
+    );
+}
+
+#[test]
+fn artifact_ref_roundtrips_domain_artifact() {
+    let fetched_at = Utc.with_ymd_and_hms(2026, 4, 28, 1, 2, 3).unwrap();
+    let artifact = Artifact {
+        id: ArtifactId::of_content(b"fixture"),
+        source_id: SourceId::new("stub").unwrap(),
+        source_url: "https://example.test/fixture.json".into(),
+        content_type: "application/json".into(),
+        size_bytes: 7,
+        storage_key: "artifacts/fixture".into(),
+        fetched_at,
+    };
+
+    let reference: ArtifactRef = artifact.clone().into();
+    assert_eq!(reference.id, artifact.id);
+    assert_eq!(Artifact::from(reference), artifact);
+}
+
+#[test]
+fn empty_registry_reports_empty_and_parse_unknown_adapter() {
+    let adapters = Adapters::builder().build();
+    assert!(adapters.is_empty());
+    assert_eq!(adapters.len(), 0);
+
+    let http = AdapterHttpClient::new(RateLimit::new(60, Duration::from_secs(60)).unwrap());
+    let blob_store = BlobStore::new(InMemory::new());
+    let artifact = ArtifactRef {
+        id: ArtifactId::of_content(b"fixture"),
+        source_id: SourceId::new("stub").unwrap(),
+        source_url: "https://example.test/fixture.json".into(),
+        content_type: "application/json".into(),
+        storage_key: "artifacts/fixture".into(),
+        size_bytes: 7,
+        fetched_at: Utc.with_ymd_and_hms(2026, 4, 28, 1, 2, 3).unwrap(),
+    };
+
+    let err = match adapters.parse(
+        "missing",
+        artifact,
+        &ParseCtx::new(
+            http,
+            blob_store,
+            Utc.with_ymd_and_hms(2026, 4, 28, 1, 2, 3).unwrap(),
+        ),
+    ) {
+        Ok(_) => panic!("missing adapter unexpectedly returned a parse stream"),
+        Err(err) => err,
+    };
+    assert!(matches!(err, AdapterError::UnknownAdapter(id) if id == "missing"));
 }

--- a/crates/au-kpis-adapter/tests/registry_dispatch.rs
+++ b/crates/au-kpis-adapter/tests/registry_dispatch.rs
@@ -1,0 +1,214 @@
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use au_kpis_adapter::{
+    AdapterError, AdapterHttpClient, AdapterManifest, Adapters, ArtifactRef, DiscoveredJob,
+    DiscoveryCtx, FetchCtx, ObservationStream, ParseCtx, RateLimit, SourceAdapter,
+};
+use au_kpis_domain::{
+    ArtifactId, DataflowId, MeasureId, Observation, ObservationStatus, SeriesDescriptor, SourceId,
+    TimePrecision,
+    ids::{CodeId, DimensionId, SeriesKey},
+};
+use au_kpis_storage::BlobStore;
+use bytes::Bytes;
+use chrono::{TimeZone, Utc};
+use futures::{StreamExt, stream};
+use object_store::memory::InMemory;
+
+#[derive(Debug)]
+struct StubAdapter {
+    manifest: AdapterManifest,
+}
+
+impl StubAdapter {
+    fn new() -> Self {
+        Self {
+            manifest: AdapterManifest {
+                source_id: SourceId::new("stub").unwrap(),
+                name: "Stub source".into(),
+                version: "test".into(),
+                rate_limit: RateLimit::new(60, Duration::from_secs(60)).unwrap(),
+                dataflows: vec![DataflowId::new("stub.cpi").unwrap()],
+            },
+        }
+    }
+}
+
+#[async_trait]
+impl SourceAdapter for StubAdapter {
+    fn id(&self) -> &'static str {
+        "stub"
+    }
+
+    fn manifest(&self) -> &AdapterManifest {
+        &self.manifest
+    }
+
+    #[tracing::instrument(skip(self, _ctx), fields(source = self.id()))]
+    async fn discover(&self, _ctx: &DiscoveryCtx) -> Result<Vec<DiscoveredJob>, AdapterError> {
+        Ok(vec![DiscoveredJob {
+            id: "job-1".into(),
+            source_id: self.manifest.source_id.clone(),
+            dataflow_id: self.manifest.dataflows[0].clone(),
+            source_url: "https://example.test/cpi.json".into(),
+            metadata: BTreeMap::from([("kind".into(), "fixture".into())]),
+        }])
+    }
+
+    #[tracing::instrument(skip(self, ctx), fields(source = self.id(), job_id = %job.id))]
+    async fn fetch(&self, job: DiscoveredJob, ctx: &FetchCtx) -> Result<ArtifactRef, AdapterError> {
+        let bytes = Bytes::from_static(br#"{"value": 123.4}"#);
+        let id = ctx.blob_store.put_artifact(bytes.clone()).await?;
+        Ok(ArtifactRef {
+            id,
+            source_id: job.source_id,
+            source_url: job.source_url,
+            content_type: "application/json".into(),
+            storage_key: format!("artifacts/{}", id.to_hex()),
+            size_bytes: bytes.len() as u64,
+            fetched_at: ctx.started_at,
+        })
+    }
+
+    fn parse<'a>(&'a self, artifact: ArtifactRef, ctx: &'a ParseCtx) -> ObservationStream<'a> {
+        let dataflow_id = self.manifest.dataflows[0].clone();
+        let dimensions = BTreeMap::from([(
+            DimensionId::new("region").unwrap(),
+            CodeId::new("AUS").unwrap(),
+        )]);
+        let series_key = SeriesKey::derive(
+            &dataflow_id,
+            dimensions
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        );
+        let descriptor = SeriesDescriptor {
+            series_key,
+            dataflow_id,
+            measure_id: MeasureId::new("index").unwrap(),
+            dimensions,
+            unit: "index".into(),
+        };
+        let observation = Observation {
+            series_key,
+            time: Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap(),
+            time_precision: TimePrecision::Quarter,
+            value: Some(123.4),
+            status: ObservationStatus::Normal,
+            revision_no: 0,
+            attributes: BTreeMap::new(),
+            ingested_at: ctx.started_at,
+            source_artifact_id: artifact.id,
+        };
+
+        Box::pin(stream::iter([Ok((descriptor, observation))]))
+    }
+}
+
+#[tokio::test]
+async fn registry_dispatches_discover_fetch_and_parse() {
+    let mut builder = Adapters::builder();
+    builder.register(StubAdapter::new()).unwrap();
+    let adapters = builder.build();
+
+    let http = AdapterHttpClient::new(RateLimit::new(60, Duration::from_secs(60)).unwrap());
+    let blob_store = BlobStore::new(InMemory::new());
+    let started_at = Utc.with_ymd_and_hms(2026, 4, 28, 0, 0, 0).unwrap();
+
+    let jobs = adapters
+        .discover("stub", &DiscoveryCtx::new(http.clone(), started_at))
+        .await
+        .unwrap();
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].id, "job-1");
+
+    let artifact = adapters
+        .fetch(
+            "stub",
+            jobs[0].clone(),
+            &FetchCtx::new(http.clone(), blob_store.clone(), started_at),
+        )
+        .await
+        .unwrap();
+    assert_eq!(artifact.id, ArtifactId::of_content(br#"{"value": 123.4}"#));
+
+    let rows: Vec<_> = adapters
+        .parse(
+            "stub",
+            artifact,
+            &ParseCtx::new(http, blob_store, started_at),
+        )
+        .unwrap()
+        .collect()
+        .await;
+    assert_eq!(rows.len(), 1);
+    let (series, observation) = rows.into_iter().next().unwrap().unwrap();
+    assert_eq!(series.unit, "index");
+    assert_eq!(observation.value, Some(123.4));
+}
+
+#[test]
+fn registry_rejects_duplicate_adapter_ids() {
+    let mut builder = Adapters::builder();
+    builder.register(StubAdapter::new()).unwrap();
+    let err = builder.register(StubAdapter::new()).unwrap_err();
+    assert!(matches!(err, AdapterError::DuplicateAdapter(id) if id == "stub"));
+}
+
+#[test]
+fn registry_rejects_manifest_id_mismatch() {
+    #[derive(Debug)]
+    struct BadAdapter {
+        inner: StubAdapter,
+    }
+
+    #[async_trait]
+    impl SourceAdapter for BadAdapter {
+        fn id(&self) -> &'static str {
+            "other"
+        }
+
+        fn manifest(&self) -> &AdapterManifest {
+            self.inner.manifest()
+        }
+
+        async fn discover(&self, ctx: &DiscoveryCtx) -> Result<Vec<DiscoveredJob>, AdapterError> {
+            self.inner.discover(ctx).await
+        }
+
+        async fn fetch(
+            &self,
+            job: DiscoveredJob,
+            ctx: &FetchCtx,
+        ) -> Result<ArtifactRef, AdapterError> {
+            self.inner.fetch(job, ctx).await
+        }
+
+        fn parse<'a>(&'a self, artifact: ArtifactRef, ctx: &'a ParseCtx) -> ObservationStream<'a> {
+            self.inner.parse(artifact, ctx)
+        }
+    }
+
+    let err = Adapters::builder()
+        .register(BadAdapter {
+            inner: StubAdapter::new(),
+        })
+        .unwrap_err();
+    assert!(matches!(err, AdapterError::Validation(message) if message.contains("does not match")));
+}
+
+#[test]
+fn registry_reports_unknown_adapter() {
+    let adapters = Adapters::builder().build();
+    let err = adapters.get("missing").unwrap_err();
+    assert!(matches!(err, AdapterError::UnknownAdapter(id) if id == "missing"));
+}
+
+#[test]
+fn register_arc_supports_shared_adapter_values() {
+    let adapter: Arc<dyn SourceAdapter> = Arc::new(StubAdapter::new());
+    let mut builder = Adapters::builder();
+    builder.register_arc(adapter).unwrap();
+    assert_eq!(builder.build().len(), 1);
+}


### PR DESCRIPTION
## Summary

- Adds the `au-kpis-adapter` public contract for source adapters, including manifests, rate-limited HTTP contexts, artifact/job references, errors, and registry dispatch.
- Adds a stub adapter integration test that proves discover -> fetch -> parse dispatch through `Adapters`.

## Linked issue

Closes #21

## Pass requirements

- [x] `SourceAdapter` trait per spec (`async-trait`, dyn-safe, `Send + Sync + 'static`)
- [x] `DiscoveryCtx`, `FetchCtx`, `ParseCtx` with rate-limited HTTP client
- [x] `Adapters::builder().register(...).build()` registry pattern
- [x] `AdapterError` enum
- [x] Stub adapter + integration test proving registry dispatch
- [x] `#[tracing::instrument]` on all async method implementations
- [x] Parse returns `BoxStream<(SeriesDescriptor, Observation)>`

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test -p au-kpis-adapter --locked`
- [x] `cargo clippy -p au-kpis-adapter --all-targets --locked -- -D warnings`
- [x] `cargo check --workspace --locked`

## Spec / docs impact

- [x] No Spec changes required
- [ ] Spec amended in this PR
- [ ] Spec amendment filed separately (#)

## Checklist

- [x] Conventional commit title
- [x] No secrets committed
- [x] Tests added/updated
- [x] `cargo fmt` + `biome format` clean
- [x] Clippy / Biome warnings resolved
