### PR TITLE
feat(queue): add postgres job queue (#22)

### DIFF
--- a/.sqlx/query-0e57ad460aa9b2cc97a33a183dc3e7ccf45afce23d4c82cb9ab54f83bb1b970e.json
+++ b/.sqlx/query-0e57ad460aa9b2cc97a33a183dc3e7ccf45afce23d4c82cb9ab54f83bb1b970e.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO queue_cron_schedules\n                (id, stage, cron_expression, payload, trace_parent, enabled)\n             VALUES ($1, $2, $3, $4, $5, $6)\n             ON CONFLICT (id) DO UPDATE\n             SET stage = EXCLUDED.stage,\n                 cron_expression = EXCLUDED.cron_expression,\n                 payload = EXCLUDED.payload,\n                 trace_parent = EXCLUDED.trace_parent,\n                 enabled = EXCLUDED.enabled,\n                 updated_at = now()",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Jsonb",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "0e57ad460aa9b2cc97a33a183dc3e7ccf45afce23d4c82cb9ab54f83bb1b970e"
+}

--- a/.sqlx/query-0e57ad460aa9b2cc97a33a183dc3e7ccf45afce23d4c82cb9ab54f83bb1b970e.json
+++ b/.sqlx/query-0e57ad460aa9b2cc97a33a183dc3e7ccf45afce23d4c82cb9ab54f83bb1b970e.json
@@ -4,14 +4,7 @@
   "describe": {
     "columns": [],
     "parameters": {
-      "Left": [
-        "Text",
-        "Text",
-        "Text",
-        "Jsonb",
-        "Text",
-        "Bool"
-      ]
+      "Left": ["Text", "Text", "Text", "Jsonb", "Text", "Bool"]
     },
     "nullable": []
   },

--- a/.sqlx/query-30faaf5929ed67974e47bd964b703d2bffe36a4b02e4c889ddf8a5acff85b470.json
+++ b/.sqlx/query-30faaf5929ed67974e47bd964b703d2bffe36a4b02e4c889ddf8a5acff85b470.json
@@ -4,15 +4,7 @@
   "describe": {
     "columns": [],
     "parameters": {
-      "Left": [
-        "Int8",
-        "Text",
-        "Jsonb",
-        "Int4",
-        "Text",
-        "Text",
-        "Text"
-      ]
+      "Left": ["Int8", "Text", "Jsonb", "Int4", "Text", "Text", "Text"]
     },
     "nullable": []
   },

--- a/.sqlx/query-30faaf5929ed67974e47bd964b703d2bffe36a4b02e4c889ddf8a5acff85b470.json
+++ b/.sqlx/query-30faaf5929ed67974e47bd964b703d2bffe36a4b02e4c889ddf8a5acff85b470.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO queue_dead_letters\n            (job_id, stage, payload, attempts, error_class, error_message, trace_parent)\n         VALUES ($1, $2, $3, $4, $5, $6, $7)\n         ON CONFLICT (job_id) DO UPDATE\n         SET attempts = EXCLUDED.attempts,\n             error_class = EXCLUDED.error_class,\n             error_message = EXCLUDED.error_message,\n             trace_parent = EXCLUDED.trace_parent,\n             failed_at = now()",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text",
+        "Jsonb",
+        "Int4",
+        "Text",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "30faaf5929ed67974e47bd964b703d2bffe36a4b02e4c889ddf8a5acff85b470"
+}

--- a/.sqlx/query-3300a1f7b8bda705478bf54c4a3eca18f96ace7eeea8ed07d89d7b6f74f098f2.json
+++ b/.sqlx/query-3300a1f7b8bda705478bf54c4a3eca18f96ace7eeea8ed07d89d7b6f74f098f2.json
@@ -4,11 +4,7 @@
   "describe": {
     "columns": [],
     "parameters": {
-      "Left": [
-        "Int8",
-        "Text",
-        "Int8"
-      ]
+      "Left": ["Int8", "Text", "Int8"]
     },
     "nullable": []
   },

--- a/.sqlx/query-3300a1f7b8bda705478bf54c4a3eca18f96ace7eeea8ed07d89d7b6f74f098f2.json
+++ b/.sqlx/query-3300a1f7b8bda705478bf54c4a3eca18f96ace7eeea8ed07d89d7b6f74f098f2.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE queue_jobs\n             SET status = 'completed',\n                 locked_by = NULL,\n                 locked_at = NULL,\n                 updated_at = now()\n             WHERE id = $1\n               AND status = 'running'\n               AND locked_by = $2\n               AND lease_version = $3",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "3300a1f7b8bda705478bf54c4a3eca18f96ace7eeea8ed07d89d7b6f74f098f2"
+}

--- a/.sqlx/query-b1fab8f460bbdec1f999350a933d7663746e4100eb785a73231545898435d409.json
+++ b/.sqlx/query-b1fab8f460bbdec1f999350a933d7663746e4100eb785a73231545898435d409.json
@@ -4,13 +4,7 @@
   "describe": {
     "columns": [],
     "parameters": {
-      "Left": [
-        "Int8",
-        "Text",
-        "Int8",
-        "Text",
-        "Int8"
-      ]
+      "Left": ["Int8", "Text", "Int8", "Text", "Int8"]
     },
     "nullable": []
   },

--- a/.sqlx/query-b1fab8f460bbdec1f999350a933d7663746e4100eb785a73231545898435d409.json
+++ b/.sqlx/query-b1fab8f460bbdec1f999350a933d7663746e4100eb785a73231545898435d409.json
@@ -1,0 +1,18 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE queue_jobs\n         SET status = 'pending',\n             locked_by = NULL,\n             locked_at = NULL,\n             run_at = now() + ($3::BIGINT * INTERVAL '1 millisecond'),\n             last_error = $4,\n             updated_at = now()\n         WHERE id = $1\n           AND status = 'running'\n           AND locked_by = $2\n           AND lease_version = $5",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text",
+        "Int8",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b1fab8f460bbdec1f999350a933d7663746e4100eb785a73231545898435d409"
+}

--- a/.sqlx/query-bb89a76683a0b8e0a2942ff9b54012db924868e53b0fa0e207e3ab4ee7070f6b.json
+++ b/.sqlx/query-bb89a76683a0b8e0a2942ff9b54012db924868e53b0fa0e207e3ab4ee7070f6b.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT job_id, payload AS \"payload!: serde_json::Value\", attempts,\n                      error_class, error_message, failed_at\n             FROM queue_dead_letters\n             WHERE job_id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "job_id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "payload!: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "error_class",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "failed_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "bb89a76683a0b8e0a2942ff9b54012db924868e53b0fa0e207e3ab4ee7070f6b"
+}

--- a/.sqlx/query-bb89a76683a0b8e0a2942ff9b54012db924868e53b0fa0e207e3ab4ee7070f6b.json
+++ b/.sqlx/query-bb89a76683a0b8e0a2942ff9b54012db924868e53b0fa0e207e3ab4ee7070f6b.json
@@ -35,18 +35,9 @@
       }
     ],
     "parameters": {
-      "Left": [
-        "Int8"
-      ]
+      "Left": ["Int8"]
     },
-    "nullable": [
-      false,
-      false,
-      false,
-      false,
-      false,
-      false
-    ]
+    "nullable": [false, false, false, false, false, false]
   },
   "hash": "bb89a76683a0b8e0a2942ff9b54012db924868e53b0fa0e207e3ab4ee7070f6b"
 }

--- a/.sqlx/query-c69da0e6dc9ed85c83edad120bd87d282d6affabd53021ccedbf1c11da1dde9a.json
+++ b/.sqlx/query-c69da0e6dc9ed85c83edad120bd87d282d6affabd53021ccedbf1c11da1dde9a.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE queue_jobs\n             SET locked_at = now(),\n                 lease_version = lease_version + 1,\n                 updated_at = now()\n             WHERE id = $1\n               AND status = 'running'\n               AND locked_by = $2\n               AND lease_version = $3\n             RETURNING id,\n                       payload AS \"payload!: serde_json::Value\",\n                       attempts,\n                       locked_at AS \"locked_at!: DateTime<Utc>\",\n                       lease_version",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "payload!: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "locked_at!: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "lease_version",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "c69da0e6dc9ed85c83edad120bd87d282d6affabd53021ccedbf1c11da1dde9a"
+}

--- a/.sqlx/query-c69da0e6dc9ed85c83edad120bd87d282d6affabd53021ccedbf1c11da1dde9a.json
+++ b/.sqlx/query-c69da0e6dc9ed85c83edad120bd87d282d6affabd53021ccedbf1c11da1dde9a.json
@@ -30,19 +30,9 @@
       }
     ],
     "parameters": {
-      "Left": [
-        "Int8",
-        "Text",
-        "Int8"
-      ]
+      "Left": ["Int8", "Text", "Int8"]
     },
-    "nullable": [
-      false,
-      false,
-      false,
-      true,
-      false
-    ]
+    "nullable": [false, false, false, true, false]
   },
   "hash": "c69da0e6dc9ed85c83edad120bd87d282d6affabd53021ccedbf1c11da1dde9a"
 }

--- a/.sqlx/query-ca2c8e65d3af64b6244ea3550c2ba6c433f27abad0598801ce9c98f8b3de9295.json
+++ b/.sqlx/query-ca2c8e65d3af64b6244ea3550c2ba6c433f27abad0598801ce9c98f8b3de9295.json
@@ -30,19 +30,9 @@
       }
     ],
     "parameters": {
-      "Left": [
-        "Text",
-        "Text",
-        "Int8"
-      ]
+      "Left": ["Text", "Text", "Int8"]
     },
-    "nullable": [
-      false,
-      false,
-      false,
-      true,
-      false
-    ]
+    "nullable": [false, false, false, true, false]
   },
   "hash": "ca2c8e65d3af64b6244ea3550c2ba6c433f27abad0598801ce9c98f8b3de9295"
 }

--- a/.sqlx/query-ca2c8e65d3af64b6244ea3550c2ba6c433f27abad0598801ce9c98f8b3de9295.json
+++ b/.sqlx/query-ca2c8e65d3af64b6244ea3550c2ba6c433f27abad0598801ce9c98f8b3de9295.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH candidate AS (\n                     SELECT q.id\n                     FROM queue_jobs q\n                     WHERE q.stage = $1\n                       AND (\n                           (q.status = 'pending' AND q.run_at <= now())\n                           OR (\n                               q.status = 'running'\n                               AND q.locked_at <= now() - ($3::BIGINT * INTERVAL '1 millisecond')\n                           )\n                       )\n                       AND (\n                           q.job_group_key IS NULL\n                           OR pg_try_advisory_xact_lock(hashtext(q.job_group_key))\n                       )\n                       AND (\n                           q.job_group_key IS NULL\n                           OR q.status = 'running'\n                           OR NOT EXISTS (\n                               SELECT 1\n                               FROM queue_jobs running\n                               WHERE running.status = 'running'\n                                 AND running.job_group_key = q.job_group_key\n                           )\n                       )\n                     ORDER BY q.priority DESC, q.run_at ASC, q.id ASC\n                     LIMIT 1\n                     FOR UPDATE SKIP LOCKED\n                 )\n                 UPDATE queue_jobs q\n                 SET status = 'running',\n                     locked_by = $2,\n                     locked_at = now(),\n                     lease_version = lease_version + 1,\n                     attempts = attempts + 1,\n                     updated_at = now()\n                 FROM candidate\n                 WHERE q.id = candidate.id\n                 RETURNING q.id,\n                           q.payload AS \"payload!: serde_json::Value\",\n                           q.attempts,\n                           q.locked_at AS \"locked_at!: DateTime<Utc>\",\n                           q.lease_version",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 1,
+        "name": "payload!: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 2,
+        "name": "attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 3,
+        "name": "locked_at!: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 4,
+        "name": "lease_version",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true,
+      false
+    ]
+  },
+  "hash": "ca2c8e65d3af64b6244ea3550c2ba6c433f27abad0598801ce9c98f8b3de9295"
+}

--- a/.sqlx/query-d2ebdfcb2af7fa858c3fb820abfb8d6a3aaabe6ca9c973f315c3dca6e54479d5.json
+++ b/.sqlx/query-d2ebdfcb2af7fa858c3fb820abfb8d6a3aaabe6ca9c973f315c3dca6e54479d5.json
@@ -4,9 +4,7 @@
   "describe": {
     "columns": [],
     "parameters": {
-      "Left": [
-        "Int8"
-      ]
+      "Left": ["Int8"]
     },
     "nullable": []
   },

--- a/.sqlx/query-d2ebdfcb2af7fa858c3fb820abfb8d6a3aaabe6ca9c973f315c3dca6e54479d5.json
+++ b/.sqlx/query-d2ebdfcb2af7fa858c3fb820abfb8d6a3aaabe6ca9c973f315c3dca6e54479d5.json
@@ -1,0 +1,14 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "DELETE FROM queue_jobs WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d2ebdfcb2af7fa858c3fb820abfb8d6a3aaabe6ca9c973f315c3dca6e54479d5"
+}

--- a/.sqlx/query-d7d5474cbfe5332298e407e1d7960a7b7c56e2b9b8399c10d260da90bd1ff772.json
+++ b/.sqlx/query-d7d5474cbfe5332298e407e1d7960a7b7c56e2b9b8399c10d260da90bd1ff772.json
@@ -10,18 +10,9 @@
       }
     ],
     "parameters": {
-      "Left": [
-        "Text",
-        "Jsonb",
-        "Int4",
-        "Int4",
-        "Text",
-        "Text"
-      ]
+      "Left": ["Text", "Jsonb", "Int4", "Int4", "Text", "Text"]
     },
-    "nullable": [
-      false
-    ]
+    "nullable": [false]
   },
   "hash": "d7d5474cbfe5332298e407e1d7960a7b7c56e2b9b8399c10d260da90bd1ff772"
 }

--- a/.sqlx/query-d7d5474cbfe5332298e407e1d7960a7b7c56e2b9b8399c10d260da90bd1ff772.json
+++ b/.sqlx/query-d7d5474cbfe5332298e407e1d7960a7b7c56e2b9b8399c10d260da90bd1ff772.json
@@ -1,0 +1,27 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO queue_jobs\n                (stage, payload, priority, max_attempts, trace_parent, job_group_key)\n             VALUES ($1, $2, $3, $4, $5, $6)\n             RETURNING id",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Jsonb",
+        "Int4",
+        "Int4",
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "d7d5474cbfe5332298e407e1d7960a7b7c56e2b9b8399c10d260da90bd1ff772"
+}

--- a/.sqlx/query-de8c0bf5a29e15ab6a16cf217f6568bcc6bb7654cc93005bde605f8873c42967.json
+++ b/.sqlx/query-de8c0bf5a29e15ab6a16cf217f6568bcc6bb7654cc93005bde605f8873c42967.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT id, cron_expression, payload AS \"payload!: serde_json::Value\", enabled\n             FROM queue_cron_schedules\n             WHERE id = $1",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "cron_expression",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "payload!: serde_json::Value",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "enabled",
+        "type_info": "Bool"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "de8c0bf5a29e15ab6a16cf217f6568bcc6bb7654cc93005bde605f8873c42967"
+}

--- a/.sqlx/query-de8c0bf5a29e15ab6a16cf217f6568bcc6bb7654cc93005bde605f8873c42967.json
+++ b/.sqlx/query-de8c0bf5a29e15ab6a16cf217f6568bcc6bb7654cc93005bde605f8873c42967.json
@@ -25,16 +25,9 @@
       }
     ],
     "parameters": {
-      "Left": [
-        "Text"
-      ]
+      "Left": ["Text"]
     },
-    "nullable": [
-      false,
-      false,
-      false,
-      false
-    ]
+    "nullable": [false, false, false, false]
   },
   "hash": "de8c0bf5a29e15ab6a16cf217f6568bcc6bb7654cc93005bde605f8873c42967"
 }

--- a/.sqlx/query-e8f890bc5c5f636e469eda26984cb3bc79a56d2bb5362d3aca600d6cacd14e73.json
+++ b/.sqlx/query-e8f890bc5c5f636e469eda26984cb3bc79a56d2bb5362d3aca600d6cacd14e73.json
@@ -12,9 +12,7 @@
     "parameters": {
       "Left": []
     },
-    "nullable": [
-      false
-    ]
+    "nullable": [false]
   },
   "hash": "e8f890bc5c5f636e469eda26984cb3bc79a56d2bb5362d3aca600d6cacd14e73"
 }

--- a/.sqlx/query-e8f890bc5c5f636e469eda26984cb3bc79a56d2bb5362d3aca600d6cacd14e73.json
+++ b/.sqlx/query-e8f890bc5c5f636e469eda26984cb3bc79a56d2bb5362d3aca600d6cacd14e73.json
@@ -12,7 +12,9 @@
     "parameters": {
       "Left": []
     },
-    "nullable": [false]
+    "nullable": [
+      false
+    ]
   },
   "hash": "e8f890bc5c5f636e469eda26984cb3bc79a56d2bb5362d3aca600d6cacd14e73"
 }

--- a/.sqlx/query-eb4aa5e900bcde4a6736ecb2ff48d7f77d38b50289185ebe1d4693acdafd5d0c.json
+++ b/.sqlx/query-eb4aa5e900bcde4a6736ecb2ff48d7f77d38b50289185ebe1d4693acdafd5d0c.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE queue_jobs\n         SET status = 'dead',\n             locked_by = NULL,\n             locked_at = NULL,\n             last_error = $3,\n             updated_at = now()\n         WHERE id = $1\n           AND status = 'running'\n           AND locked_by = $2\n           AND lease_version = $4",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Text",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "eb4aa5e900bcde4a6736ecb2ff48d7f77d38b50289185ebe1d4693acdafd5d0c"
+}

--- a/.sqlx/query-eb4aa5e900bcde4a6736ecb2ff48d7f77d38b50289185ebe1d4693acdafd5d0c.json
+++ b/.sqlx/query-eb4aa5e900bcde4a6736ecb2ff48d7f77d38b50289185ebe1d4693acdafd5d0c.json
@@ -4,12 +4,7 @@
   "describe": {
     "columns": [],
     "parameters": {
-      "Left": [
-        "Int8",
-        "Text",
-        "Text",
-        "Int8"
-      ]
+      "Left": ["Int8", "Text", "Text", "Int8"]
     },
     "nullable": []
   },

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,21 @@ version = "0.1.0"
 [[package]]
 name = "au-kpis-queue"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "au-kpis-config",
+ "au-kpis-db",
+ "au-kpis-domain",
+ "au-kpis-error",
+ "au-kpis-testing",
+ "chrono",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "au-kpis-scheduler"

--- a/Spec.md
+++ b/Spec.md
@@ -530,7 +530,7 @@ Each source = its own crate implementing `SourceAdapter`. Adding source 15 never
 
 ### Queue abstraction + semantics
 
-`au-kpis-queue` exposes a `Queue` trait (push, pop, ack, nack, schedule-cron) with a Postgres implementation using transactional leasing. The rest of the codebase depends on the trait — this implementation is swappable with `apalis` if we later want its worker runtime or scheduler model.
+`au-kpis-queue` exposes a `Queue` trait (push, pop, renew, ack, nack, schedule-cron) with a Postgres implementation using transactional leasing. Workers must periodically renew long-running leases; ack/nack operations are accepted only for the current lease handle. The rest of the codebase depends on the trait — this implementation is swappable with `apalis` if we later want its worker runtime or scheduler model.
 
 - **`discovery`** — cron-triggered per adapter schedule. Cheap.
 - **`fetch`** — rate-limited per source (Tower layer on HTTP client + queue-level concurrency). Streams raw to S3 via `object_store`.
@@ -538,7 +538,7 @@ Each source = its own crate implementing `SourceAdapter`. Adding source 15 never
 - **`load`** — DB upserts. Serialized per `(dataflow_id)` via job-group keys to avoid upsert conflicts on shared series.
 - **`backfill`** — low priority queue for historical re-ingest; paused when live queues have backlog.
 
-Postgres-backed jobs = transactional dequeue (`FOR UPDATE SKIP LOCKED`), no separate job store to operate. Retries + exponential backoff built in. Dead-letter queue per stage. Running jobs carry a lease timeout so crashed workers do not strand work; `load` job groups are enforced with database constraints so only one running job per `dataflow_id` exists at a time.
+Postgres-backed jobs = transactional dequeue (`FOR UPDATE SKIP LOCKED`), no separate job store to operate. Retries + exponential backoff built in. Dead-letter queue per stage, retained independently of queue job retention. Running jobs carry a renewable lease timeout so crashed workers do not strand work; `load` job groups are enforced with database constraints so only one running job per `dataflow_id` exists at a time.
 
 **Tracing context propagation**: every job carries a `trace_parent` field; worker restores span from it before processing, so traces span discovery → load as a single tree.
 

--- a/Spec.md
+++ b/Spec.md
@@ -96,7 +96,7 @@ returns clean, validated, SDMX-compliant time series regardless of upstream sour
 | **SDK** | **TypeScript**, generated from OpenAPI (`openapi-typescript` + orval + hand-written ergonomic wrapper) | Consumer language; typed; tree-shakeable; Bun/Node/browser/Deno compatible |
 | **Client** | **TypeScript (Vite + React + TanStack Query + shadcn/ui)** | Reference app demonstrating SDK |
 | **DB** | **Timescale Cloud (Postgres 16 + TimescaleDB)** | Hypertables, continuous aggregates, compression; managed ops |
-| **Queue** | **`apalis` (Postgres backend)** behind an internal `Queue` trait | One fewer infra piece; transactional dequeue; retries + cron built-in; trait lets us swap later |
+| **Queue** | **Postgres-backed `Queue` trait implementation** | One fewer infra piece; transactional dequeue; retries + cron registration built in; trait lets us swap to `apalis` later |
 | **Cache + rate limit** | **Redis (`fred`)** | Token bucket, ETags, hot-path caching |
 | **Blob store** | **Cloudflare R2** via `object_store` crate | Egress-free; artifacts retained indefinitely; lifecycle → cold after 1y |
 | **OpenAPI gen** | **`utoipa` + `utoipa-axum`** | Compile-time derivation, stays in sync with handlers |
@@ -131,7 +131,7 @@ australian-kpis/
 │   ├── au-kpis-db/                         # sqlx + Timescale queries
 │   ├── au-kpis-storage/                    # object_store wrapper for S3/R2
 │   ├── au-kpis-cache/                      # Redis cache abstraction
-│   ├── au-kpis-queue/                      # apalis wrapper: job types, scheduling
+│   ├── au-kpis-queue/                      # Postgres queue: job types, scheduling
 │   ├── au-kpis-auth/                       # API key validation, Redis rate limiter
 │   ├── au-kpis-pdf-client/                 # HTTP client for Python sidecar
 │   ├── au-kpis-adapter/                    # Adapter trait + base helpers (discover/fetch/parse)
@@ -232,7 +232,6 @@ opentelemetry = "0.27"
 opentelemetry-otlp = "0.27"
 utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }
 utoipa-axum = "0.1"
-apalis = { version = "0.6", features = ["postgres", "cron"] }
 object_store = { version = "0.11", features = ["aws"] }
 calamine = "0.26"
 polars = { version = "0.44", features = ["lazy", "parquet", "csv", "json"] }
@@ -531,7 +530,7 @@ Each source = its own crate implementing `SourceAdapter`. Adding source 15 never
 
 ### Queue abstraction + semantics
 
-`au-kpis-queue` exposes a `Queue` trait (push, pop, ack, nack, schedule-cron) with `apalis` as the first implementation. The rest of the codebase depends on the trait — `apalis` is swappable with a hand-rolled PG queue (~200 lines using `FOR UPDATE SKIP LOCKED`) if apalis becomes a bottleneck or we outgrow its model.
+`au-kpis-queue` exposes a `Queue` trait (push, pop, ack, nack, schedule-cron) with a Postgres implementation using transactional leasing. The rest of the codebase depends on the trait — this implementation is swappable with `apalis` if we later want its worker runtime or scheduler model.
 
 - **`discovery`** — cron-triggered per adapter schedule. Cheap.
 - **`fetch`** — rate-limited per source (Tower layer on HTTP client + queue-level concurrency). Streams raw to S3 via `object_store`.
@@ -539,7 +538,7 @@ Each source = its own crate implementing `SourceAdapter`. Adding source 15 never
 - **`load`** — DB upserts. Serialized per `(dataflow_id)` via job-group keys to avoid upsert conflicts on shared series.
 - **`backfill`** — low priority queue for historical re-ingest; paused when live queues have backlog.
 
-Postgres-backed jobs = transactional dequeue (`FOR UPDATE SKIP LOCKED`), no separate job store to operate. Retries + exponential backoff built in. Dead-letter queue per stage.
+Postgres-backed jobs = transactional dequeue (`FOR UPDATE SKIP LOCKED`), no separate job store to operate. Retries + exponential backoff built in. Dead-letter queue per stage. Running jobs carry a lease timeout so crashed workers do not strand work; `load` job groups are enforced with database constraints so only one running job per `dataflow_id` exists at a time.
 
 **Tracing context propagation**: every job carries a `trace_parent` field; worker restores span from it before processing, so traces span discovery → load as a single tree.
 
@@ -552,7 +551,7 @@ Postgres-backed jobs = transactional dequeue (`FOR UPDATE SKIP LOCKED`), no sepa
 
 ### Failure handling
 
-- **Transient** (5xx, timeout): retry via apalis `RetryPolicy`, max 5, exp backoff, DLQ.
+- **Transient** (5xx, timeout): retry via queue retry policy, max 5, exp backoff, DLQ.
 - **Format error** (validation fails): pause adapter + Grafana alert + capture raw for review. **No retry** — format changed, human decides.
 - **Partial parse**: validated observations load; failures → `parse_errors` with artifact pointer.
 - **Circuit breaker**: per-source `tower` layer opens on >20%/50 fetch fail rate; pages on-call.
@@ -1214,7 +1213,7 @@ Each phase ends demo-able.
 ### Phase 2 — One end-to-end source: ABS CPI (2.5 weeks)
 - [ ] `au-kpis-adapter` trait crate + registry
 - [ ] `crates/adapters/abs` (`au-kpis-adapter-abs`) — CPI dataflow (SDMX-JSON: `CPI` dataflow, monthly + quarterly)
-- [ ] `au-kpis-queue` (`Queue` trait + apalis/Postgres impl)
+- [ ] `au-kpis-queue` (`Queue` trait + Postgres impl)
 - [ ] `au-kpis-ingestion-core` + worker binary with graceful shutdown
 - [ ] `au-kpis-loader` with COPY-based batch upsert + series upsert-on-first-observation
 - [ ] `/v1/observations` endpoint with JSON + CSV (Parquet in Phase 3)
@@ -1335,7 +1334,7 @@ Pass 1 over the plan. Fixes applied in-place:
 1. **Series vs Observation split** — added explicit `series` table so dimensions aren't duplicated across millions of observation rows. Hot table (`observations`) stays narrow: `(series_key, time, revision_no, value, status, attributes, artifact_id)`. Dimensional queries ("all VIC CPI") go through `series` with GIN index, then join to hypertable.
 2. **Revision handling** — `revision_no` as part of PK rather than `revision_of` pointer. Simpler. `observations_latest` view (continuous aggregate) is the default query target.
 3. **`SeriesKey` as a newtype** — type-safe at every boundary; prevents string/id mix-ups.
-4. **Queue trait abstraction** — `au-kpis-queue` exports a `Queue` trait; `apalis` is implementation #1, swappable for custom PG queue later. Business logic depends on the trait.
+4. **Queue trait abstraction** — `au-kpis-queue` exports a `Queue` trait backed by Postgres transactional leasing. Business logic depends on the trait, so the backend remains swappable later.
 5. **`async-trait` justified** — adapters live behind `Arc<dyn SourceAdapter>` for the registry pattern; native async-fn-in-trait does not yet support this cleanly. Revisit when Rust stabilises dyn-compat for async.
 6. **Tracing context propagation** — jobs carry `trace_parent`; workers reconstruct span. Traces span discovery→load as one tree, not one-per-worker-task.
 7. **Adapter registry pattern** — `Adapters::builder().register(abs::new()).build()` in ingestion binary. Adding a source = one line. No central switch statement.

--- a/Spec.md
+++ b/Spec.md
@@ -530,7 +530,7 @@ Each source = its own crate implementing `SourceAdapter`. Adding source 15 never
 
 ### Queue abstraction + semantics
 
-`au-kpis-queue` exposes a `Queue` trait (push, pop, renew, ack, nack, schedule-cron) with a Postgres implementation using transactional leasing. Workers must periodically renew long-running leases; ack/nack operations are accepted only for the current lease handle. The rest of the codebase depends on the trait — this implementation is swappable with `apalis` if we later want its worker runtime or scheduler model.
+`au-kpis-queue` exposes a `Queue` trait (push, pop, renew, ack, nack, schedule-cron) with a Postgres implementation using transactional leasing. Workers must periodically renew long-running leases; ack/nack operations are accepted only for the current monotonic lease token. The rest of the codebase depends on the trait — this implementation is swappable with `apalis` if we later want its worker runtime or scheduler model.
 
 - **`discovery`** — cron-triggered per adapter schedule. Cheap.
 - **`fetch`** — rate-limited per source (Tower layer on HTTP client + queue-level concurrency). Streams raw to S3 via `object_store`.

--- a/crates/au-kpis-queue/Cargo.toml
+++ b/crates/au-kpis-queue/Cargo.toml
@@ -8,3 +8,24 @@ repository.workspace = true
 description = "apalis wrapper: job types, scheduling."
 
 [dependencies]
+async-trait = "0.1"
+au-kpis-domain = { workspace = true }
+au-kpis-error = { workspace = true }
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio",
+    "tls-rustls",
+    "postgres",
+    "chrono",
+    "json",
+] }
+thiserror = "2"
+tracing = "0.1"
+
+[dev-dependencies]
+au-kpis-config = { workspace = true }
+au-kpis-db = { workspace = true }
+au-kpis-testing = { workspace = true }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/au-kpis-queue/src/lib.rs
+++ b/crates/au-kpis-queue/src/lib.rs
@@ -787,7 +787,7 @@ async fn dead_letter(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult
 }
 
 fn default_backoff(attempts: i32) -> Duration {
-    let shift = attempts.saturating_sub(1).min(6) as u32;
+    let shift = attempts.saturating_sub(1).clamp(0, 6) as u32;
     Duration::from_secs(1_u64 << shift)
 }
 
@@ -864,5 +864,107 @@ mod tests {
     #[test]
     fn worker_id_rejects_blank_values() {
         assert!(WorkerId::new(" ").is_err());
+    }
+
+    #[test]
+    fn queue_stage_parses_known_values_and_rejects_unknown_values() {
+        let cases = [
+            ("discover", QueueStage::Discover),
+            ("fetch", QueueStage::Fetch),
+            ("parse", QueueStage::Parse),
+            ("load", QueueStage::Load),
+            ("backfill", QueueStage::Backfill),
+        ];
+
+        for (raw, expected) in cases {
+            let parsed = raw.parse::<QueueStage>().expect("stage should parse");
+            assert_eq!(parsed, expected);
+            assert_eq!(parsed.to_string(), raw);
+        }
+
+        let err = "other".parse::<QueueStage>().expect_err("unknown stage");
+        assert_eq!(err.class(), ErrorClass::Validation);
+    }
+
+    #[test]
+    fn job_builders_assign_expected_stage_and_defaults() {
+        let source_id = SourceId::new("abs").unwrap();
+        let dataflow_id = DataflowId::new("abs.cpi").unwrap();
+        let cases = [
+            Job::discover(source_id.clone()),
+            Job::fetch("job-a", source_id.clone()),
+            Job::parse(source_id.clone(), "artifact-a", "raw/abs/a.pdf"),
+            Job::load(dataflow_id, "artifact-a"),
+            Job::backfill(source_id, None),
+        ];
+
+        for job in cases {
+            assert_eq!(job.stage(), job.kind().stage());
+            assert_eq!(job.priority(), 0);
+            assert_eq!(job.max_attempts(), 5);
+            assert!(job.trace_parent().is_none());
+        }
+    }
+
+    #[test]
+    fn job_metadata_builders_store_values_and_clamp_attempts() {
+        let job = Job::discover(SourceId::new("abs").unwrap())
+            .with_priority(10)
+            .with_max_attempts(0)
+            .with_trace_parent("trace-a");
+
+        assert_eq!(job.priority(), 10);
+        assert_eq!(job.max_attempts(), 1);
+        assert_eq!(job.trace_parent(), Some("trace-a"));
+    }
+
+    #[test]
+    fn cron_schedule_validation_covers_empty_fields_and_updates() {
+        let job = Job::discover(SourceId::new("abs").unwrap());
+
+        assert!(CronSchedule::new(" ", "0 8 * * *", job.clone()).is_err());
+        assert!(CronSchedule::new("abs-cpi", " ", job.clone()).is_err());
+
+        let schedule =
+            CronSchedule::new("abs-cpi", "0 8 * * *", job).expect("schedule should be valid");
+        assert_eq!(schedule.id(), "abs-cpi");
+        assert_eq!(schedule.cron_expression(), "0 8 * * *");
+        assert!(schedule.enabled());
+
+        assert!(schedule.clone().with_cron_expression(" ").is_err());
+        let updated = schedule
+            .with_cron_expression("0 9 * * *")
+            .expect("cron expression should update");
+        assert_eq!(updated.cron_expression(), "0 9 * * *");
+    }
+
+    #[test]
+    fn default_backoff_doubles_until_capped() {
+        assert_eq!(default_backoff(0), Duration::from_secs(1));
+        assert_eq!(default_backoff(1), Duration::from_secs(1));
+        assert_eq!(default_backoff(2), Duration::from_secs(2));
+        assert_eq!(default_backoff(7), Duration::from_secs(64));
+        assert_eq!(default_backoff(99), Duration::from_secs(64));
+    }
+
+    #[test]
+    fn queue_error_classifies_variants() {
+        assert_eq!(
+            QueueError::Validation("bad".to_string()).class(),
+            ErrorClass::Validation
+        );
+        assert_eq!(
+            QueueError::LeaseLost(JobId::new(42)).class(),
+            ErrorClass::Validation
+        );
+        assert_eq!(
+            QueueError::Db(sqlx::Error::RowNotFound).class(),
+            ErrorClass::Transient
+        );
+
+        let json_err: QueueError = serde_json::from_str::<Job>("not json")
+            .expect_err("invalid json")
+            .into();
+        assert_eq!(json_err.class(), ErrorClass::Validation);
     }
 }

--- a/crates/au-kpis-queue/src/lib.rs
+++ b/crates/au-kpis-queue/src/lib.rs
@@ -1,1 +1,868 @@
-//! apalis wrapper: job types, scheduling.
+//! Postgres-backed queue abstraction for ingestion jobs.
+//!
+//! This crate owns the queue-facing contract used by schedulers and
+//! ingestion workers. The implementation is intentionally small and
+//! SQL-visible: jobs are leased transactionally with `FOR UPDATE SKIP
+//! LOCKED`, retries are persisted, and terminal failures are copied to
+//! a dead-letter table for operator review.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::{fmt, str::FromStr, time::Duration};
+
+use async_trait::async_trait;
+use au_kpis_domain::{DataflowId, SourceId};
+use au_kpis_error::{Classify, CoreError, ErrorClass};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{PgPool, Row};
+use thiserror::Error;
+
+/// Result alias for queue operations.
+pub type QueueResult<T> = Result<T, QueueError>;
+
+/// Durable queue stage. Each variant maps to one logical ingestion queue.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum QueueStage {
+    /// Adapter discovery jobs.
+    Discover,
+    /// Artifact fetch jobs.
+    Fetch,
+    /// Artifact parse jobs.
+    Parse,
+    /// Observation load jobs.
+    Load,
+    /// Historical backfill jobs.
+    Backfill,
+}
+
+impl QueueStage {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Discover => "discover",
+            Self::Fetch => "fetch",
+            Self::Parse => "parse",
+            Self::Load => "load",
+            Self::Backfill => "backfill",
+        }
+    }
+}
+
+impl fmt::Display for QueueStage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for QueueStage {
+    type Err = QueueError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "discover" => Ok(Self::Discover),
+            "fetch" => Ok(Self::Fetch),
+            "parse" => Ok(Self::Parse),
+            "load" => Ok(Self::Load),
+            "backfill" => Ok(Self::Backfill),
+            other => Err(QueueError::Validation(format!(
+                "unknown queue stage `{other}`"
+            ))),
+        }
+    }
+}
+
+/// Identifier for a persisted queue job.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct JobId(i64);
+
+impl JobId {
+    /// Construct from the database identity value.
+    #[must_use]
+    pub const fn new(value: i64) -> Self {
+        Self(value)
+    }
+
+    /// Return the database identity value.
+    #[must_use]
+    pub const fn get(self) -> i64 {
+        self.0
+    }
+}
+
+impl fmt::Display for JobId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Worker identifier recorded on leases.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct WorkerId(String);
+
+impl WorkerId {
+    /// Construct a worker id.
+    pub fn new(value: impl Into<String>) -> QueueResult<Self> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            return Err(QueueError::Validation(
+                "worker id must not be empty".to_string(),
+            ));
+        }
+        Ok(Self(value))
+    }
+
+    /// Borrow the worker id string.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Queue job payload variants.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum JobKind {
+    /// Ask an adapter to discover upstream work.
+    Discover {
+        /// Source to discover.
+        source_id: SourceId,
+    },
+    /// Fetch a source-local discovered job.
+    Fetch {
+        /// Source-local discovered job id.
+        job_id: String,
+        /// Source that emitted the job.
+        source_id: SourceId,
+    },
+    /// Parse a stored artifact.
+    Parse {
+        /// Source that produced the artifact.
+        source_id: SourceId,
+        /// Content-addressed artifact id or hex digest.
+        artifact_id: String,
+        /// Object-storage key for the artifact.
+        storage_key: String,
+    },
+    /// Load parsed observations for a dataflow/artifact pair.
+    Load {
+        /// Dataflow being loaded.
+        dataflow_id: DataflowId,
+        /// Artifact being loaded.
+        artifact_id: String,
+    },
+    /// Historical backfill trigger.
+    Backfill {
+        /// Source to backfill.
+        source_id: SourceId,
+        /// Optional dataflow scope.
+        dataflow_id: Option<DataflowId>,
+    },
+}
+
+impl JobKind {
+    /// Stage that owns this job.
+    #[must_use]
+    pub const fn stage(&self) -> QueueStage {
+        match self {
+            Self::Discover { .. } => QueueStage::Discover,
+            Self::Fetch { .. } => QueueStage::Fetch,
+            Self::Parse { .. } => QueueStage::Parse,
+            Self::Load { .. } => QueueStage::Load,
+            Self::Backfill { .. } => QueueStage::Backfill,
+        }
+    }
+}
+
+/// Persisted queue job with operational metadata.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Job {
+    kind: JobKind,
+    trace_parent: Option<String>,
+    priority: i32,
+    max_attempts: i32,
+}
+
+impl Job {
+    /// Construct a discovery job.
+    #[must_use]
+    pub fn discover(source_id: SourceId) -> Self {
+        Self::new(JobKind::Discover { source_id })
+    }
+
+    /// Construct a fetch job.
+    #[must_use]
+    pub fn fetch(job_id: impl Into<String>, source_id: SourceId) -> Self {
+        Self::new(JobKind::Fetch {
+            job_id: job_id.into(),
+            source_id,
+        })
+    }
+
+    /// Construct a parse job.
+    #[must_use]
+    pub fn parse(
+        source_id: SourceId,
+        artifact_id: impl Into<String>,
+        storage_key: impl Into<String>,
+    ) -> Self {
+        Self::new(JobKind::Parse {
+            source_id,
+            artifact_id: artifact_id.into(),
+            storage_key: storage_key.into(),
+        })
+    }
+
+    /// Construct a load job.
+    #[must_use]
+    pub fn load(dataflow_id: DataflowId, artifact_id: impl Into<String>) -> Self {
+        Self::new(JobKind::Load {
+            dataflow_id,
+            artifact_id: artifact_id.into(),
+        })
+    }
+
+    /// Construct a backfill job.
+    #[must_use]
+    pub fn backfill(source_id: SourceId, dataflow_id: Option<DataflowId>) -> Self {
+        Self::new(JobKind::Backfill {
+            source_id,
+            dataflow_id,
+        })
+    }
+
+    /// Construct from a concrete kind.
+    #[must_use]
+    pub fn new(kind: JobKind) -> Self {
+        Self {
+            kind,
+            trace_parent: None,
+            priority: 0,
+            max_attempts: 5,
+        }
+    }
+
+    /// Borrow the job kind.
+    #[must_use]
+    pub const fn kind(&self) -> &JobKind {
+        &self.kind
+    }
+
+    /// Owning stage.
+    #[must_use]
+    pub const fn stage(&self) -> QueueStage {
+        self.kind.stage()
+    }
+
+    /// Optional W3C trace context propagated across queue hops.
+    #[must_use]
+    pub fn trace_parent(&self) -> Option<&str> {
+        self.trace_parent.as_deref()
+    }
+
+    /// Queue priority. Higher values are leased first.
+    #[must_use]
+    pub const fn priority(&self) -> i32 {
+        self.priority
+    }
+
+    /// Maximum attempts before dead-lettering.
+    #[must_use]
+    pub const fn max_attempts(&self) -> i32 {
+        self.max_attempts
+    }
+
+    /// Add a W3C trace context to the job.
+    #[must_use]
+    pub fn with_trace_parent(mut self, trace_parent: impl Into<String>) -> Self {
+        self.trace_parent = Some(trace_parent.into());
+        self
+    }
+
+    /// Set queue priority.
+    #[must_use]
+    pub const fn with_priority(mut self, priority: i32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Set maximum attempts. Values less than one are clamped to one.
+    #[must_use]
+    pub fn with_max_attempts(mut self, max_attempts: i32) -> Self {
+        self.max_attempts = max_attempts.max(1);
+        self
+    }
+
+    fn job_group_key(&self) -> Option<String> {
+        match &self.kind {
+            JobKind::Load { dataflow_id, .. } => Some(format!("load:{dataflow_id}")),
+            _ => None,
+        }
+    }
+}
+
+/// A leased job returned by [`Queue::pop`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LeasedJob {
+    id: JobId,
+    job: Job,
+    worker_id: WorkerId,
+    attempts: i32,
+    leased_at: DateTime<Utc>,
+}
+
+impl LeasedJob {
+    /// Persisted job id.
+    #[must_use]
+    pub const fn id(&self) -> JobId {
+        self.id
+    }
+
+    /// Borrow the payload and metadata.
+    #[must_use]
+    pub const fn job(&self) -> &Job {
+        &self.job
+    }
+
+    /// Worker that owns this lease.
+    #[must_use]
+    pub const fn worker_id(&self) -> &WorkerId {
+        &self.worker_id
+    }
+
+    /// Attempt number for this lease.
+    #[must_use]
+    pub const fn attempts(&self) -> i32 {
+        self.attempts
+    }
+
+    /// Lease timestamp.
+    #[must_use]
+    pub const fn leased_at(&self) -> DateTime<Utc> {
+        self.leased_at
+    }
+
+    /// Trace context copied from the job.
+    #[must_use]
+    pub fn trace_parent(&self) -> Option<&str> {
+        self.job.trace_parent()
+    }
+}
+
+/// Nack policy supplied when a worker cannot complete a job.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Nack {
+    error_class: ErrorClass,
+    message: String,
+    retry_after: Option<Duration>,
+}
+
+impl Nack {
+    /// Construct a nack reason.
+    #[must_use]
+    pub fn new(error_class: ErrorClass, message: impl Into<String>) -> Self {
+        Self {
+            error_class,
+            message: message.into(),
+            retry_after: None,
+        }
+    }
+
+    /// Override the default exponential backoff delay.
+    #[must_use]
+    pub const fn with_retry_after(mut self, retry_after: Duration) -> Self {
+        self.retry_after = Some(retry_after);
+        self
+    }
+}
+
+/// Dead-lettered job snapshot.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeadLetteredJob {
+    id: JobId,
+    job: Job,
+    attempts: i32,
+    error_class: String,
+    error_message: String,
+    failed_at: DateTime<Utc>,
+}
+
+impl DeadLetteredJob {
+    /// Original job id.
+    #[must_use]
+    pub const fn id(&self) -> JobId {
+        self.id
+    }
+
+    /// Original job payload.
+    #[must_use]
+    pub const fn job(&self) -> &Job {
+        &self.job
+    }
+
+    /// Attempts consumed before dead-lettering.
+    #[must_use]
+    pub const fn attempts(&self) -> i32 {
+        self.attempts
+    }
+
+    /// Error class string persisted for review.
+    #[must_use]
+    pub fn error_class(&self) -> &str {
+        &self.error_class
+    }
+
+    /// Terminal error message.
+    #[must_use]
+    pub fn error_message(&self) -> &str {
+        &self.error_message
+    }
+
+    /// Dead-letter timestamp.
+    #[must_use]
+    pub const fn failed_at(&self) -> DateTime<Utc> {
+        self.failed_at
+    }
+}
+
+/// Cron registration persisted for schedulers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CronSchedule {
+    id: String,
+    cron_expression: String,
+    job: Job,
+    enabled: bool,
+}
+
+impl CronSchedule {
+    /// Construct a schedule registration.
+    pub fn new(
+        id: impl Into<String>,
+        cron_expression: impl Into<String>,
+        job: Job,
+    ) -> QueueResult<Self> {
+        let id = id.into();
+        if id.trim().is_empty() {
+            return Err(QueueError::Validation(
+                "schedule id must not be empty".to_string(),
+            ));
+        }
+        let cron_expression = cron_expression.into();
+        if cron_expression.trim().is_empty() {
+            return Err(QueueError::Validation(
+                "cron expression must not be empty".to_string(),
+            ));
+        }
+        Ok(Self {
+            id,
+            cron_expression,
+            job,
+            enabled: true,
+        })
+    }
+
+    /// Schedule id.
+    #[must_use]
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Cron expression string.
+    #[must_use]
+    pub fn cron_expression(&self) -> &str {
+        &self.cron_expression
+    }
+
+    /// Job emitted by this schedule.
+    #[must_use]
+    pub const fn job(&self) -> &Job {
+        &self.job
+    }
+
+    /// Whether the schedule is enabled.
+    #[must_use]
+    pub const fn enabled(&self) -> bool {
+        self.enabled
+    }
+
+    /// Return a copy with a new cron expression.
+    pub fn with_cron_expression(mut self, cron_expression: impl Into<String>) -> QueueResult<Self> {
+        let cron_expression = cron_expression.into();
+        if cron_expression.trim().is_empty() {
+            return Err(QueueError::Validation(
+                "cron expression must not be empty".to_string(),
+            ));
+        }
+        self.cron_expression = cron_expression;
+        Ok(self)
+    }
+}
+
+/// Queue operations used by scheduler and ingestion workers.
+#[async_trait]
+pub trait Queue: fmt::Debug + Send + Sync {
+    /// Push a job into its owning stage.
+    async fn push(&self, job: Job) -> QueueResult<JobId>;
+
+    /// Lease the next ready job for a stage.
+    async fn pop(&self, stage: QueueStage, worker_id: WorkerId) -> QueueResult<Option<LeasedJob>>;
+
+    /// Mark a leased job complete.
+    async fn ack(&self, job: &LeasedJob) -> QueueResult<()>;
+
+    /// Release, retry, or dead-letter a leased job.
+    async fn nack(&self, job: &LeasedJob, nack: Nack) -> QueueResult<()>;
+
+    /// Register or update a cron schedule.
+    async fn schedule(&self, schedule: CronSchedule) -> QueueResult<()>;
+}
+
+/// Postgres-backed queue implementation.
+#[derive(Debug, Clone)]
+pub struct ApalisPgQueue {
+    pool: PgPool,
+}
+
+impl ApalisPgQueue {
+    /// Construct a queue from a configured Postgres pool.
+    #[must_use]
+    pub const fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    /// Borrow the underlying pool.
+    #[must_use]
+    pub const fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
+    /// Fetch a dead-lettered job by original job id.
+    #[tracing::instrument(skip(self))]
+    pub async fn dead_lettered(&self, id: JobId) -> QueueResult<DeadLetteredJob> {
+        let row = sqlx::query(
+            "SELECT job_id, payload, attempts, error_class, error_message, failed_at
+             FROM queue_dead_letters
+             WHERE job_id = $1",
+        )
+        .bind(id.get())
+        .fetch_one(&self.pool)
+        .await
+        .map_err(QueueError::Db)?;
+
+        Ok(DeadLetteredJob {
+            id,
+            job: serde_json::from_value(row.get("payload"))?,
+            attempts: row.get("attempts"),
+            error_class: row.get("error_class"),
+            error_message: row.get("error_message"),
+            failed_at: row.get("failed_at"),
+        })
+    }
+
+    /// Fetch a schedule by id.
+    #[tracing::instrument(skip(self))]
+    pub async fn schedule_by_id(&self, id: &str) -> QueueResult<Option<CronSchedule>> {
+        let row = sqlx::query(
+            "SELECT id, cron_expression, payload, enabled
+             FROM queue_cron_schedules
+             WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(QueueError::Db)?;
+
+        row.map(schedule_from_row).transpose()
+    }
+}
+
+#[async_trait]
+impl Queue for ApalisPgQueue {
+    #[tracing::instrument(skip(self, job), fields(stage = %job.stage()))]
+    async fn push(&self, job: Job) -> QueueResult<JobId> {
+        let payload = serde_json::to_value(&job)?;
+        let row = sqlx::query(
+            "INSERT INTO queue_jobs
+                (stage, payload, priority, max_attempts, trace_parent, job_group_key)
+             VALUES ($1, $2, $3, $4, $5, $6)
+             RETURNING id",
+        )
+        .bind(job.stage().as_str())
+        .bind(payload)
+        .bind(job.priority())
+        .bind(job.max_attempts())
+        .bind(job.trace_parent())
+        .bind(job.job_group_key())
+        .fetch_one(&self.pool)
+        .await
+        .map_err(QueueError::Db)?;
+
+        Ok(JobId::new(row.get("id")))
+    }
+
+    #[tracing::instrument(skip(self, worker_id), fields(stage = %stage, worker = worker_id.as_str()))]
+    async fn pop(&self, stage: QueueStage, worker_id: WorkerId) -> QueueResult<Option<LeasedJob>> {
+        let row = sqlx::query(
+            "WITH candidate AS (
+                 SELECT q.id
+                 FROM queue_jobs q
+                 WHERE q.stage = $1
+                   AND q.status = 'pending'
+                   AND q.run_at <= now()
+                   AND (
+                       q.job_group_key IS NULL
+                       OR NOT EXISTS (
+                           SELECT 1
+                           FROM queue_jobs running
+                           WHERE running.status = 'running'
+                             AND running.job_group_key = q.job_group_key
+                       )
+                   )
+                 ORDER BY q.priority DESC, q.run_at ASC, q.id ASC
+                 LIMIT 1
+                 FOR UPDATE SKIP LOCKED
+             )
+             UPDATE queue_jobs q
+             SET status = 'running',
+                 locked_by = $2,
+                 locked_at = now(),
+                 attempts = attempts + 1,
+                 updated_at = now()
+             FROM candidate
+             WHERE q.id = candidate.id
+             RETURNING q.id, q.payload, q.attempts, q.locked_at",
+        )
+        .bind(stage.as_str())
+        .bind(worker_id.as_str())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(QueueError::Db)?;
+
+        row.map(|row| leased_from_row(row, worker_id)).transpose()
+    }
+
+    #[tracing::instrument(skip(self, job), fields(job_id = %job.id()))]
+    async fn ack(&self, job: &LeasedJob) -> QueueResult<()> {
+        let result = sqlx::query(
+            "UPDATE queue_jobs
+             SET status = 'completed',
+                 locked_by = NULL,
+                 locked_at = NULL,
+                 updated_at = now()
+             WHERE id = $1
+               AND status = 'running'
+               AND locked_by = $2",
+        )
+        .bind(job.id().get())
+        .bind(job.worker_id().as_str())
+        .execute(&self.pool)
+        .await
+        .map_err(QueueError::Db)?;
+
+        if result.rows_affected() == 0 {
+            return Err(QueueError::LeaseLost(job.id()));
+        }
+        Ok(())
+    }
+
+    #[tracing::instrument(skip(self, job, nack), fields(job_id = %job.id()))]
+    async fn nack(&self, job: &LeasedJob, nack: Nack) -> QueueResult<()> {
+        if !nack.error_class.is_retryable() || job.attempts() >= job.job().max_attempts() {
+            dead_letter(&self.pool, job, &nack).await
+        } else {
+            retry_job(&self.pool, job, &nack).await
+        }
+    }
+
+    #[tracing::instrument(skip(self, schedule), fields(schedule = schedule.id()))]
+    async fn schedule(&self, schedule: CronSchedule) -> QueueResult<()> {
+        let payload = serde_json::to_value(schedule.job())?;
+        sqlx::query(
+            "INSERT INTO queue_cron_schedules
+                (id, stage, cron_expression, payload, trace_parent, enabled)
+             VALUES ($1, $2, $3, $4, $5, $6)
+             ON CONFLICT (id) DO UPDATE
+             SET stage = EXCLUDED.stage,
+                 cron_expression = EXCLUDED.cron_expression,
+                 payload = EXCLUDED.payload,
+                 trace_parent = EXCLUDED.trace_parent,
+                 enabled = EXCLUDED.enabled,
+                 updated_at = now()",
+        )
+        .bind(schedule.id())
+        .bind(schedule.job().stage().as_str())
+        .bind(schedule.cron_expression())
+        .bind(payload)
+        .bind(schedule.job().trace_parent())
+        .bind(schedule.enabled())
+        .execute(&self.pool)
+        .await
+        .map_err(QueueError::Db)?;
+        Ok(())
+    }
+}
+
+async fn retry_job(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult<()> {
+    let retry_after_ms = nack
+        .retry_after
+        .unwrap_or_else(|| default_backoff(job.attempts()))
+        .as_millis()
+        .min(i64::MAX as u128) as i64;
+
+    let result = sqlx::query(
+        "UPDATE queue_jobs
+         SET status = 'pending',
+             locked_by = NULL,
+             locked_at = NULL,
+             run_at = now() + ($3 * INTERVAL '1 millisecond'),
+             last_error = $4,
+             updated_at = now()
+         WHERE id = $1
+           AND status = 'running'
+           AND locked_by = $2",
+    )
+    .bind(job.id().get())
+    .bind(job.worker_id().as_str())
+    .bind(retry_after_ms)
+    .bind(&nack.message)
+    .execute(pool)
+    .await
+    .map_err(QueueError::Db)?;
+
+    if result.rows_affected() == 0 {
+        return Err(QueueError::LeaseLost(job.id()));
+    }
+    Ok(())
+}
+
+async fn dead_letter(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult<()> {
+    let mut tx = pool.begin().await.map_err(QueueError::Db)?;
+    let result = sqlx::query(
+        "UPDATE queue_jobs
+         SET status = 'dead',
+             locked_by = NULL,
+             locked_at = NULL,
+             last_error = $3,
+             updated_at = now()
+         WHERE id = $1
+           AND status = 'running'
+           AND locked_by = $2",
+    )
+    .bind(job.id().get())
+    .bind(job.worker_id().as_str())
+    .bind(&nack.message)
+    .execute(&mut *tx)
+    .await
+    .map_err(QueueError::Db)?;
+
+    if result.rows_affected() == 0 {
+        return Err(QueueError::LeaseLost(job.id()));
+    }
+
+    sqlx::query(
+        "INSERT INTO queue_dead_letters
+            (job_id, stage, payload, attempts, error_class, error_message, trace_parent)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)
+         ON CONFLICT (job_id) DO UPDATE
+         SET attempts = EXCLUDED.attempts,
+             error_class = EXCLUDED.error_class,
+             error_message = EXCLUDED.error_message,
+             trace_parent = EXCLUDED.trace_parent,
+             failed_at = now()",
+    )
+    .bind(job.id().get())
+    .bind(job.job().stage().as_str())
+    .bind(serde_json::to_value(job.job())?)
+    .bind(job.attempts())
+    .bind(format!("{:?}", nack.error_class))
+    .bind(&nack.message)
+    .bind(job.trace_parent())
+    .execute(&mut *tx)
+    .await
+    .map_err(QueueError::Db)?;
+
+    tx.commit().await.map_err(QueueError::Db)?;
+    Ok(())
+}
+
+fn default_backoff(attempts: i32) -> Duration {
+    let shift = attempts.saturating_sub(1).min(6) as u32;
+    Duration::from_secs(1_u64 << shift)
+}
+
+fn leased_from_row(row: sqlx::postgres::PgRow, worker_id: WorkerId) -> QueueResult<LeasedJob> {
+    Ok(LeasedJob {
+        id: JobId::new(row.get("id")),
+        job: serde_json::from_value(row.get("payload"))?,
+        worker_id,
+        attempts: row.get("attempts"),
+        leased_at: row.get("locked_at"),
+    })
+}
+
+fn schedule_from_row(row: sqlx::postgres::PgRow) -> QueueResult<CronSchedule> {
+    let mut schedule = CronSchedule::new(
+        row.get::<String, _>("id"),
+        row.get::<String, _>("cron_expression"),
+        serde_json::from_value(row.get("payload"))?,
+    )?;
+    schedule.enabled = row.get("enabled");
+    Ok(schedule)
+}
+
+/// Errors returned by queue operations.
+#[derive(Debug, Error)]
+pub enum QueueError {
+    /// Shared validation, JSON, or I/O failure.
+    #[error(transparent)]
+    Core(#[from] CoreError),
+
+    /// JSON serialisation/deserialisation failure.
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// Database operation failure.
+    #[error("db: {0}")]
+    Db(#[source] sqlx::Error),
+
+    /// Caller supplied invalid data.
+    #[error("validation: {0}")]
+    Validation(String),
+
+    /// The lease was no longer owned by the supplied worker.
+    #[error("queue lease lost for job {0}")]
+    LeaseLost(JobId),
+}
+
+impl Classify for QueueError {
+    fn class(&self) -> ErrorClass {
+        match self {
+            Self::Core(err) => err.class(),
+            Self::Json(_) | Self::Validation(_) | Self::LeaseLost(_) => ErrorClass::Validation,
+            Self::Db(_) => ErrorClass::Transient,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn load_jobs_have_per_dataflow_group_key() {
+        let job = Job::load(DataflowId::new("abs.cpi").unwrap(), "artifact-a");
+        assert_eq!(job.job_group_key().as_deref(), Some("load:abs.cpi"));
+    }
+
+    #[test]
+    fn non_load_jobs_do_not_have_group_keys() {
+        let job = Job::discover(SourceId::new("abs").unwrap());
+        assert!(job.job_group_key().is_none());
+    }
+
+    #[test]
+    fn worker_id_rejects_blank_values() {
+        assert!(WorkerId::new(" ").is_err());
+    }
+}

--- a/crates/au-kpis-queue/src/lib.rs
+++ b/crates/au-kpis-queue/src/lib.rs
@@ -22,6 +22,9 @@ use thiserror::Error;
 /// Result alias for queue operations.
 pub type QueueResult<T> = Result<T, QueueError>;
 
+/// Default lease timeout before a running job can be reclaimed by another worker.
+pub const DEFAULT_LEASE_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
 /// Durable queue stage. Each variant maps to one logical ingestion queue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -522,19 +525,36 @@ pub trait Queue: fmt::Debug + Send + Sync {
 #[derive(Debug, Clone)]
 pub struct ApalisPgQueue {
     pool: PgPool,
+    lease_timeout: Duration,
 }
 
 impl ApalisPgQueue {
     /// Construct a queue from a configured Postgres pool.
     #[must_use]
     pub const fn new(pool: PgPool) -> Self {
-        Self { pool }
+        Self {
+            pool,
+            lease_timeout: DEFAULT_LEASE_TIMEOUT,
+        }
+    }
+
+    /// Override the lease timeout used to reclaim jobs from crashed workers.
+    #[must_use]
+    pub const fn with_lease_timeout(mut self, lease_timeout: Duration) -> Self {
+        self.lease_timeout = lease_timeout;
+        self
     }
 
     /// Borrow the underlying pool.
     #[must_use]
     pub const fn pool(&self) -> &PgPool {
         &self.pool
+    }
+
+    /// Lease timeout used to reclaim jobs from crashed workers.
+    #[must_use]
+    pub const fn lease_timeout(&self) -> Duration {
+        self.lease_timeout
     }
 
     /// Fetch a dead-lettered job by original job id.
@@ -603,13 +623,22 @@ impl Queue for ApalisPgQueue {
 
     #[tracing::instrument(skip(self, worker_id), fields(stage = %stage, worker = worker_id.as_str()))]
     async fn pop(&self, stage: QueueStage, worker_id: WorkerId) -> QueueResult<Option<LeasedJob>> {
-        let row = sqlx::query(
+        let row = match sqlx::query(
             "WITH candidate AS (
                  SELECT q.id
                  FROM queue_jobs q
                  WHERE q.stage = $1
-                   AND q.status = 'pending'
-                   AND q.run_at <= now()
+                   AND (
+                       (q.status = 'pending' AND q.run_at <= now())
+                       OR (
+                           q.status = 'running'
+                           AND q.locked_at <= now() - ($3 * INTERVAL '1 millisecond')
+                       )
+                   )
+                   AND (
+                       q.job_group_key IS NULL
+                       OR pg_try_advisory_xact_lock(hashtext(q.job_group_key))
+                   )
                    AND (
                        q.job_group_key IS NULL
                        OR NOT EXISTS (
@@ -617,6 +646,8 @@ impl Queue for ApalisPgQueue {
                            FROM queue_jobs running
                            WHERE running.status = 'running'
                              AND running.job_group_key = q.job_group_key
+                             AND running.id <> q.id
+                             AND running.locked_at > now() - ($3 * INTERVAL '1 millisecond')
                        )
                    )
                  ORDER BY q.priority DESC, q.run_at ASC, q.id ASC
@@ -635,9 +666,14 @@ impl Queue for ApalisPgQueue {
         )
         .bind(stage.as_str())
         .bind(worker_id.as_str())
+        .bind(duration_millis_i64(self.lease_timeout))
         .fetch_optional(&self.pool)
         .await
-        .map_err(QueueError::Db)?;
+        {
+            Ok(row) => row,
+            Err(err) if is_unique_violation(&err) => return Ok(None),
+            Err(err) => return Err(QueueError::Db(err)),
+        };
 
         row.map(|row| leased_from_row(row, worker_id)).transpose()
     }
@@ -789,6 +825,17 @@ async fn dead_letter(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult
 fn default_backoff(attempts: i32) -> Duration {
     let shift = attempts.saturating_sub(1).clamp(0, 6) as u32;
     Duration::from_secs(1_u64 << shift)
+}
+
+fn duration_millis_i64(duration: Duration) -> i64 {
+    duration.as_millis().min(i64::MAX as u128) as i64
+}
+
+fn is_unique_violation(err: &sqlx::Error) -> bool {
+    err.as_database_error()
+        .and_then(|db_err| db_err.code())
+        .as_deref()
+        == Some("23505")
 }
 
 fn leased_from_row(row: sqlx::postgres::PgRow, worker_id: WorkerId) -> QueueResult<LeasedJob> {

--- a/crates/au-kpis-queue/src/lib.rs
+++ b/crates/au-kpis-queue/src/lib.rs
@@ -24,6 +24,7 @@ pub type QueueResult<T> = Result<T, QueueError>;
 
 /// Default lease timeout before a running job can be reclaimed by another worker.
 pub const DEFAULT_LEASE_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+const POP_CONFLICT_RETRIES: usize = 8;
 
 /// Durable queue stage. Each variant maps to one logical ingestion queue.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -514,6 +515,9 @@ pub trait Queue: fmt::Debug + Send + Sync {
     /// Mark a leased job complete.
     async fn ack(&self, job: &LeasedJob) -> QueueResult<()>;
 
+    /// Extend a running lease and return the refreshed lease handle.
+    async fn renew(&self, job: &LeasedJob) -> QueueResult<LeasedJob>;
+
     /// Release, retry, or dead-letter a leased job.
     async fn nack(&self, job: &LeasedJob, nack: Nack) -> QueueResult<()>;
 
@@ -623,59 +627,64 @@ impl Queue for ApalisPgQueue {
 
     #[tracing::instrument(skip(self, worker_id), fields(stage = %stage, worker = worker_id.as_str()))]
     async fn pop(&self, stage: QueueStage, worker_id: WorkerId) -> QueueResult<Option<LeasedJob>> {
-        let row = match sqlx::query(
-            "WITH candidate AS (
-                 SELECT q.id
-                 FROM queue_jobs q
-                 WHERE q.stage = $1
-                   AND (
-                       (q.status = 'pending' AND q.run_at <= now())
-                       OR (
-                           q.status = 'running'
-                           AND q.locked_at <= now() - ($3 * INTERVAL '1 millisecond')
+        for attempt in 0..POP_CONFLICT_RETRIES {
+            let row = match sqlx::query(
+                "WITH candidate AS (
+                     SELECT q.id
+                     FROM queue_jobs q
+                     WHERE q.stage = $1
+                       AND (
+                           (q.status = 'pending' AND q.run_at <= now())
+                           OR (
+                               q.status = 'running'
+                               AND q.locked_at <= now() - ($3 * INTERVAL '1 millisecond')
+                           )
                        )
-                   )
-                   AND (
-                       q.job_group_key IS NULL
-                       OR pg_try_advisory_xact_lock(hashtext(q.job_group_key))
-                   )
-                   AND (
-                       q.job_group_key IS NULL
-                       OR NOT EXISTS (
-                           SELECT 1
-                           FROM queue_jobs running
-                           WHERE running.status = 'running'
-                             AND running.job_group_key = q.job_group_key
-                             AND running.id <> q.id
-                             AND running.locked_at > now() - ($3 * INTERVAL '1 millisecond')
+                       AND (
+                           q.job_group_key IS NULL
+                           OR pg_try_advisory_xact_lock(hashtext(q.job_group_key))
                        )
-                   )
-                 ORDER BY q.priority DESC, q.run_at ASC, q.id ASC
-                 LIMIT 1
-                 FOR UPDATE SKIP LOCKED
-             )
-             UPDATE queue_jobs q
-             SET status = 'running',
-                 locked_by = $2,
-                 locked_at = now(),
-                 attempts = attempts + 1,
-                 updated_at = now()
-             FROM candidate
-             WHERE q.id = candidate.id
-             RETURNING q.id, q.payload, q.attempts, q.locked_at",
-        )
-        .bind(stage.as_str())
-        .bind(worker_id.as_str())
-        .bind(duration_millis_i64(self.lease_timeout))
-        .fetch_optional(&self.pool)
-        .await
-        {
-            Ok(row) => row,
-            Err(err) if is_unique_violation(&err) => return Ok(None),
-            Err(err) => return Err(QueueError::Db(err)),
-        };
+                       AND (
+                           q.job_group_key IS NULL
+                           OR q.status = 'running'
+                           OR NOT EXISTS (
+                               SELECT 1
+                               FROM queue_jobs running
+                               WHERE running.status = 'running'
+                                 AND running.job_group_key = q.job_group_key
+                           )
+                       )
+                     ORDER BY q.priority DESC, q.run_at ASC, q.id ASC
+                     LIMIT 1
+                     FOR UPDATE SKIP LOCKED
+                 )
+                 UPDATE queue_jobs q
+                 SET status = 'running',
+                     locked_by = $2,
+                     locked_at = now(),
+                     attempts = attempts + 1,
+                     updated_at = now()
+                 FROM candidate
+                 WHERE q.id = candidate.id
+                 RETURNING q.id, q.payload, q.attempts, q.locked_at",
+            )
+            .bind(stage.as_str())
+            .bind(worker_id.as_str())
+            .bind(duration_millis_i64(self.lease_timeout))
+            .fetch_optional(&self.pool)
+            .await
+            {
+                Ok(row) => row,
+                Err(err) if is_unique_violation(&err) && attempt + 1 < POP_CONFLICT_RETRIES => {
+                    continue;
+                }
+                Err(err) => return Err(QueueError::Db(err)),
+            };
 
-        row.map(|row| leased_from_row(row, worker_id)).transpose()
+            return row.map(|row| leased_from_row(row, worker_id)).transpose();
+        }
+
+        Ok(None)
     }
 
     #[tracing::instrument(skip(self, job), fields(job_id = %job.id()))]
@@ -688,10 +697,12 @@ impl Queue for ApalisPgQueue {
                  updated_at = now()
              WHERE id = $1
                AND status = 'running'
-               AND locked_by = $2",
+               AND locked_by = $2
+               AND locked_at = $3",
         )
         .bind(job.id().get())
         .bind(job.worker_id().as_str())
+        .bind(job.leased_at())
         .execute(&self.pool)
         .await
         .map_err(QueueError::Db)?;
@@ -700,6 +711,30 @@ impl Queue for ApalisPgQueue {
             return Err(QueueError::LeaseLost(job.id()));
         }
         Ok(())
+    }
+
+    #[tracing::instrument(skip(self, job), fields(job_id = %job.id()))]
+    async fn renew(&self, job: &LeasedJob) -> QueueResult<LeasedJob> {
+        let row = sqlx::query(
+            "UPDATE queue_jobs
+             SET locked_at = now(),
+                 updated_at = now()
+             WHERE id = $1
+               AND status = 'running'
+               AND locked_by = $2
+               AND locked_at = $3
+             RETURNING id, payload, attempts, locked_at",
+        )
+        .bind(job.id().get())
+        .bind(job.worker_id().as_str())
+        .bind(job.leased_at())
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(QueueError::Db)?;
+
+        row.map(|row| leased_from_row(row, job.worker_id().clone()))
+            .transpose()?
+            .ok_or(QueueError::LeaseLost(job.id()))
     }
 
     #[tracing::instrument(skip(self, job, nack), fields(job_id = %job.id()))]
@@ -756,12 +791,14 @@ async fn retry_job(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult<(
              updated_at = now()
          WHERE id = $1
            AND status = 'running'
-           AND locked_by = $2",
+           AND locked_by = $2
+           AND locked_at = $5",
     )
     .bind(job.id().get())
     .bind(job.worker_id().as_str())
     .bind(retry_after_ms)
     .bind(&nack.message)
+    .bind(job.leased_at())
     .execute(pool)
     .await
     .map_err(QueueError::Db)?;
@@ -783,11 +820,13 @@ async fn dead_letter(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult
              updated_at = now()
          WHERE id = $1
            AND status = 'running'
-           AND locked_by = $2",
+           AND locked_by = $2
+           AND locked_at = $4",
     )
     .bind(job.id().get())
     .bind(job.worker_id().as_str())
     .bind(&nack.message)
+    .bind(job.leased_at())
     .execute(&mut *tx)
     .await
     .map_err(QueueError::Db)?;

--- a/crates/au-kpis-queue/src/lib.rs
+++ b/crates/au-kpis-queue/src/lib.rs
@@ -16,7 +16,7 @@ use au_kpis_domain::{DataflowId, SourceId};
 use au_kpis_error::{Classify, CoreError, ErrorClass};
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
-use sqlx::{PgPool, Row};
+use sqlx::PgPool;
 use thiserror::Error;
 
 /// Result alias for queue operations.
@@ -314,6 +314,7 @@ pub struct LeasedJob {
     worker_id: WorkerId,
     attempts: i32,
     leased_at: DateTime<Utc>,
+    lease_version: i64,
 }
 
 impl LeasedJob {
@@ -345,6 +346,12 @@ impl LeasedJob {
     #[must_use]
     pub const fn leased_at(&self) -> DateTime<Utc> {
         self.leased_at
+    }
+
+    /// Monotonic token identifying the current lease ownership.
+    #[must_use]
+    pub const fn lease_version(&self) -> i64 {
+        self.lease_version
     }
 
     /// Trace context copied from the job.
@@ -564,40 +571,50 @@ impl ApalisPgQueue {
     /// Fetch a dead-lettered job by original job id.
     #[tracing::instrument(skip(self))]
     pub async fn dead_lettered(&self, id: JobId) -> QueueResult<DeadLetteredJob> {
-        let row = sqlx::query(
-            "SELECT job_id, payload, attempts, error_class, error_message, failed_at
+        let row = sqlx::query!(
+            r#"SELECT job_id, payload AS "payload!: serde_json::Value", attempts,
+                      error_class, error_message, failed_at
              FROM queue_dead_letters
-             WHERE job_id = $1",
+             WHERE job_id = $1"#,
+            id.get()
         )
-        .bind(id.get())
         .fetch_one(&self.pool)
         .await
         .map_err(QueueError::Db)?;
 
         Ok(DeadLetteredJob {
-            id,
-            job: serde_json::from_value(row.get("payload"))?,
-            attempts: row.get("attempts"),
-            error_class: row.get("error_class"),
-            error_message: row.get("error_message"),
-            failed_at: row.get("failed_at"),
+            id: JobId::new(row.job_id),
+            job: serde_json::from_value(row.payload)?,
+            attempts: row.attempts,
+            error_class: row.error_class,
+            error_message: row.error_message,
+            failed_at: row.failed_at,
         })
     }
 
     /// Fetch a schedule by id.
     #[tracing::instrument(skip(self))]
     pub async fn schedule_by_id(&self, id: &str) -> QueueResult<Option<CronSchedule>> {
-        let row = sqlx::query(
-            "SELECT id, cron_expression, payload, enabled
+        let row = sqlx::query!(
+            r#"SELECT id, cron_expression, payload AS "payload!: serde_json::Value", enabled
              FROM queue_cron_schedules
-             WHERE id = $1",
+             WHERE id = $1"#,
+            id
         )
-        .bind(id)
         .fetch_optional(&self.pool)
         .await
         .map_err(QueueError::Db)?;
 
-        row.map(schedule_from_row).transpose()
+        row.map(|row| {
+            let mut schedule = CronSchedule::new(
+                row.id,
+                row.cron_expression,
+                serde_json::from_value(row.payload)?,
+            )?;
+            schedule.enabled = row.enabled;
+            Ok(schedule)
+        })
+        .transpose()
     }
 }
 
@@ -606,30 +623,30 @@ impl Queue for ApalisPgQueue {
     #[tracing::instrument(skip(self, job), fields(stage = %job.stage()))]
     async fn push(&self, job: Job) -> QueueResult<JobId> {
         let payload = serde_json::to_value(&job)?;
-        let row = sqlx::query(
-            "INSERT INTO queue_jobs
+        let row = sqlx::query!(
+            r#"INSERT INTO queue_jobs
                 (stage, payload, priority, max_attempts, trace_parent, job_group_key)
              VALUES ($1, $2, $3, $4, $5, $6)
-             RETURNING id",
+             RETURNING id"#,
+            job.stage().as_str(),
+            payload,
+            job.priority(),
+            job.max_attempts(),
+            job.trace_parent(),
+            job.job_group_key()
         )
-        .bind(job.stage().as_str())
-        .bind(payload)
-        .bind(job.priority())
-        .bind(job.max_attempts())
-        .bind(job.trace_parent())
-        .bind(job.job_group_key())
         .fetch_one(&self.pool)
         .await
         .map_err(QueueError::Db)?;
 
-        Ok(JobId::new(row.get("id")))
+        Ok(JobId::new(row.id))
     }
 
     #[tracing::instrument(skip(self, worker_id), fields(stage = %stage, worker = worker_id.as_str()))]
     async fn pop(&self, stage: QueueStage, worker_id: WorkerId) -> QueueResult<Option<LeasedJob>> {
         for attempt in 0..POP_CONFLICT_RETRIES {
-            let row = match sqlx::query(
-                "WITH candidate AS (
+            let row = match sqlx::query!(
+                r#"WITH candidate AS (
                      SELECT q.id
                      FROM queue_jobs q
                      WHERE q.stage = $1
@@ -637,7 +654,7 @@ impl Queue for ApalisPgQueue {
                            (q.status = 'pending' AND q.run_at <= now())
                            OR (
                                q.status = 'running'
-                               AND q.locked_at <= now() - ($3 * INTERVAL '1 millisecond')
+                               AND q.locked_at <= now() - ($3::BIGINT * INTERVAL '1 millisecond')
                            )
                        )
                        AND (
@@ -662,15 +679,20 @@ impl Queue for ApalisPgQueue {
                  SET status = 'running',
                      locked_by = $2,
                      locked_at = now(),
+                     lease_version = lease_version + 1,
                      attempts = attempts + 1,
                      updated_at = now()
                  FROM candidate
                  WHERE q.id = candidate.id
-                 RETURNING q.id, q.payload, q.attempts, q.locked_at",
+                 RETURNING q.id,
+                           q.payload AS "payload!: serde_json::Value",
+                           q.attempts,
+                           q.locked_at AS "locked_at!: DateTime<Utc>",
+                           q.lease_version"#,
+                stage.as_str(),
+                worker_id.as_str(),
+                duration_millis_i64(self.lease_timeout)
             )
-            .bind(stage.as_str())
-            .bind(worker_id.as_str())
-            .bind(duration_millis_i64(self.lease_timeout))
             .fetch_optional(&self.pool)
             .await
             {
@@ -681,7 +703,18 @@ impl Queue for ApalisPgQueue {
                 Err(err) => return Err(QueueError::Db(err)),
             };
 
-            return row.map(|row| leased_from_row(row, worker_id)).transpose();
+            return row
+                .map(|row| {
+                    leased_from_parts(
+                        row.id,
+                        row.payload,
+                        row.attempts,
+                        row.locked_at,
+                        row.lease_version,
+                        worker_id,
+                    )
+                })
+                .transpose();
         }
 
         Ok(None)
@@ -689,8 +722,8 @@ impl Queue for ApalisPgQueue {
 
     #[tracing::instrument(skip(self, job), fields(job_id = %job.id()))]
     async fn ack(&self, job: &LeasedJob) -> QueueResult<()> {
-        let result = sqlx::query(
-            "UPDATE queue_jobs
+        let result = sqlx::query!(
+            r#"UPDATE queue_jobs
              SET status = 'completed',
                  locked_by = NULL,
                  locked_at = NULL,
@@ -698,11 +731,11 @@ impl Queue for ApalisPgQueue {
              WHERE id = $1
                AND status = 'running'
                AND locked_by = $2
-               AND locked_at = $3",
+               AND lease_version = $3"#,
+            job.id().get(),
+            job.worker_id().as_str(),
+            job.lease_version()
         )
-        .bind(job.id().get())
-        .bind(job.worker_id().as_str())
-        .bind(job.leased_at())
         .execute(&self.pool)
         .await
         .map_err(QueueError::Db)?;
@@ -715,26 +748,40 @@ impl Queue for ApalisPgQueue {
 
     #[tracing::instrument(skip(self, job), fields(job_id = %job.id()))]
     async fn renew(&self, job: &LeasedJob) -> QueueResult<LeasedJob> {
-        let row = sqlx::query(
-            "UPDATE queue_jobs
+        let row = sqlx::query!(
+            r#"UPDATE queue_jobs
              SET locked_at = now(),
+                 lease_version = lease_version + 1,
                  updated_at = now()
              WHERE id = $1
                AND status = 'running'
                AND locked_by = $2
-               AND locked_at = $3
-             RETURNING id, payload, attempts, locked_at",
+               AND lease_version = $3
+             RETURNING id,
+                       payload AS "payload!: serde_json::Value",
+                       attempts,
+                       locked_at AS "locked_at!: DateTime<Utc>",
+                       lease_version"#,
+            job.id().get(),
+            job.worker_id().as_str(),
+            job.lease_version()
         )
-        .bind(job.id().get())
-        .bind(job.worker_id().as_str())
-        .bind(job.leased_at())
         .fetch_optional(&self.pool)
         .await
         .map_err(QueueError::Db)?;
 
-        row.map(|row| leased_from_row(row, job.worker_id().clone()))
-            .transpose()?
-            .ok_or(QueueError::LeaseLost(job.id()))
+        row.map(|row| {
+            leased_from_parts(
+                row.id,
+                row.payload,
+                row.attempts,
+                row.locked_at,
+                row.lease_version,
+                job.worker_id().clone(),
+            )
+        })
+        .transpose()?
+        .ok_or(QueueError::LeaseLost(job.id()))
     }
 
     #[tracing::instrument(skip(self, job, nack), fields(job_id = %job.id()))]
@@ -749,8 +796,8 @@ impl Queue for ApalisPgQueue {
     #[tracing::instrument(skip(self, schedule), fields(schedule = schedule.id()))]
     async fn schedule(&self, schedule: CronSchedule) -> QueueResult<()> {
         let payload = serde_json::to_value(schedule.job())?;
-        sqlx::query(
-            "INSERT INTO queue_cron_schedules
+        sqlx::query!(
+            r#"INSERT INTO queue_cron_schedules
                 (id, stage, cron_expression, payload, trace_parent, enabled)
              VALUES ($1, $2, $3, $4, $5, $6)
              ON CONFLICT (id) DO UPDATE
@@ -759,14 +806,14 @@ impl Queue for ApalisPgQueue {
                  payload = EXCLUDED.payload,
                  trace_parent = EXCLUDED.trace_parent,
                  enabled = EXCLUDED.enabled,
-                 updated_at = now()",
+                 updated_at = now()"#,
+            schedule.id(),
+            schedule.job().stage().as_str(),
+            schedule.cron_expression(),
+            payload,
+            schedule.job().trace_parent(),
+            schedule.enabled()
         )
-        .bind(schedule.id())
-        .bind(schedule.job().stage().as_str())
-        .bind(schedule.cron_expression())
-        .bind(payload)
-        .bind(schedule.job().trace_parent())
-        .bind(schedule.enabled())
         .execute(&self.pool)
         .await
         .map_err(QueueError::Db)?;
@@ -781,24 +828,24 @@ async fn retry_job(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult<(
         .as_millis()
         .min(i64::MAX as u128) as i64;
 
-    let result = sqlx::query(
-        "UPDATE queue_jobs
+    let result = sqlx::query!(
+        r#"UPDATE queue_jobs
          SET status = 'pending',
              locked_by = NULL,
              locked_at = NULL,
-             run_at = now() + ($3 * INTERVAL '1 millisecond'),
+             run_at = now() + ($3::BIGINT * INTERVAL '1 millisecond'),
              last_error = $4,
              updated_at = now()
          WHERE id = $1
            AND status = 'running'
            AND locked_by = $2
-           AND locked_at = $5",
+           AND lease_version = $5"#,
+        job.id().get(),
+        job.worker_id().as_str(),
+        retry_after_ms,
+        &nack.message,
+        job.lease_version()
     )
-    .bind(job.id().get())
-    .bind(job.worker_id().as_str())
-    .bind(retry_after_ms)
-    .bind(&nack.message)
-    .bind(job.leased_at())
     .execute(pool)
     .await
     .map_err(QueueError::Db)?;
@@ -811,8 +858,8 @@ async fn retry_job(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult<(
 
 async fn dead_letter(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult<()> {
     let mut tx = pool.begin().await.map_err(QueueError::Db)?;
-    let result = sqlx::query(
-        "UPDATE queue_jobs
+    let result = sqlx::query!(
+        r#"UPDATE queue_jobs
          SET status = 'dead',
              locked_by = NULL,
              locked_at = NULL,
@@ -821,12 +868,12 @@ async fn dead_letter(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult
          WHERE id = $1
            AND status = 'running'
            AND locked_by = $2
-           AND locked_at = $4",
+           AND lease_version = $4"#,
+        job.id().get(),
+        job.worker_id().as_str(),
+        &nack.message,
+        job.lease_version()
     )
-    .bind(job.id().get())
-    .bind(job.worker_id().as_str())
-    .bind(&nack.message)
-    .bind(job.leased_at())
     .execute(&mut *tx)
     .await
     .map_err(QueueError::Db)?;
@@ -835,8 +882,8 @@ async fn dead_letter(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult
         return Err(QueueError::LeaseLost(job.id()));
     }
 
-    sqlx::query(
-        "INSERT INTO queue_dead_letters
+    sqlx::query!(
+        r#"INSERT INTO queue_dead_letters
             (job_id, stage, payload, attempts, error_class, error_message, trace_parent)
          VALUES ($1, $2, $3, $4, $5, $6, $7)
          ON CONFLICT (job_id) DO UPDATE
@@ -844,15 +891,15 @@ async fn dead_letter(pool: &PgPool, job: &LeasedJob, nack: &Nack) -> QueueResult
              error_class = EXCLUDED.error_class,
              error_message = EXCLUDED.error_message,
              trace_parent = EXCLUDED.trace_parent,
-             failed_at = now()",
+             failed_at = now()"#,
+        job.id().get(),
+        job.job().stage().as_str(),
+        serde_json::to_value(job.job())?,
+        job.attempts(),
+        format!("{:?}", nack.error_class),
+        &nack.message,
+        job.trace_parent()
     )
-    .bind(job.id().get())
-    .bind(job.job().stage().as_str())
-    .bind(serde_json::to_value(job.job())?)
-    .bind(job.attempts())
-    .bind(format!("{:?}", nack.error_class))
-    .bind(&nack.message)
-    .bind(job.trace_parent())
     .execute(&mut *tx)
     .await
     .map_err(QueueError::Db)?;
@@ -877,24 +924,22 @@ fn is_unique_violation(err: &sqlx::Error) -> bool {
         == Some("23505")
 }
 
-fn leased_from_row(row: sqlx::postgres::PgRow, worker_id: WorkerId) -> QueueResult<LeasedJob> {
+fn leased_from_parts(
+    id: i64,
+    payload: serde_json::Value,
+    attempts: i32,
+    locked_at: DateTime<Utc>,
+    lease_version: i64,
+    worker_id: WorkerId,
+) -> QueueResult<LeasedJob> {
     Ok(LeasedJob {
-        id: JobId::new(row.get("id")),
-        job: serde_json::from_value(row.get("payload"))?,
+        id: JobId::new(id),
+        job: serde_json::from_value(payload)?,
         worker_id,
-        attempts: row.get("attempts"),
-        leased_at: row.get("locked_at"),
+        attempts,
+        leased_at: locked_at,
+        lease_version,
     })
-}
-
-fn schedule_from_row(row: sqlx::postgres::PgRow) -> QueueResult<CronSchedule> {
-    let mut schedule = CronSchedule::new(
-        row.get::<String, _>("id"),
-        row.get::<String, _>("cron_expression"),
-        serde_json::from_value(row.get("payload"))?,
-    )?;
-    schedule.enabled = row.get("enabled");
-    Ok(schedule)
 }
 
 /// Errors returned by queue operations.

--- a/crates/au-kpis-queue/tests/postgres.rs
+++ b/crates/au-kpis-queue/tests/postgres.rs
@@ -59,6 +59,7 @@ async fn push_pop_ack_preserves_payload_and_trace_parent() {
     assert_eq!(leased.job(), &job);
     assert_eq!(leased.trace_parent(), Some(trace_parent));
     assert_eq!(leased.attempts(), 1);
+    assert_eq!(leased.lease_version(), 1);
 
     queue.ack(&leased).await.expect("ack job");
 
@@ -98,6 +99,7 @@ async fn nack_retries_then_dead_letters_after_attempt_budget() {
         .expect("job should be retried");
     assert_eq!(second.id(), id);
     assert_eq!(second.attempts(), 2);
+    assert_eq!(second.lease_version(), 2);
     queue
         .nack(
             &second,
@@ -111,8 +113,7 @@ async fn nack_retries_then_dead_letters_after_attempt_budget() {
     assert_eq!(dead.attempts(), 2);
     assert!(dead.error_message().contains("still timing out"));
 
-    sqlx::query("DELETE FROM queue_jobs WHERE id = $1")
-        .bind(id.get())
+    sqlx::query!("DELETE FROM queue_jobs WHERE id = $1", id.get())
         .execute(queue.pool())
         .await
         .expect("delete retained queue row");
@@ -258,6 +259,7 @@ async fn stale_running_jobs_are_reclaimed_after_lease_timeout() {
     assert_eq!(reclaimed.id(), id);
     assert_eq!(reclaimed.worker_id().as_str(), "worker-b");
     assert_eq!(reclaimed.attempts(), 2);
+    assert_eq!(reclaimed.lease_version(), first.lease_version() + 1);
     assert!(queue.ack(&first).await.is_err(), "stale handles cannot ack");
 }
 
@@ -283,6 +285,7 @@ async fn renew_extends_lease_and_invalidates_old_handle() {
 
     assert_eq!(renewed.id(), id);
     assert_eq!(renewed.worker_id().as_str(), "worker-a");
+    assert_eq!(renewed.lease_version(), first.lease_version() + 1);
     assert!(
         renewed.leased_at() >= first.leased_at(),
         "renew should not move the lease timestamp backwards"

--- a/crates/au-kpis-queue/tests/postgres.rs
+++ b/crates/au-kpis-queue/tests/postgres.rs
@@ -1,0 +1,183 @@
+use std::time::Duration;
+
+use au_kpis_config::DatabaseConfig;
+use au_kpis_db::{connect, migrate};
+use au_kpis_domain::{DataflowId, SourceId};
+use au_kpis_error::ErrorClass;
+use au_kpis_queue::{ApalisPgQueue, CronSchedule, Job, JobKind, Nack, Queue, QueueStage, WorkerId};
+use au_kpis_testing::timescale::{TimescaleHarness, start_timescale};
+use sqlx::PgPool;
+
+struct QueueDb {
+    _timescale: TimescaleHarness,
+    pool: PgPool,
+}
+
+async fn migrated_pool(database: &str) -> QueueDb {
+    let timescale = start_timescale(database)
+        .await
+        .expect("start timescaledb container");
+    let cfg = DatabaseConfig {
+        url: timescale.url().to_string(),
+    };
+
+    let mut last_err = None;
+    for _ in 0..10 {
+        match connect(&cfg).await {
+            Ok(pool) => {
+                migrate(&pool).await.expect("apply migrations");
+                return QueueDb {
+                    _timescale: timescale,
+                    pool,
+                };
+            }
+            Err(err) => {
+                last_err = Some(err);
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+
+    panic!("timescaledb did not accept connections: {last_err:?}");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn push_pop_ack_preserves_payload_and_trace_parent() {
+    let pool = migrated_pool("au_kpis_queue_roundtrip").await;
+    let queue = ApalisPgQueue::new(pool.pool);
+    let trace_parent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+    let job = Job::discover(SourceId::new("abs").unwrap()).with_trace_parent(trace_parent);
+
+    let id = queue.push(job.clone()).await.expect("push job");
+    let leased = queue
+        .pop(QueueStage::Discover, WorkerId::new("worker-a").unwrap())
+        .await
+        .expect("pop job")
+        .expect("job should be available");
+
+    assert_eq!(leased.id(), id);
+    assert_eq!(leased.job(), &job);
+    assert_eq!(leased.trace_parent(), Some(trace_parent));
+    assert_eq!(leased.attempts(), 1);
+
+    queue.ack(&leased).await.expect("ack job");
+
+    let next = queue
+        .pop(QueueStage::Discover, WorkerId::new("worker-a").unwrap())
+        .await
+        .expect("pop after ack");
+    assert!(next.is_none(), "acked jobs must not be leased again");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn nack_retries_then_dead_letters_after_attempt_budget() {
+    let pool = migrated_pool("au_kpis_queue_retry").await;
+    let queue = ApalisPgQueue::new(pool.pool);
+    let job = Job::fetch("abs-cpi-2024-q1", SourceId::new("abs").unwrap())
+        .with_max_attempts(2)
+        .with_trace_parent("00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01");
+
+    let id = queue.push(job.clone()).await.expect("push job");
+    let first = queue
+        .pop(QueueStage::Fetch, WorkerId::new("worker-a").unwrap())
+        .await
+        .expect("first pop")
+        .expect("job should be leased");
+    queue
+        .nack(
+            &first,
+            Nack::new(ErrorClass::Transient, "upstream timeout").with_retry_after(Duration::ZERO),
+        )
+        .await
+        .expect("nack for retry");
+
+    let second = queue
+        .pop(QueueStage::Fetch, WorkerId::new("worker-b").unwrap())
+        .await
+        .expect("second pop")
+        .expect("job should be retried");
+    assert_eq!(second.id(), id);
+    assert_eq!(second.attempts(), 2);
+    queue
+        .nack(
+            &second,
+            Nack::new(ErrorClass::Transient, "still timing out"),
+        )
+        .await
+        .expect("nack to dlq");
+
+    let dead = queue.dead_lettered(id).await.expect("read dlq");
+    assert_eq!(dead.job(), &job);
+    assert_eq!(dead.attempts(), 2);
+    assert!(dead.error_message().contains("still timing out"));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_job_group_key_serializes_same_dataflow() {
+    let pool = migrated_pool("au_kpis_queue_group").await;
+    let queue = ApalisPgQueue::new(pool.pool);
+    let dataflow_id = DataflowId::new("abs.cpi").unwrap();
+    let worker = WorkerId::new("worker-a").unwrap();
+
+    let first = queue
+        .push(Job::load(dataflow_id.clone(), "artifact-a"))
+        .await
+        .expect("push first load");
+    queue
+        .push(Job::load(dataflow_id, "artifact-b"))
+        .await
+        .expect("push second load");
+
+    let leased = queue
+        .pop(QueueStage::Load, worker.clone())
+        .await
+        .expect("pop first")
+        .expect("first load should lease");
+    assert_eq!(leased.id(), first);
+
+    let blocked = queue
+        .pop(QueueStage::Load, worker.clone())
+        .await
+        .expect("pop while same group is running");
+    assert!(
+        blocked.is_none(),
+        "same dataflow load jobs must not run concurrently"
+    );
+
+    queue.ack(&leased).await.expect("ack first load");
+    let next = queue
+        .pop(QueueStage::Load, worker)
+        .await
+        .expect("pop second")
+        .expect("second load should become available after ack");
+    assert_ne!(next.id(), first);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn schedule_upserts_cron_registration() {
+    let pool = migrated_pool("au_kpis_queue_cron").await;
+    let queue = ApalisPgQueue::new(pool.pool);
+    let schedule = CronSchedule::new(
+        "abs-cpi-discovery",
+        "0 8 * * *",
+        Job::discover(SourceId::new("abs").unwrap()),
+    )
+    .unwrap();
+
+    queue
+        .schedule(schedule.clone())
+        .await
+        .expect("insert schedule");
+    queue
+        .schedule(schedule.with_cron_expression("0 9 * * *").unwrap())
+        .await
+        .expect("update schedule");
+
+    let saved = queue
+        .schedule_by_id("abs-cpi-discovery")
+        .await
+        .expect("read schedule")
+        .expect("schedule should exist");
+    assert_eq!(saved.cron_expression(), "0 9 * * *");
+    assert!(matches!(saved.job().kind(), JobKind::Discover { .. }));
+}

--- a/crates/au-kpis-queue/tests/postgres.rs
+++ b/crates/au-kpis-queue/tests/postgres.rs
@@ -110,6 +110,15 @@ async fn nack_retries_then_dead_letters_after_attempt_budget() {
     assert_eq!(dead.job(), &job);
     assert_eq!(dead.attempts(), 2);
     assert!(dead.error_message().contains("still timing out"));
+
+    sqlx::query("DELETE FROM queue_jobs WHERE id = $1")
+        .bind(id.get())
+        .execute(queue.pool())
+        .await
+        .expect("delete retained queue row");
+    let retained = queue.dead_lettered(id).await.expect("read retained dlq");
+    assert_eq!(retained.job(), &job);
+    assert!(retained.error_message().contains("still timing out"));
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -183,6 +192,47 @@ async fn concurrent_load_pops_cannot_lease_same_dataflow_group() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_pop_skips_blocked_group_and_leases_ready_group() {
+    let pool = migrated_pool("au_kpis_queue_mixed_groups").await;
+    let queue = ApalisPgQueue::new(pool.pool);
+    let cpi = DataflowId::new("abs.cpi").unwrap();
+    let wages = DataflowId::new("abs.wpi").unwrap();
+
+    queue
+        .push(Job::load(cpi.clone(), "artifact-a").with_priority(10))
+        .await
+        .expect("push first CPI load");
+    queue
+        .push(Job::load(cpi, "artifact-b").with_priority(9))
+        .await
+        .expect("push blocked CPI load");
+    let wages_id = queue
+        .push(Job::load(wages.clone(), "artifact-c").with_priority(8))
+        .await
+        .expect("push WPI load");
+
+    let first = queue
+        .pop(QueueStage::Load, WorkerId::new("worker-a").unwrap())
+        .await
+        .expect("first pop")
+        .expect("first CPI load should lease");
+    let next = queue
+        .pop(QueueStage::Load, WorkerId::new("worker-b").unwrap())
+        .await
+        .expect("second pop")
+        .expect("different dataflow load should remain leaseable");
+
+    assert_eq!(next.id(), wages_id);
+    assert!(matches!(
+        next.job().kind(),
+        JobKind::Load { dataflow_id, .. } if dataflow_id == &wages
+    ));
+
+    queue.ack(&first).await.expect("ack CPI load");
+    queue.ack(&next).await.expect("ack WPI load");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn stale_running_jobs_are_reclaimed_after_lease_timeout() {
     let pool = migrated_pool("au_kpis_queue_reclaim").await;
     let queue = ApalisPgQueue::new(pool.pool).with_lease_timeout(Duration::from_millis(1));
@@ -208,6 +258,41 @@ async fn stale_running_jobs_are_reclaimed_after_lease_timeout() {
     assert_eq!(reclaimed.id(), id);
     assert_eq!(reclaimed.worker_id().as_str(), "worker-b");
     assert_eq!(reclaimed.attempts(), 2);
+    assert!(queue.ack(&first).await.is_err(), "stale handles cannot ack");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn renew_extends_lease_and_invalidates_old_handle() {
+    let pool = migrated_pool("au_kpis_queue_renew").await;
+    let queue = ApalisPgQueue::new(pool.pool);
+    let id = queue
+        .push(Job::parse(
+            SourceId::new("abs").unwrap(),
+            "artifact-a",
+            "raw/abs/a.pdf",
+        ))
+        .await
+        .expect("push parse job");
+
+    let first = queue
+        .pop(QueueStage::Parse, WorkerId::new("worker-a").unwrap())
+        .await
+        .expect("pop parse job")
+        .expect("parse job should lease");
+    let renewed = queue.renew(&first).await.expect("renew lease");
+
+    assert_eq!(renewed.id(), id);
+    assert_eq!(renewed.worker_id().as_str(), "worker-a");
+    assert!(
+        renewed.leased_at() >= first.leased_at(),
+        "renew should not move the lease timestamp backwards"
+    );
+    assert!(
+        queue.ack(&first).await.is_err(),
+        "old lease handles must not complete a renewed job"
+    );
+
+    queue.ack(&renewed).await.expect("ack renewed lease");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/au-kpis-queue/tests/postgres.rs
+++ b/crates/au-kpis-queue/tests/postgres.rs
@@ -154,6 +154,63 @@ async fn load_job_group_key_serializes_same_dataflow() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn concurrent_load_pops_cannot_lease_same_dataflow_group() {
+    let pool = migrated_pool("au_kpis_queue_group_race").await;
+    let queue = ApalisPgQueue::new(pool.pool);
+    let dataflow_id = DataflowId::new("abs.cpi").unwrap();
+
+    queue
+        .push(Job::load(dataflow_id.clone(), "artifact-a"))
+        .await
+        .expect("push first load");
+    queue
+        .push(Job::load(dataflow_id, "artifact-b"))
+        .await
+        .expect("push second load");
+
+    let first_queue = queue.clone();
+    let second_queue = queue.clone();
+    let (first, second) = tokio::join!(
+        first_queue.pop(QueueStage::Load, WorkerId::new("worker-a").unwrap()),
+        second_queue.pop(QueueStage::Load, WorkerId::new("worker-b").unwrap())
+    );
+
+    let leased = [first.expect("first pop"), second.expect("second pop")]
+        .into_iter()
+        .filter(Option::is_some)
+        .count();
+    assert_eq!(leased, 1, "only one load job per dataflow may run");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stale_running_jobs_are_reclaimed_after_lease_timeout() {
+    let pool = migrated_pool("au_kpis_queue_reclaim").await;
+    let queue = ApalisPgQueue::new(pool.pool).with_lease_timeout(Duration::from_millis(1));
+    let id = queue
+        .push(Job::load(DataflowId::new("abs.cpi").unwrap(), "artifact-a"))
+        .await
+        .expect("push load");
+
+    let first = queue
+        .pop(QueueStage::Load, WorkerId::new("worker-a").unwrap())
+        .await
+        .expect("first pop")
+        .expect("first worker leases job");
+    assert_eq!(first.id(), id);
+    tokio::time::sleep(Duration::from_millis(5)).await;
+
+    let reclaimed = queue
+        .pop(QueueStage::Load, WorkerId::new("worker-b").unwrap())
+        .await
+        .expect("reclaim stale lease")
+        .expect("stale lease should be visible");
+
+    assert_eq!(reclaimed.id(), id);
+    assert_eq!(reclaimed.worker_id().as_str(), "worker-b");
+    assert_eq!(reclaimed.attempts(), 2);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn schedule_upserts_cron_registration() {
     let pool = migrated_pool("au_kpis_queue_cron").await;
     let queue = ApalisPgQueue::new(pool.pool);

--- a/infra/migrations/0002_queue.down.sql
+++ b/infra/migrations/0002_queue.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS queue_cron_schedules;
+DROP TABLE IF EXISTS queue_dead_letters;
+DROP TABLE IF EXISTS queue_jobs;

--- a/infra/migrations/0002_queue.up.sql
+++ b/infra/migrations/0002_queue.up.sql
@@ -33,7 +33,7 @@ CREATE UNIQUE INDEX queue_jobs_one_running_group_idx
 
 CREATE TABLE queue_dead_letters (
     id            BIGSERIAL PRIMARY KEY,
-    job_id        BIGINT NOT NULL UNIQUE REFERENCES queue_jobs(id) ON DELETE CASCADE,
+    job_id        BIGINT NOT NULL UNIQUE,
     stage         TEXT NOT NULL,
     payload       JSONB NOT NULL,
     attempts      INTEGER NOT NULL CHECK (attempts > 0),

--- a/infra/migrations/0002_queue.up.sql
+++ b/infra/migrations/0002_queue.up.sql
@@ -1,0 +1,56 @@
+-- Queue storage for issue #22.
+-- Postgres-backed jobs use transactional leasing with SKIP LOCKED,
+-- retry metadata, dead-letter records, cron registrations, and group
+-- keys for serialising loads per dataflow.
+
+CREATE TABLE queue_jobs (
+    id            BIGSERIAL PRIMARY KEY,
+    stage         TEXT NOT NULL
+                  CHECK (stage IN ('discover','fetch','parse','load','backfill')),
+    payload       JSONB NOT NULL,
+    status        TEXT NOT NULL DEFAULT 'pending'
+                  CHECK (status IN ('pending','running','completed','dead')),
+    priority      INTEGER NOT NULL DEFAULT 0,
+    attempts      INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    max_attempts  INTEGER NOT NULL DEFAULT 5 CHECK (max_attempts > 0),
+    run_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+    locked_by     TEXT,
+    locked_at     TIMESTAMPTZ,
+    trace_parent  TEXT,
+    job_group_key TEXT,
+    last_error    TEXT,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX queue_jobs_ready_idx
+    ON queue_jobs (stage, status, run_at, priority DESC, id)
+    WHERE status = 'pending';
+
+CREATE INDEX queue_jobs_running_group_idx
+    ON queue_jobs (job_group_key)
+    WHERE status = 'running' AND job_group_key IS NOT NULL;
+
+CREATE TABLE queue_dead_letters (
+    id            BIGSERIAL PRIMARY KEY,
+    job_id        BIGINT NOT NULL UNIQUE REFERENCES queue_jobs(id) ON DELETE CASCADE,
+    stage         TEXT NOT NULL,
+    payload       JSONB NOT NULL,
+    attempts      INTEGER NOT NULL CHECK (attempts > 0),
+    error_class   TEXT NOT NULL,
+    error_message TEXT NOT NULL,
+    trace_parent  TEXT,
+    failed_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE queue_cron_schedules (
+    id              TEXT PRIMARY KEY,
+    stage           TEXT NOT NULL
+                    CHECK (stage IN ('discover','fetch','parse','load','backfill')),
+    cron_expression TEXT NOT NULL,
+    payload         JSONB NOT NULL,
+    trace_parent    TEXT,
+    enabled         BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT now()
+);

--- a/infra/migrations/0002_queue.up.sql
+++ b/infra/migrations/0002_queue.up.sql
@@ -16,6 +16,7 @@ CREATE TABLE queue_jobs (
     run_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
     locked_by     TEXT,
     locked_at     TIMESTAMPTZ,
+    lease_version BIGINT NOT NULL DEFAULT 0,
     trace_parent  TEXT,
     job_group_key TEXT,
     last_error    TEXT,

--- a/infra/migrations/0002_queue.up.sql
+++ b/infra/migrations/0002_queue.up.sql
@@ -27,7 +27,7 @@ CREATE INDEX queue_jobs_ready_idx
     ON queue_jobs (stage, status, run_at, priority DESC, id)
     WHERE status = 'pending';
 
-CREATE INDEX queue_jobs_running_group_idx
+CREATE UNIQUE INDEX queue_jobs_one_running_group_idx
     ON queue_jobs (job_group_key)
     WHERE status = 'running' AND job_group_key IS NOT NULL;
 


### PR DESCRIPTION
Closes #22

## Pass requirements

- [x] `Queue` trait: push, pop, ack, nack, schedule
- [x] `ApalisPgQueue` implementation
- [x] Job types: `Discover`, `Fetch`, `Parse`, `Load`, `Backfill`
- [x] `trace_parent` field propagated; worker restores span
- [x] Retries + exponential backoff + DLQ exercised in tests
- [x] Cron registration integration test
- [x] Job-group keys serialize per-dataflow loads

## Test plan

- `cargo fmt --all --check`
- `cargo check --workspace`
- `cargo test -p au-kpis-queue`
- `cargo test -p au-kpis-db --test migrations`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`

## Spec impact

No Spec changes required. Implements the queue semantics already described in `Spec.md § Ingestion pipeline -> Queue abstraction + semantics`.