### PR TITLE
feat(adapter-abs): discover CPI dataflow (#24)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -437,7 +437,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p target/contract
-          cargo run -p au-kpis-api-http --example contract_server > target/contract/server.log 2>&1 &
+          cargo build -p au-kpis-api-http --example contract_server --locked
+          ./target/debug/examples/contract_server > target/contract/server.log 2>&1 &
           echo $! > target/contract/server.pid
 
       - name: Wait for API readiness

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -194,6 +194,18 @@ dependencies = [
 [[package]]
 name = "au-kpis-adapter-abs"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "au-kpis-adapter",
+ "au-kpis-domain",
+ "au-kpis-error",
+ "chrono",
+ "futures",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "au-kpis-adapter-aemo"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -201,6 +201,8 @@ dependencies = [
  "au-kpis-error",
  "chrono",
  "futures",
+ "insta",
+ "proptest",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/adapters/abs/Cargo.toml
+++ b/crates/adapters/abs/Cargo.toml
@@ -19,4 +19,6 @@ tracing = "0.1"
 
 [dev-dependencies]
 chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+insta = { version = "1", features = ["json"] }
+proptest = "1"
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread"] }

--- a/crates/adapters/abs/Cargo.toml
+++ b/crates/adapters/abs/Cargo.toml
@@ -8,3 +8,15 @@ repository.workspace = true
 description = "ABS adapter (SDMX-JSON)."
 
 [dependencies]
+async-trait = "0.1"
+au-kpis-adapter = { workspace = true }
+au-kpis-domain = { workspace = true }
+au-kpis-error = { workspace = true }
+futures = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+
+[dev-dependencies]
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread"] }

--- a/crates/adapters/abs/src/lib.rs
+++ b/crates/adapters/abs/src/lib.rs
@@ -25,7 +25,6 @@ const USER_AGENT: &str = concat!("au-kpis-adapter-abs/", env!("CARGO_PKG_VERSION
 pub struct AbsAdapter {
     manifest: AdapterManifest,
     base_url: String,
-    known_revisions: BTreeMap<String, DataflowRevision>,
 }
 
 impl Default for AbsAdapter {
@@ -67,6 +66,16 @@ impl AbsAdapter {
             .collect()
     }
 
+    /// Convert current ABS dataflows into discovery jobs without persisted diff state.
+    #[must_use]
+    pub fn current_jobs(current: &[AbsDataflow]) -> Vec<DiscoveredJob> {
+        current
+            .iter()
+            .filter(|flow| flow.id == CPI_DATAFLOW_ID)
+            .map(AbsDataflow::to_discovered_job)
+            .collect()
+    }
+
     fn dataflow_url(&self) -> String {
         format!("{}/dataflow/ABS/CPI?detail=allstubs", self.base_url)
     }
@@ -96,10 +105,7 @@ impl SourceAdapter for AbsAdapter {
             .await?
             .error_for_status()?;
         let message = response.json::<AbsDataflowMessage>().await?;
-        Ok(Self::discoverable_jobs(
-            &message.data.dataflows,
-            &self.known_revisions,
-        ))
+        Ok(Self::current_jobs(&message.data.dataflows))
     }
 
     async fn fetch(
@@ -125,14 +131,12 @@ impl SourceAdapter for AbsAdapter {
 #[derive(Debug, Clone)]
 pub struct AbsAdapterBuilder {
     base_url: String,
-    known_revisions: BTreeMap<String, DataflowRevision>,
 }
 
 impl Default for AbsAdapterBuilder {
     fn default() -> Self {
         Self {
             base_url: DEFAULT_BASE_URL.to_string(),
-            known_revisions: BTreeMap::new(),
         }
     }
 }
@@ -142,17 +146,6 @@ impl AbsAdapterBuilder {
     #[must_use]
     pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
         self.base_url = base_url.into().trim_end_matches('/').to_string();
-        self
-    }
-
-    /// Register the stored upstream revision for a dataflow.
-    #[must_use]
-    pub fn known_revision(
-        mut self,
-        dataflow_id: impl Into<String>,
-        revision: DataflowRevision,
-    ) -> Self {
-        self.known_revisions.insert(dataflow_id.into(), revision);
         self
     }
 
@@ -169,7 +162,6 @@ impl AbsAdapterBuilder {
                 dataflows: vec![DataflowId::new("abs.cpi").expect("static dataflow id is valid")],
             },
             base_url: self.base_url,
-            known_revisions: self.known_revisions,
         }
     }
 }
@@ -283,6 +275,8 @@ struct RawAbsDataflow {
 #[derive(Debug, Deserialize)]
 struct AbsLink {
     href: String,
+    #[serde(default)]
+    rel: Option<String>,
 }
 
 impl<'de> Deserialize<'de> for AbsDataflow {
@@ -296,11 +290,8 @@ impl<'de> Deserialize<'de> for AbsDataflow {
             .or_else(|| raw.names.get("en").cloned())
             .unwrap_or_else(|| raw.id.clone());
         let agency_id = raw.agency_id.unwrap_or_else(|| "ABS".to_string());
-        let dataflow_url = raw
-            .links
-            .first()
-            .map(|link| link.href.clone())
-            .ok_or_else(|| serde::de::Error::custom("ABS dataflow is missing links"))?;
+        let dataflow_url = canonical_dataflow_url(&raw.links, &agency_id, &raw.id, &raw.version)
+            .ok_or_else(|| serde::de::Error::custom("ABS dataflow is missing canonical link"))?;
         let source_url =
             data_url_from_dataflow_url(&dataflow_url, &agency_id, &raw.id, &raw.version);
 
@@ -313,6 +304,44 @@ impl<'de> Deserialize<'de> for AbsDataflow {
             source_url,
             dataflow_url,
         })
+    }
+}
+
+fn canonical_dataflow_url(
+    links: &[AbsLink],
+    agency_id: &str,
+    dataflow_id: &str,
+    version: &str,
+) -> Option<String> {
+    let expected_suffix = format!("/dataflow/{agency_id}/{dataflow_id}/{version}");
+    links
+        .iter()
+        .filter(|link| is_supported_dataflow_rel(link.rel.as_deref()))
+        .filter(|link| {
+            let href = link
+                .href
+                .split_once('?')
+                .map_or(link.href.as_str(), |(href, _)| href);
+            href.ends_with(&expected_suffix)
+        })
+        .min_by_key(|link| dataflow_link_rank(link.rel.as_deref()))
+        .map(|link| link.href.clone())
+}
+
+fn is_supported_dataflow_rel(rel: Option<&str>) -> bool {
+    rel.is_none_or(|rel| {
+        matches!(
+            rel.to_ascii_lowercase().as_str(),
+            "self" | "canonical" | "dataflow" | "external"
+        )
+    })
+}
+
+fn dataflow_link_rank(rel: Option<&str>) -> u8 {
+    match rel.map(str::to_ascii_lowercase).as_deref() {
+        Some("self" | "canonical" | "dataflow") => 0,
+        Some("external") => 1,
+        _ => 2,
     }
 }
 

--- a/crates/adapters/abs/src/lib.rs
+++ b/crates/adapters/abs/src/lib.rs
@@ -18,6 +18,7 @@ use serde::Deserialize;
 const DEFAULT_BASE_URL: &str = "https://data.api.abs.gov.au/rest";
 const STRUCTURE_JSON_ACCEPT: &str = "application/vnd.sdmx.structure+json";
 const CPI_DATAFLOW_ID: &str = "CPI";
+const USER_AGENT: &str = concat!("au-kpis-adapter-abs/", env!("CARGO_PKG_VERSION"));
 
 /// ABS SDMX adapter.
 #[derive(Debug, Clone)]
@@ -89,6 +90,7 @@ impl SourceAdapter for AbsAdapter {
                 ctx.http
                     .raw()
                     .get(self.dataflow_url())
+                    .header("user-agent", USER_AGENT)
                     .header("accept", STRUCTURE_JSON_ACCEPT),
             )
             .await?
@@ -239,7 +241,12 @@ impl AbsDataflow {
         }
 
         DiscoveredJob {
-            id: format!("abs:{}:{}", self.id, self.version),
+            id: format!(
+                "abs:{}:{}:{}",
+                self.id,
+                self.version,
+                revision_token(self.last_updated.as_deref())
+            ),
             source_id: SourceId::new("abs").expect("static source id is valid"),
             dataflow_id: DataflowId::new("abs.cpi").expect("static dataflow id is valid"),
             source_url: self.source_url.clone(),
@@ -255,7 +262,6 @@ struct AbsDataflowMessage {
 
 #[derive(Debug, Deserialize)]
 struct AbsDataflowData {
-    #[serde(default)]
     dataflows: Vec<AbsDataflow>,
 }
 
@@ -264,15 +270,13 @@ struct RawAbsDataflow {
     id: String,
     #[serde(rename = "agencyID", default)]
     agency_id: Option<String>,
-    #[serde(default)]
-    version: Option<String>,
+    version: String,
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
     names: BTreeMap<String, String>,
     #[serde(default, alias = "lastUpdated", alias = "last_updated")]
     updated: Option<String>,
-    #[serde(default)]
     links: Vec<AbsLink>,
 }
 
@@ -292,23 +296,18 @@ impl<'de> Deserialize<'de> for AbsDataflow {
             .or_else(|| raw.names.get("en").cloned())
             .unwrap_or_else(|| raw.id.clone());
         let agency_id = raw.agency_id.unwrap_or_else(|| "ABS".to_string());
-        let version = raw.version.unwrap_or_else(|| "latest".to_string());
         let dataflow_url = raw
             .links
             .first()
             .map(|link| link.href.clone())
-            .unwrap_or_else(|| {
-                format!(
-                    "{DEFAULT_BASE_URL}/dataflow/{agency_id}/{}/{version}",
-                    raw.id
-                )
-            });
-        let source_url = data_url_from_dataflow_url(&dataflow_url, &agency_id, &raw.id, &version);
+            .ok_or_else(|| serde::de::Error::custom("ABS dataflow is missing links"))?;
+        let source_url =
+            data_url_from_dataflow_url(&dataflow_url, &agency_id, &raw.id, &raw.version);
 
         Ok(Self {
             id: raw.id,
             agency_id,
-            version,
+            version: raw.version,
             name,
             last_updated: raw.updated,
             source_url,
@@ -331,4 +330,18 @@ fn data_url_from_dataflow_url(
     format!(
         "{DEFAULT_BASE_URL}/data/{agency_id},{dataflow_id},{version}/all?dimensionAtObservation=TIME_PERIOD"
     )
+}
+
+fn revision_token(last_updated: Option<&str>) -> String {
+    last_updated
+        .unwrap_or("unknown")
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect()
 }

--- a/crates/adapters/abs/src/lib.rs
+++ b/crates/adapters/abs/src/lib.rs
@@ -51,9 +51,8 @@ impl AbsAdapter {
         current: &[AbsDataflow],
         known_revisions: &BTreeMap<String, UpstreamRevision>,
     ) -> Vec<DiscoveredJob> {
-        current
-            .iter()
-            .filter(|flow| flow.id == CPI_DATAFLOW_ID)
+        latest_dataflow_revisions(current)
+            .into_values()
             .filter(|flow| {
                 known_revisions
                     .get(&flow.revision_key())
@@ -66,9 +65,8 @@ impl AbsAdapter {
     /// Convert current ABS dataflows into discovery jobs without persisted diff state.
     #[must_use]
     pub fn current_jobs(current: &[AbsDataflow]) -> Vec<DiscoveredJob> {
-        current
-            .iter()
-            .filter(|flow| flow.id == CPI_DATAFLOW_ID)
+        latest_dataflow_revisions(current)
+            .into_values()
             .map(AbsDataflow::to_discovered_job)
             .collect()
     }
@@ -192,7 +190,7 @@ impl AbsDataflow {
     }
 
     fn revision_key(&self) -> String {
-        format!("{}:{}:{}", self.agency_id, self.id, self.version)
+        format!("{}:{}", self.agency_id, self.id)
     }
 
     fn to_discovered_job(&self) -> DiscoveredJob {
@@ -230,23 +228,24 @@ fn parse_dataflow_listing_with_base(
     let message = serde_json::from_str::<RawAbsDataflowMessage>(body).map_err(CoreError::from)?;
     let mut dataflows = Vec::new();
     for raw in message.data.dataflows {
-        match raw.id.as_deref() {
-            Some(CPI_DATAFLOW_ID) => {
-                dataflows.push(AbsDataflow::try_from_raw(raw, source_base_url)?)
-            }
-            Some(_) => {
-                if let Ok(dataflow) = AbsDataflow::try_from_raw(raw, source_base_url) {
-                    dataflows.push(dataflow);
-                }
-            }
-            None => {
-                return Err(AdapterError::Validation(
-                    "ABS dataflow row is missing id".to_string(),
-                ));
-            }
-        }
+        dataflows.push(AbsDataflow::try_from_raw(raw, source_base_url)?);
     }
     Ok(dataflows)
+}
+
+fn latest_dataflow_revisions(current: &[AbsDataflow]) -> BTreeMap<String, &AbsDataflow> {
+    let mut latest = BTreeMap::new();
+    for flow in current.iter().filter(|flow| flow.id == CPI_DATAFLOW_ID) {
+        latest
+            .entry(flow.revision_key())
+            .and_modify(|stored: &mut &AbsDataflow| {
+                if flow.is_newer_revision_than(stored) {
+                    *stored = flow;
+                }
+            })
+            .or_insert(flow);
+    }
+    latest
 }
 
 #[derive(Debug, Deserialize)]
@@ -286,9 +285,9 @@ impl AbsDataflow {
     fn try_from_raw(raw: RawAbsDataflow, source_base_url: &str) -> Result<Self, AdapterError> {
         let id = raw
             .id
-            .ok_or_else(|| AdapterError::Validation("ABS dataflow is missing id".to_string()))?;
+            .ok_or_else(|| AdapterError::FormatDrift("ABS dataflow is missing id".to_string()))?;
         let version = raw.version.ok_or_else(|| {
-            AdapterError::Validation(format!("ABS dataflow {id} is missing version"))
+            AdapterError::FormatDrift(format!("ABS dataflow {id} is missing version"))
         })?;
         let name = raw
             .name
@@ -297,7 +296,7 @@ impl AbsDataflow {
         let agency_id = raw.agency_id.unwrap_or_else(|| "ABS".to_string());
         let dataflow_url = canonical_dataflow_url(&raw.links, &agency_id, &id, &version)
             .ok_or_else(|| {
-                AdapterError::Validation(format!("ABS dataflow {id} is missing canonical link"))
+                AdapterError::FormatDrift(format!("ABS dataflow {id} is missing canonical link"))
             })?;
         let source_url = data_url_from_base(source_base_url, &agency_id, &id, &version);
 
@@ -311,6 +310,18 @@ impl AbsDataflow {
             dataflow_url,
         })
     }
+
+    fn is_newer_revision_than(&self, other: &Self) -> bool {
+        version_cmp_key(&self.version) > version_cmp_key(&other.version)
+            || (self.version == other.version && self.last_updated > other.last_updated)
+    }
+}
+
+fn version_cmp_key(version: &str) -> Vec<u64> {
+    version
+        .split('.')
+        .map(|part| part.parse::<u64>().unwrap_or(0))
+        .collect()
 }
 
 fn canonical_dataflow_url(

--- a/crates/adapters/abs/src/lib.rs
+++ b/crates/adapters/abs/src/lib.rs
@@ -1,1 +1,334 @@
 //! ABS adapter (SDMX-JSON).
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::{collections::BTreeMap, time::Duration};
+
+use async_trait::async_trait;
+use au_kpis_adapter::{
+    AdapterError, AdapterManifest, ArtifactRef, DiscoveredJob, DiscoveryCtx, FetchCtx,
+    ObservationStream, ParseCtx, RateLimit, SourceAdapter,
+};
+use au_kpis_domain::{DataflowId, SourceId};
+use au_kpis_error::CoreError;
+use futures::stream;
+use serde::Deserialize;
+
+const DEFAULT_BASE_URL: &str = "https://data.api.abs.gov.au/rest";
+const STRUCTURE_JSON_ACCEPT: &str = "application/vnd.sdmx.structure+json";
+const CPI_DATAFLOW_ID: &str = "CPI";
+
+/// ABS SDMX adapter.
+#[derive(Debug, Clone)]
+pub struct AbsAdapter {
+    manifest: AdapterManifest,
+    base_url: String,
+    known_revisions: BTreeMap<String, DataflowRevision>,
+}
+
+impl Default for AbsAdapter {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
+impl AbsAdapter {
+    /// Start building an ABS adapter.
+    #[must_use]
+    pub fn builder() -> AbsAdapterBuilder {
+        AbsAdapterBuilder::default()
+    }
+
+    /// Parse an ABS SDMX-JSON dataflow listing.
+    pub fn parse_dataflow_listing(body: &str) -> Result<Vec<AbsDataflow>, AdapterError> {
+        Ok(serde_json::from_str::<AbsDataflowMessage>(body)
+            .map_err(CoreError::from)?
+            .data
+            .dataflows)
+    }
+
+    /// Diff current ABS dataflows against stored upstream revisions.
+    #[must_use]
+    pub fn discoverable_jobs(
+        current: &[AbsDataflow],
+        known_revisions: &BTreeMap<String, DataflowRevision>,
+    ) -> Vec<DiscoveredJob> {
+        current
+            .iter()
+            .filter(|flow| flow.id == CPI_DATAFLOW_ID)
+            .filter(|flow| {
+                known_revisions
+                    .get(&flow.id)
+                    .is_none_or(|known| known != &flow.revision())
+            })
+            .map(AbsDataflow::to_discovered_job)
+            .collect()
+    }
+
+    fn dataflow_url(&self) -> String {
+        format!("{}/dataflow/ABS/CPI?detail=allstubs", self.base_url)
+    }
+}
+
+#[async_trait]
+impl SourceAdapter for AbsAdapter {
+    fn id(&self) -> &'static str {
+        "abs"
+    }
+
+    fn manifest(&self) -> &AdapterManifest {
+        &self.manifest
+    }
+
+    #[tracing::instrument(skip(self, ctx), fields(source = self.id()))]
+    async fn discover(&self, ctx: &DiscoveryCtx) -> Result<Vec<DiscoveredJob>, AdapterError> {
+        let response = ctx
+            .http
+            .execute(
+                ctx.http
+                    .raw()
+                    .get(self.dataflow_url())
+                    .header("accept", STRUCTURE_JSON_ACCEPT),
+            )
+            .await?
+            .error_for_status()?;
+        let message = response.json::<AbsDataflowMessage>().await?;
+        Ok(Self::discoverable_jobs(
+            &message.data.dataflows,
+            &self.known_revisions,
+        ))
+    }
+
+    async fn fetch(
+        &self,
+        _job: DiscoveredJob,
+        _ctx: &FetchCtx,
+    ) -> Result<ArtifactRef, AdapterError> {
+        Err(AdapterError::Validation(
+            "ABS fetch is implemented in issue #25".to_string(),
+        ))
+    }
+
+    fn parse<'a>(&'a self, _artifact: ArtifactRef, _ctx: &'a ParseCtx) -> ObservationStream<'a> {
+        Box::pin(stream::once(async {
+            Err(AdapterError::Validation(
+                "ABS parse is implemented in issue #26".to_string(),
+            ))
+        }))
+    }
+}
+
+/// Builder for [`AbsAdapter`].
+#[derive(Debug, Clone)]
+pub struct AbsAdapterBuilder {
+    base_url: String,
+    known_revisions: BTreeMap<String, DataflowRevision>,
+}
+
+impl Default for AbsAdapterBuilder {
+    fn default() -> Self {
+        Self {
+            base_url: DEFAULT_BASE_URL.to_string(),
+            known_revisions: BTreeMap::new(),
+        }
+    }
+}
+
+impl AbsAdapterBuilder {
+    /// Override the ABS REST base URL. Intended for deterministic tests.
+    #[must_use]
+    pub fn base_url(mut self, base_url: impl Into<String>) -> Self {
+        self.base_url = base_url.into().trim_end_matches('/').to_string();
+        self
+    }
+
+    /// Register the stored upstream revision for a dataflow.
+    #[must_use]
+    pub fn known_revision(
+        mut self,
+        dataflow_id: impl Into<String>,
+        revision: DataflowRevision,
+    ) -> Self {
+        self.known_revisions.insert(dataflow_id.into(), revision);
+        self
+    }
+
+    /// Build the adapter.
+    #[must_use]
+    pub fn build(self) -> AbsAdapter {
+        AbsAdapter {
+            manifest: AdapterManifest {
+                source_id: SourceId::new("abs").expect("static source id is valid"),
+                name: "Australian Bureau of Statistics".to_string(),
+                version: env!("CARGO_PKG_VERSION").to_string(),
+                rate_limit: RateLimit::new(60, Duration::from_secs(60))
+                    .expect("static rate limit is valid"),
+                dataflows: vec![DataflowId::new("abs.cpi").expect("static dataflow id is valid")],
+            },
+            base_url: self.base_url,
+            known_revisions: self.known_revisions,
+        }
+    }
+}
+
+/// Stored upstream dataflow revision used for discovery diffing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataflowRevision {
+    version: String,
+    last_updated: Option<String>,
+}
+
+impl DataflowRevision {
+    /// Construct a stored revision.
+    #[must_use]
+    pub fn new(version: impl Into<String>, last_updated: Option<impl Into<String>>) -> Self {
+        Self {
+            version: version.into(),
+            last_updated: last_updated.map(Into::into),
+        }
+    }
+
+    /// Upstream dataflow version.
+    #[must_use]
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    /// Upstream update timestamp when exposed by ABS.
+    #[must_use]
+    pub fn last_updated(&self) -> Option<&str> {
+        self.last_updated.as_deref()
+    }
+}
+
+/// ABS dataflow metadata relevant to discovery.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AbsDataflow {
+    /// ABS dataflow id, e.g. `CPI`.
+    pub id: String,
+    /// Maintaining agency, usually `ABS`.
+    pub agency_id: String,
+    /// ABS dataflow version.
+    pub version: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Upstream update timestamp when present.
+    pub last_updated: Option<String>,
+    /// Canonical SDMX-JSON data URL to fetch for this dataflow.
+    pub source_url: String,
+    /// Canonical ABS dataflow metadata URL.
+    pub dataflow_url: String,
+}
+
+impl AbsDataflow {
+    fn revision(&self) -> DataflowRevision {
+        DataflowRevision::new(self.version.clone(), self.last_updated.clone())
+    }
+
+    fn to_discovered_job(&self) -> DiscoveredJob {
+        let mut metadata = BTreeMap::from([
+            ("abs_dataflow_id".to_string(), self.id.clone()),
+            ("agency_id".to_string(), self.agency_id.clone()),
+            ("version".to_string(), self.version.clone()),
+            ("name".to_string(), self.name.clone()),
+            ("dataflow_url".to_string(), self.dataflow_url.clone()),
+        ]);
+        if let Some(last_updated) = &self.last_updated {
+            metadata.insert("last_updated".to_string(), last_updated.clone());
+        }
+
+        DiscoveredJob {
+            id: format!("abs:{}:{}", self.id, self.version),
+            source_id: SourceId::new("abs").expect("static source id is valid"),
+            dataflow_id: DataflowId::new("abs.cpi").expect("static dataflow id is valid"),
+            source_url: self.source_url.clone(),
+            metadata,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AbsDataflowMessage {
+    data: AbsDataflowData,
+}
+
+#[derive(Debug, Deserialize)]
+struct AbsDataflowData {
+    #[serde(default)]
+    dataflows: Vec<AbsDataflow>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawAbsDataflow {
+    id: String,
+    #[serde(rename = "agencyID", default)]
+    agency_id: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    names: BTreeMap<String, String>,
+    #[serde(default, alias = "lastUpdated", alias = "last_updated")]
+    updated: Option<String>,
+    #[serde(default)]
+    links: Vec<AbsLink>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AbsLink {
+    href: String,
+}
+
+impl<'de> Deserialize<'de> for AbsDataflow {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = RawAbsDataflow::deserialize(deserializer)?;
+        let name = raw
+            .name
+            .or_else(|| raw.names.get("en").cloned())
+            .unwrap_or_else(|| raw.id.clone());
+        let agency_id = raw.agency_id.unwrap_or_else(|| "ABS".to_string());
+        let version = raw.version.unwrap_or_else(|| "latest".to_string());
+        let dataflow_url = raw
+            .links
+            .first()
+            .map(|link| link.href.clone())
+            .unwrap_or_else(|| {
+                format!(
+                    "{DEFAULT_BASE_URL}/dataflow/{agency_id}/{}/{version}",
+                    raw.id
+                )
+            });
+        let source_url = data_url_from_dataflow_url(&dataflow_url, &agency_id, &raw.id, &version);
+
+        Ok(Self {
+            id: raw.id,
+            agency_id,
+            version,
+            name,
+            last_updated: raw.updated,
+            source_url,
+            dataflow_url,
+        })
+    }
+}
+
+fn data_url_from_dataflow_url(
+    dataflow_url: &str,
+    agency_id: &str,
+    dataflow_id: &str,
+    version: &str,
+) -> String {
+    if let Some((base, _)) = dataflow_url.split_once("/dataflow/") {
+        return format!(
+            "{base}/data/{agency_id},{dataflow_id},{version}/all?dimensionAtObservation=TIME_PERIOD"
+        );
+    }
+    format!(
+        "{DEFAULT_BASE_URL}/data/{agency_id},{dataflow_id},{version}/all?dimensionAtObservation=TIME_PERIOD"
+    )
+}

--- a/crates/adapters/abs/src/lib.rs
+++ b/crates/adapters/abs/src/lib.rs
@@ -239,7 +239,11 @@ fn parse_dataflow_listing_with_base(
                     dataflows.push(dataflow);
                 }
             }
-            None => {}
+            None => {
+                return Err(AdapterError::Validation(
+                    "ABS dataflow row is missing id".to_string(),
+                ));
+            }
         }
     }
     Ok(dataflows)

--- a/crates/adapters/abs/src/lib.rs
+++ b/crates/adapters/abs/src/lib.rs
@@ -42,10 +42,7 @@ impl AbsAdapter {
 
     /// Parse an ABS SDMX-JSON dataflow listing.
     pub fn parse_dataflow_listing(body: &str) -> Result<Vec<AbsDataflow>, AdapterError> {
-        Ok(serde_json::from_str::<AbsDataflowMessage>(body)
-            .map_err(CoreError::from)?
-            .data
-            .dataflows)
+        parse_dataflow_listing_with_base(body, DEFAULT_BASE_URL)
     }
 
     /// Diff current ABS dataflows against stored upstream revisions.
@@ -104,11 +101,9 @@ impl SourceAdapter for AbsAdapter {
             )
             .await?
             .error_for_status()?;
-        let message = response.json::<AbsDataflowMessage>().await?;
-        Ok(Self::discoverable_jobs(
-            &message.data.dataflows,
-            ctx.known_revisions(),
-        ))
+        let body = response.text().await?;
+        let dataflows = parse_dataflow_listing_with_base(&body, &self.base_url)?;
+        Ok(Self::discoverable_jobs(&dataflows, ctx.known_revisions()))
     }
 
     async fn fetch(
@@ -228,28 +223,51 @@ impl AbsDataflow {
     }
 }
 
-#[derive(Debug, Deserialize)]
-struct AbsDataflowMessage {
-    data: AbsDataflowData,
+fn parse_dataflow_listing_with_base(
+    body: &str,
+    source_base_url: &str,
+) -> Result<Vec<AbsDataflow>, AdapterError> {
+    let message = serde_json::from_str::<RawAbsDataflowMessage>(body).map_err(CoreError::from)?;
+    let mut dataflows = Vec::new();
+    for raw in message.data.dataflows {
+        match raw.id.as_deref() {
+            Some(CPI_DATAFLOW_ID) => {
+                dataflows.push(AbsDataflow::try_from_raw(raw, source_base_url)?)
+            }
+            Some(_) => {
+                if let Ok(dataflow) = AbsDataflow::try_from_raw(raw, source_base_url) {
+                    dataflows.push(dataflow);
+                }
+            }
+            None => {}
+        }
+    }
+    Ok(dataflows)
 }
 
 #[derive(Debug, Deserialize)]
-struct AbsDataflowData {
-    dataflows: Vec<AbsDataflow>,
+struct RawAbsDataflowMessage {
+    data: RawAbsDataflowData,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawAbsDataflowData {
+    dataflows: Vec<RawAbsDataflow>,
 }
 
 #[derive(Debug, Deserialize)]
 struct RawAbsDataflow {
-    id: String,
+    id: Option<String>,
     #[serde(rename = "agencyID", default)]
     agency_id: Option<String>,
-    version: String,
+    version: Option<String>,
     #[serde(default)]
     name: Option<String>,
     #[serde(default)]
     names: BTreeMap<String, String>,
     #[serde(default, alias = "lastUpdated", alias = "last_updated")]
     updated: Option<String>,
+    #[serde(default)]
     links: Vec<AbsLink>,
 }
 
@@ -260,26 +278,29 @@ struct AbsLink {
     rel: Option<String>,
 }
 
-impl<'de> Deserialize<'de> for AbsDataflow {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        let raw = RawAbsDataflow::deserialize(deserializer)?;
+impl AbsDataflow {
+    fn try_from_raw(raw: RawAbsDataflow, source_base_url: &str) -> Result<Self, AdapterError> {
+        let id = raw
+            .id
+            .ok_or_else(|| AdapterError::Validation("ABS dataflow is missing id".to_string()))?;
+        let version = raw.version.ok_or_else(|| {
+            AdapterError::Validation(format!("ABS dataflow {id} is missing version"))
+        })?;
         let name = raw
             .name
             .or_else(|| raw.names.get("en").cloned())
-            .unwrap_or_else(|| raw.id.clone());
+            .unwrap_or_else(|| id.clone());
         let agency_id = raw.agency_id.unwrap_or_else(|| "ABS".to_string());
-        let dataflow_url = canonical_dataflow_url(&raw.links, &agency_id, &raw.id, &raw.version)
-            .ok_or_else(|| serde::de::Error::custom("ABS dataflow is missing canonical link"))?;
-        let source_url =
-            data_url_from_dataflow_url(&dataflow_url, &agency_id, &raw.id, &raw.version);
+        let dataflow_url = canonical_dataflow_url(&raw.links, &agency_id, &id, &version)
+            .ok_or_else(|| {
+                AdapterError::Validation(format!("ABS dataflow {id} is missing canonical link"))
+            })?;
+        let source_url = data_url_from_base(source_base_url, &agency_id, &id, &version);
 
         Ok(Self {
-            id: raw.id,
+            id,
             agency_id,
-            version: raw.version,
+            version,
             name,
             last_updated: raw.updated,
             source_url,
@@ -326,19 +347,15 @@ fn dataflow_link_rank(rel: Option<&str>) -> u8 {
     }
 }
 
-fn data_url_from_dataflow_url(
-    dataflow_url: &str,
+fn data_url_from_base(
+    source_base_url: &str,
     agency_id: &str,
     dataflow_id: &str,
     version: &str,
 ) -> String {
-    if let Some((base, _)) = dataflow_url.split_once("/dataflow/") {
-        return format!(
-            "{base}/data/{agency_id},{dataflow_id},{version}/all?dimensionAtObservation=TIME_PERIOD"
-        );
-    }
+    let base = source_base_url.trim_end_matches('/');
     format!(
-        "{DEFAULT_BASE_URL}/data/{agency_id},{dataflow_id},{version}/all?dimensionAtObservation=TIME_PERIOD"
+        "{base}/data/{agency_id},{dataflow_id},{version}/all?dimensionAtObservation=TIME_PERIOD"
     )
 }
 

--- a/crates/adapters/abs/src/lib.rs
+++ b/crates/adapters/abs/src/lib.rs
@@ -8,7 +8,7 @@ use std::{collections::BTreeMap, time::Duration};
 use async_trait::async_trait;
 use au_kpis_adapter::{
     AdapterError, AdapterManifest, ArtifactRef, DiscoveredJob, DiscoveryCtx, FetchCtx,
-    ObservationStream, ParseCtx, RateLimit, SourceAdapter,
+    ObservationStream, ParseCtx, RateLimit, SourceAdapter, UpstreamRevision,
 };
 use au_kpis_domain::{DataflowId, SourceId};
 use au_kpis_error::CoreError;
@@ -52,14 +52,14 @@ impl AbsAdapter {
     #[must_use]
     pub fn discoverable_jobs(
         current: &[AbsDataflow],
-        known_revisions: &BTreeMap<String, DataflowRevision>,
+        known_revisions: &BTreeMap<String, UpstreamRevision>,
     ) -> Vec<DiscoveredJob> {
         current
             .iter()
             .filter(|flow| flow.id == CPI_DATAFLOW_ID)
             .filter(|flow| {
                 known_revisions
-                    .get(&flow.id)
+                    .get(&flow.revision_key())
                     .is_none_or(|known| known != &flow.revision())
             })
             .map(AbsDataflow::to_discovered_job)
@@ -105,7 +105,10 @@ impl SourceAdapter for AbsAdapter {
             .await?
             .error_for_status()?;
         let message = response.json::<AbsDataflowMessage>().await?;
-        Ok(Self::current_jobs(&message.data.dataflows))
+        Ok(Self::discoverable_jobs(
+            &message.data.dataflows,
+            ctx.known_revisions(),
+        ))
     }
 
     async fn fetch(
@@ -167,34 +170,7 @@ impl AbsAdapterBuilder {
 }
 
 /// Stored upstream dataflow revision used for discovery diffing.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct DataflowRevision {
-    version: String,
-    last_updated: Option<String>,
-}
-
-impl DataflowRevision {
-    /// Construct a stored revision.
-    #[must_use]
-    pub fn new(version: impl Into<String>, last_updated: Option<impl Into<String>>) -> Self {
-        Self {
-            version: version.into(),
-            last_updated: last_updated.map(Into::into),
-        }
-    }
-
-    /// Upstream dataflow version.
-    #[must_use]
-    pub fn version(&self) -> &str {
-        &self.version
-    }
-
-    /// Upstream update timestamp when exposed by ABS.
-    #[must_use]
-    pub fn last_updated(&self) -> Option<&str> {
-        self.last_updated.as_deref()
-    }
-}
+pub type DataflowRevision = UpstreamRevision;
 
 /// ABS dataflow metadata relevant to discovery.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -216,8 +192,12 @@ pub struct AbsDataflow {
 }
 
 impl AbsDataflow {
-    fn revision(&self) -> DataflowRevision {
-        DataflowRevision::new(self.version.clone(), self.last_updated.clone())
+    fn revision(&self) -> UpstreamRevision {
+        UpstreamRevision::new(self.version.clone(), self.last_updated.clone())
+    }
+
+    fn revision_key(&self) -> String {
+        format!("{}:{}:{}", self.agency_id, self.id, self.version)
     }
 
     fn to_discovered_job(&self) -> DiscoveredJob {
@@ -225,6 +205,7 @@ impl AbsDataflow {
             ("abs_dataflow_id".to_string(), self.id.clone()),
             ("agency_id".to_string(), self.agency_id.clone()),
             ("version".to_string(), self.version.clone()),
+            ("revision_key".to_string(), self.revision_key()),
             ("name".to_string(), self.name.clone()),
             ("dataflow_url".to_string(), self.dataflow_url.clone()),
         ]);

--- a/crates/adapters/abs/tests/discover.rs
+++ b/crates/adapters/abs/tests/discover.rs
@@ -1,7 +1,8 @@
 use std::{collections::BTreeMap, time::Duration};
 
-use au_kpis_adapter::{AdapterHttpClient, DiscoveryCtx, SourceAdapter};
+use au_kpis_adapter::{AdapterError, AdapterHttpClient, DiscoveryCtx, SourceAdapter};
 use au_kpis_adapter_abs::{AbsAdapter, DataflowRevision};
+use au_kpis_error::{Classify, ErrorClass};
 use chrono::{TimeZone, Utc};
 use proptest::prelude::*;
 use serde_json::json;
@@ -102,11 +103,11 @@ async fn serve_once(body: &'static str) -> String {
 fn diff_cpi_dataflow_emits_only_new_or_changed_releases() {
     let current = AbsAdapter::parse_dataflow_listing(DATAFLOW_FIXTURE).expect("parse fixture");
     let unchanged = BTreeMap::from([(
-        "ABS:CPI:2.0.0".to_string(),
+        "ABS:CPI".to_string(),
         DataflowRevision::new("2.0.0", Some("2026-04-28T00:00:00Z")),
     )]);
     let changed = BTreeMap::from([(
-        "ABS:CPI:2.0.0".to_string(),
+        "ABS:CPI".to_string(),
         DataflowRevision::new("2.0.0", Some("2025-01-01T00:00:00Z")),
     )]);
 
@@ -127,7 +128,7 @@ fn diff_cpi_dataflow_emits_only_new_or_changed_releases() {
     );
     assert_eq!(jobs[0].metadata["abs_dataflow_id"], "CPI");
     assert_eq!(jobs[0].metadata["version"], "2.0.0");
-    assert_eq!(jobs[0].metadata["revision_key"], "ABS:CPI:2.0.0");
+    assert_eq!(jobs[0].metadata["revision_key"], "ABS:CPI");
     assert_eq!(jobs[0].metadata["last_updated"], "2026-04-28T00:00:00Z");
 }
 
@@ -155,7 +156,7 @@ async fn discover_applies_known_revisions_from_context() {
     let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
     let ctx = DiscoveryCtx::new(http, Utc.with_ymd_and_hms(2026, 4, 29, 0, 0, 0).unwrap())
         .with_known_revision(
-            "ABS:CPI:2.0.0",
+            "ABS:CPI",
             DataflowRevision::new("2.0.0", Some("2026-04-28T00:00:00Z")),
         );
 
@@ -168,7 +169,7 @@ async fn discover_applies_known_revisions_from_context() {
 fn changed_timestamp_emits_distinct_job_id_for_same_version() {
     let current = AbsAdapter::parse_dataflow_listing(DATAFLOW_FIXTURE).expect("parse fixture");
     let known = BTreeMap::from([(
-        "ABS:CPI:2.0.0".to_string(),
+        "ABS:CPI".to_string(),
         DataflowRevision::new("2.0.0", Some("2026-04-27T00:00:00Z")),
     )]);
 
@@ -179,35 +180,23 @@ fn changed_timestamp_emits_distinct_job_id_for_same_version() {
 }
 
 #[test]
-fn diff_keys_cpi_revisions_by_agency_id_and_version() {
+fn diff_keys_cpi_revisions_by_dataflow_and_selects_latest_version() {
     let current =
         AbsAdapter::parse_dataflow_listing(MULTI_VERSION_CPI_FIXTURE).expect("parse fixture");
-    let unchanged = BTreeMap::from([
-        (
-            "ABS:CPI:1.0.0".to_string(),
-            DataflowRevision::new("1.0.0", Some("2025-01-01T00:00:00Z")),
-        ),
-        (
-            "ABS:CPI:2.0.0".to_string(),
-            DataflowRevision::new("2.0.0", Some("2026-04-28T00:00:00Z")),
-        ),
-    ]);
+    let unchanged = BTreeMap::from([(
+        "ABS:CPI".to_string(),
+        DataflowRevision::new("2.0.0", Some("2026-04-28T00:00:00Z")),
+    )]);
     assert!(AbsAdapter::discoverable_jobs(&current, &unchanged).is_empty());
 
-    let changed_latest = BTreeMap::from([
-        (
-            "ABS:CPI:1.0.0".to_string(),
-            DataflowRevision::new("1.0.0", Some("2025-01-01T00:00:00Z")),
-        ),
-        (
-            "ABS:CPI:2.0.0".to_string(),
-            DataflowRevision::new("2.0.0", Some("2026-04-27T00:00:00Z")),
-        ),
-    ]);
+    let changed_latest = BTreeMap::from([(
+        "ABS:CPI".to_string(),
+        DataflowRevision::new("1.0.0", Some("2025-01-01T00:00:00Z")),
+    )]);
     let jobs = AbsAdapter::discoverable_jobs(&current, &changed_latest);
 
     assert_eq!(jobs.len(), 1);
-    assert_eq!(jobs[0].metadata["revision_key"], "ABS:CPI:2.0.0");
+    assert_eq!(jobs[0].metadata["revision_key"], "ABS:CPI");
     assert_eq!(jobs[0].id, "abs:CPI:2.0.0:2026-04-28T00-00-00Z");
 }
 
@@ -238,6 +227,8 @@ fn parse_dataflow_listing_rejects_missing_version() {
 
     let err = AbsAdapter::parse_dataflow_listing(body).expect_err("missing version should fail");
 
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
     assert!(err.to_string().contains("version"));
 }
 
@@ -261,11 +252,13 @@ fn parse_dataflow_listing_rejects_missing_id_rows() {
 
     let err = AbsAdapter::parse_dataflow_listing(body).expect_err("missing id should fail");
 
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
     assert!(err.to_string().contains("missing id"));
 }
 
 #[test]
-fn parse_dataflow_listing_skips_malformed_non_cpi_rows() {
+fn parse_dataflow_listing_rejects_malformed_non_cpi_rows() {
     let body = r#"{
       "data": {
         "dataflows": [
@@ -288,10 +281,11 @@ fn parse_dataflow_listing_skips_malformed_non_cpi_rows() {
       }
     }"#;
 
-    let current = AbsAdapter::parse_dataflow_listing(body).expect("parse valid CPI");
+    let err = AbsAdapter::parse_dataflow_listing(body).expect_err("malformed row should fail");
 
-    assert_eq!(current.len(), 1);
-    assert_eq!(current[0].id, "CPI");
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(err.to_string().contains("version"));
 }
 
 #[test]
@@ -312,6 +306,8 @@ fn parse_dataflow_listing_rejects_missing_links() {
 
     let err = AbsAdapter::parse_dataflow_listing(body).expect_err("missing links should fail");
 
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
     assert!(err.to_string().contains("canonical link"));
 }
 
@@ -397,7 +393,7 @@ fn parse_dataflow_listing_snapshot() {
                 "last_updated": flow.last_updated,
                 "source_url": flow.source_url,
                 "dataflow_url": flow.dataflow_url,
-                "revision_key": format!("{}:{}:{}", flow.agency_id, flow.id, flow.version),
+                "revision_key": format!("{}:{}", flow.agency_id, flow.id),
             })
         })
         .collect::<Vec<_>>();

--- a/crates/adapters/abs/tests/discover.rs
+++ b/crates/adapters/abs/tests/discover.rs
@@ -3,6 +3,8 @@ use std::{collections::BTreeMap, time::Duration};
 use au_kpis_adapter::{AdapterHttpClient, DiscoveryCtx, SourceAdapter};
 use au_kpis_adapter_abs::{AbsAdapter, DataflowRevision};
 use chrono::{TimeZone, Utc};
+use proptest::prelude::*;
+use serde_json::json;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
@@ -18,6 +20,7 @@ const DATAFLOW_FIXTURE: &str = r#"{
         "name": "Consumer Price Index (CPI)",
         "updated": "2026-04-28T00:00:00Z",
         "links": [
+          { "href": "https://example.test/metadata/CPI", "rel": "alternate" },
           { "href": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0", "rel": "external" }
         ]
       },
@@ -103,13 +106,7 @@ fn diff_cpi_dataflow_emits_only_new_or_changed_releases() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn discover_fetches_abs_dataflow_listing_over_http() {
     let base_url = serve_once(DATAFLOW_FIXTURE).await;
-    let adapter = AbsAdapter::builder()
-        .base_url(base_url)
-        .known_revision(
-            "CPI",
-            DataflowRevision::new("1.0.0", Some("2025-01-01T00:00:00Z")),
-        )
-        .build();
+    let adapter = AbsAdapter::builder().base_url(base_url).build();
     let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
     let ctx = DiscoveryCtx::new(http, Utc.with_ymd_and_hms(2026, 4, 29, 0, 0, 0).unwrap());
 
@@ -181,7 +178,61 @@ fn parse_dataflow_listing_rejects_missing_links() {
 
     let err = AbsAdapter::parse_dataflow_listing(body).expect_err("missing links should fail");
 
-    assert!(err.to_string().contains("links"));
+    assert!(err.to_string().contains("canonical link"));
+}
+
+#[test]
+fn parse_dataflow_listing_selects_canonical_dataflow_link_by_href_and_rel() {
+    let body = r#"{
+      "data": {
+        "dataflows": [
+          {
+            "id": "CPI",
+            "agencyID": "ABS",
+            "version": "2.0.0",
+            "names": {"en": "Consumer Price Index"},
+            "lastUpdated": "2026-04-28T00:00:00Z",
+            "links": [
+              { "href": "https://example.test/first", "rel": "external" },
+              { "href": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0", "rel": "self" }
+            ]
+          }
+        ]
+      }
+    }"#;
+
+    let current = AbsAdapter::parse_dataflow_listing(body).expect("parse canonical link fixture");
+
+    assert_eq!(
+        current[0].dataflow_url,
+        "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0"
+    );
+    assert_eq!(
+        current[0].source_url,
+        "https://data.api.abs.gov.au/rest/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD"
+    );
+    assert_eq!(current[0].name, "Consumer Price Index");
+}
+
+#[test]
+fn parse_dataflow_listing_snapshot() {
+    let current = AbsAdapter::parse_dataflow_listing(DATAFLOW_FIXTURE).expect("parse fixture");
+    let snapshot = current
+        .iter()
+        .map(|flow| {
+            json!({
+                "id": flow.id,
+                "agency_id": flow.agency_id,
+                "version": flow.version,
+                "name": flow.name,
+                "last_updated": flow.last_updated,
+                "source_url": flow.source_url,
+                "dataflow_url": flow.dataflow_url,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    insta::assert_json_snapshot!(snapshot);
 }
 
 #[test]
@@ -194,4 +245,51 @@ fn manifest_declares_abs_cpi_and_conservative_rate_limit() {
     assert_eq!(manifest.dataflows[0].as_str(), "abs.cpi");
     assert_eq!(manifest.rate_limit.max_requests, 60);
     assert_eq!(manifest.rate_limit.per, Duration::from_secs(60));
+}
+
+proptest! {
+    #[test]
+    fn parse_dataflow_listing_uses_canonical_link_regardless_of_order(
+        insert_at in 0usize..6,
+        noise_count in 0usize..5,
+    ) {
+        let canonical = json!({
+            "href": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0",
+            "rel": "self",
+        });
+        let mut links = (0..noise_count)
+            .map(|idx| {
+                json!({
+                    "href": format!("https://example.test/noise/{idx}"),
+                    "rel": "external",
+                })
+            })
+            .collect::<Vec<_>>();
+        let position = insert_at.min(links.len());
+        links.insert(position, canonical);
+
+        let body = json!({
+            "data": {
+                "dataflows": [{
+                    "id": "CPI",
+                    "agencyID": "ABS",
+                    "version": "2.0.0",
+                    "name": "Consumer Price Index",
+                    "updated": "2026-04-28T00:00:00Z",
+                    "links": links,
+                }]
+            }
+        })
+        .to_string();
+
+        let current = AbsAdapter::parse_dataflow_listing(&body).expect("parse generated dataflow");
+        prop_assert_eq!(
+            current[0].dataflow_url.as_str(),
+            "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0"
+        );
+        prop_assert_eq!(
+            current[0].source_url.as_str(),
+            "https://data.api.abs.gov.au/rest/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD"
+        );
+    }
 }

--- a/crates/adapters/abs/tests/discover.rs
+++ b/crates/adapters/abs/tests/discover.rs
@@ -1,0 +1,124 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use au_kpis_adapter::{AdapterHttpClient, DiscoveryCtx, SourceAdapter};
+use au_kpis_adapter_abs::{AbsAdapter, DataflowRevision};
+use chrono::{TimeZone, Utc};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+const DATAFLOW_FIXTURE: &str = r#"{
+  "data": {
+    "dataflows": [
+      {
+        "id": "CPI",
+        "agencyID": "ABS",
+        "version": "2.0.0",
+        "name": "Consumer Price Index (CPI)",
+        "updated": "2026-04-28T00:00:00Z",
+        "links": [
+          { "href": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0", "rel": "external" }
+        ]
+      },
+      {
+        "id": "WPI",
+        "agencyID": "ABS",
+        "version": "1.0.0",
+        "name": "Wage Price Index",
+        "updated": "2026-04-20T00:00:00Z"
+      }
+    ]
+  }
+}"#;
+
+async fn serve_once(body: &'static str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fixture server");
+    let addr = listener.local_addr().expect("fixture server address");
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).await.expect("read request");
+        let request = String::from_utf8_lossy(&request[..read]);
+        assert!(request.starts_with("GET /rest/dataflow/ABS/CPI?detail=allstubs HTTP/1.1"));
+        assert!(request.contains("application/vnd.sdmx.structure+json"));
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response");
+    });
+
+    format!("http://{addr}/rest")
+}
+
+#[test]
+fn diff_cpi_dataflow_emits_only_new_or_changed_releases() {
+    let current = AbsAdapter::parse_dataflow_listing(DATAFLOW_FIXTURE).expect("parse fixture");
+    let unchanged = BTreeMap::from([(
+        "CPI".to_string(),
+        DataflowRevision::new("2.0.0", Some("2026-04-28T00:00:00Z")),
+    )]);
+    let changed = BTreeMap::from([(
+        "CPI".to_string(),
+        DataflowRevision::new("1.0.0", Some("2025-01-01T00:00:00Z")),
+    )]);
+
+    assert!(AbsAdapter::discoverable_jobs(&current, &unchanged).is_empty());
+
+    let jobs = AbsAdapter::discoverable_jobs(&current, &changed);
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].id, "abs:CPI:2.0.0");
+    assert_eq!(jobs[0].source_id.as_str(), "abs");
+    assert_eq!(jobs[0].dataflow_id.as_str(), "abs.cpi");
+    assert_eq!(
+        jobs[0].source_url,
+        "https://data.api.abs.gov.au/rest/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD"
+    );
+    assert_eq!(
+        jobs[0].metadata["dataflow_url"],
+        "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0"
+    );
+    assert_eq!(jobs[0].metadata["abs_dataflow_id"], "CPI");
+    assert_eq!(jobs[0].metadata["version"], "2.0.0");
+    assert_eq!(jobs[0].metadata["last_updated"], "2026-04-28T00:00:00Z");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn discover_fetches_abs_dataflow_listing_over_http() {
+    let base_url = serve_once(DATAFLOW_FIXTURE).await;
+    let adapter = AbsAdapter::builder()
+        .base_url(base_url)
+        .known_revision(
+            "CPI",
+            DataflowRevision::new("1.0.0", Some("2025-01-01T00:00:00Z")),
+        )
+        .build();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = DiscoveryCtx::new(http, Utc.with_ymd_and_hms(2026, 4, 29, 0, 0, 0).unwrap());
+
+    let jobs = adapter.discover(&ctx).await.expect("discover CPI");
+
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].id, "abs:CPI:2.0.0");
+}
+
+#[test]
+fn manifest_declares_abs_cpi_and_conservative_rate_limit() {
+    let adapter = AbsAdapter::default();
+    let manifest = adapter.manifest();
+
+    assert_eq!(adapter.id(), "abs");
+    assert_eq!(manifest.source_id.as_str(), "abs");
+    assert_eq!(manifest.dataflows[0].as_str(), "abs.cpi");
+    assert_eq!(manifest.rate_limit.max_requests, 60);
+    assert_eq!(manifest.rate_limit.per, Duration::from_secs(60));
+}

--- a/crates/adapters/abs/tests/discover.rs
+++ b/crates/adapters/abs/tests/discover.rs
@@ -26,7 +26,10 @@ const DATAFLOW_FIXTURE: &str = r#"{
         "agencyID": "ABS",
         "version": "1.0.0",
         "name": "Wage Price Index",
-        "updated": "2026-04-20T00:00:00Z"
+        "updated": "2026-04-20T00:00:00Z",
+        "links": [
+          { "href": "https://data.api.abs.gov.au/rest/dataflow/ABS/WPI/1.0.0", "rel": "external" }
+        ]
       }
     ]
   }
@@ -45,6 +48,11 @@ async fn serve_once(body: &'static str) -> String {
         let request = String::from_utf8_lossy(&request[..read]);
         assert!(request.starts_with("GET /rest/dataflow/ABS/CPI?detail=allstubs HTTP/1.1"));
         assert!(request.contains("application/vnd.sdmx.structure+json"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("user-agent: au-kpis-adapter-abs/")
+        );
 
         let response = format!(
             "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
@@ -76,7 +84,7 @@ fn diff_cpi_dataflow_emits_only_new_or_changed_releases() {
 
     let jobs = AbsAdapter::discoverable_jobs(&current, &changed);
     assert_eq!(jobs.len(), 1);
-    assert_eq!(jobs[0].id, "abs:CPI:2.0.0");
+    assert_eq!(jobs[0].id, "abs:CPI:2.0.0:2026-04-28T00-00-00Z");
     assert_eq!(jobs[0].source_id.as_str(), "abs");
     assert_eq!(jobs[0].dataflow_id.as_str(), "abs.cpi");
     assert_eq!(
@@ -108,7 +116,72 @@ async fn discover_fetches_abs_dataflow_listing_over_http() {
     let jobs = adapter.discover(&ctx).await.expect("discover CPI");
 
     assert_eq!(jobs.len(), 1);
-    assert_eq!(jobs[0].id, "abs:CPI:2.0.0");
+    assert_eq!(jobs[0].id, "abs:CPI:2.0.0:2026-04-28T00-00-00Z");
+}
+
+#[test]
+fn changed_timestamp_emits_distinct_job_id_for_same_version() {
+    let current = AbsAdapter::parse_dataflow_listing(DATAFLOW_FIXTURE).expect("parse fixture");
+    let known = BTreeMap::from([(
+        "CPI".to_string(),
+        DataflowRevision::new("2.0.0", Some("2026-04-27T00:00:00Z")),
+    )]);
+
+    let jobs = AbsAdapter::discoverable_jobs(&current, &known);
+
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].id, "abs:CPI:2.0.0:2026-04-28T00-00-00Z");
+}
+
+#[test]
+fn parse_dataflow_listing_rejects_missing_dataflows() {
+    let err = AbsAdapter::parse_dataflow_listing(r#"{"data":{}}"#)
+        .expect_err("missing dataflows should fail");
+
+    assert!(err.to_string().contains("dataflows"));
+}
+
+#[test]
+fn parse_dataflow_listing_rejects_missing_version() {
+    let body = r#"{
+      "data": {
+        "dataflows": [
+          {
+            "id": "CPI",
+            "agencyID": "ABS",
+            "name": "Consumer Price Index",
+            "links": [
+              { "href": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0" }
+            ]
+          }
+        ]
+      }
+    }"#;
+
+    let err = AbsAdapter::parse_dataflow_listing(body).expect_err("missing version should fail");
+
+    assert!(err.to_string().contains("version"));
+}
+
+#[test]
+fn parse_dataflow_listing_rejects_missing_links() {
+    let body = r#"{
+      "data": {
+        "dataflows": [
+          {
+            "id": "CPI",
+            "agencyID": "ABS",
+            "version": "2.0.0",
+            "name": "Consumer Price Index",
+            "links": []
+          }
+        ]
+      }
+    }"#;
+
+    let err = AbsAdapter::parse_dataflow_listing(body).expect_err("missing links should fail");
+
+    assert!(err.to_string().contains("links"));
 }
 
 #[test]

--- a/crates/adapters/abs/tests/discover.rs
+++ b/crates/adapters/abs/tests/discover.rs
@@ -38,6 +38,33 @@ const DATAFLOW_FIXTURE: &str = r#"{
   }
 }"#;
 
+const MULTI_VERSION_CPI_FIXTURE: &str = r#"{
+  "data": {
+    "dataflows": [
+      {
+        "id": "CPI",
+        "agencyID": "ABS",
+        "version": "1.0.0",
+        "name": "Consumer Price Index (old)",
+        "updated": "2025-01-01T00:00:00Z",
+        "links": [
+          { "href": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/1.0.0", "rel": "self" }
+        ]
+      },
+      {
+        "id": "CPI",
+        "agencyID": "ABS",
+        "version": "2.0.0",
+        "name": "Consumer Price Index",
+        "updated": "2026-04-28T00:00:00Z",
+        "links": [
+          { "href": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0", "rel": "self" }
+        ]
+      }
+    ]
+  }
+}"#;
+
 async fn serve_once(body: &'static str) -> String {
     let listener = TcpListener::bind("127.0.0.1:0")
         .await
@@ -75,12 +102,12 @@ async fn serve_once(body: &'static str) -> String {
 fn diff_cpi_dataflow_emits_only_new_or_changed_releases() {
     let current = AbsAdapter::parse_dataflow_listing(DATAFLOW_FIXTURE).expect("parse fixture");
     let unchanged = BTreeMap::from([(
-        "CPI".to_string(),
+        "ABS:CPI:2.0.0".to_string(),
         DataflowRevision::new("2.0.0", Some("2026-04-28T00:00:00Z")),
     )]);
     let changed = BTreeMap::from([(
-        "CPI".to_string(),
-        DataflowRevision::new("1.0.0", Some("2025-01-01T00:00:00Z")),
+        "ABS:CPI:2.0.0".to_string(),
+        DataflowRevision::new("2.0.0", Some("2025-01-01T00:00:00Z")),
     )]);
 
     assert!(AbsAdapter::discoverable_jobs(&current, &unchanged).is_empty());
@@ -100,6 +127,7 @@ fn diff_cpi_dataflow_emits_only_new_or_changed_releases() {
     );
     assert_eq!(jobs[0].metadata["abs_dataflow_id"], "CPI");
     assert_eq!(jobs[0].metadata["version"], "2.0.0");
+    assert_eq!(jobs[0].metadata["revision_key"], "ABS:CPI:2.0.0");
     assert_eq!(jobs[0].metadata["last_updated"], "2026-04-28T00:00:00Z");
 }
 
@@ -116,17 +144,66 @@ async fn discover_fetches_abs_dataflow_listing_over_http() {
     assert_eq!(jobs[0].id, "abs:CPI:2.0.0:2026-04-28T00-00-00Z");
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn discover_applies_known_revisions_from_context() {
+    let base_url = serve_once(DATAFLOW_FIXTURE).await;
+    let adapter = AbsAdapter::builder().base_url(base_url).build();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = DiscoveryCtx::new(http, Utc.with_ymd_and_hms(2026, 4, 29, 0, 0, 0).unwrap())
+        .with_known_revision(
+            "ABS:CPI:2.0.0",
+            DataflowRevision::new("2.0.0", Some("2026-04-28T00:00:00Z")),
+        );
+
+    let jobs = adapter.discover(&ctx).await.expect("discover CPI");
+
+    assert!(jobs.is_empty());
+}
+
 #[test]
 fn changed_timestamp_emits_distinct_job_id_for_same_version() {
     let current = AbsAdapter::parse_dataflow_listing(DATAFLOW_FIXTURE).expect("parse fixture");
     let known = BTreeMap::from([(
-        "CPI".to_string(),
+        "ABS:CPI:2.0.0".to_string(),
         DataflowRevision::new("2.0.0", Some("2026-04-27T00:00:00Z")),
     )]);
 
     let jobs = AbsAdapter::discoverable_jobs(&current, &known);
 
     assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].id, "abs:CPI:2.0.0:2026-04-28T00-00-00Z");
+}
+
+#[test]
+fn diff_keys_cpi_revisions_by_agency_id_and_version() {
+    let current =
+        AbsAdapter::parse_dataflow_listing(MULTI_VERSION_CPI_FIXTURE).expect("parse fixture");
+    let unchanged = BTreeMap::from([
+        (
+            "ABS:CPI:1.0.0".to_string(),
+            DataflowRevision::new("1.0.0", Some("2025-01-01T00:00:00Z")),
+        ),
+        (
+            "ABS:CPI:2.0.0".to_string(),
+            DataflowRevision::new("2.0.0", Some("2026-04-28T00:00:00Z")),
+        ),
+    ]);
+    assert!(AbsAdapter::discoverable_jobs(&current, &unchanged).is_empty());
+
+    let changed_latest = BTreeMap::from([
+        (
+            "ABS:CPI:1.0.0".to_string(),
+            DataflowRevision::new("1.0.0", Some("2025-01-01T00:00:00Z")),
+        ),
+        (
+            "ABS:CPI:2.0.0".to_string(),
+            DataflowRevision::new("2.0.0", Some("2026-04-27T00:00:00Z")),
+        ),
+    ]);
+    let jobs = AbsAdapter::discoverable_jobs(&current, &changed_latest);
+
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].metadata["revision_key"], "ABS:CPI:2.0.0");
     assert_eq!(jobs[0].id, "abs:CPI:2.0.0:2026-04-28T00-00-00Z");
 }
 
@@ -228,6 +305,7 @@ fn parse_dataflow_listing_snapshot() {
                 "last_updated": flow.last_updated,
                 "source_url": flow.source_url,
                 "dataflow_url": flow.dataflow_url,
+                "revision_key": format!("{}:{}:{}", flow.agency_id, flow.id, flow.version),
             })
         })
         .collect::<Vec<_>>();

--- a/crates/adapters/abs/tests/discover.rs
+++ b/crates/adapters/abs/tests/discover.rs
@@ -242,6 +242,29 @@ fn parse_dataflow_listing_rejects_missing_version() {
 }
 
 #[test]
+fn parse_dataflow_listing_rejects_missing_id_rows() {
+    let body = r#"{
+      "data": {
+        "dataflows": [
+          {
+            "agencyID": "ABS",
+            "version": "2.0.0",
+            "name": "Consumer Price Index",
+            "updated": "2026-04-28T00:00:00Z",
+            "links": [
+              { "href": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0", "rel": "self" }
+            ]
+          }
+        ]
+      }
+    }"#;
+
+    let err = AbsAdapter::parse_dataflow_listing(body).expect_err("missing id should fail");
+
+    assert!(err.to_string().contains("missing id"));
+}
+
+#[test]
 fn parse_dataflow_listing_skips_malformed_non_cpi_rows() {
     let body = r#"{
       "data": {

--- a/crates/adapters/abs/tests/discover.rs
+++ b/crates/adapters/abs/tests/discover.rs
@@ -134,7 +134,7 @@ fn diff_cpi_dataflow_emits_only_new_or_changed_releases() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn discover_fetches_abs_dataflow_listing_over_http() {
     let base_url = serve_once(DATAFLOW_FIXTURE).await;
-    let adapter = AbsAdapter::builder().base_url(base_url).build();
+    let adapter = AbsAdapter::builder().base_url(&base_url).build();
     let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
     let ctx = DiscoveryCtx::new(http, Utc.with_ymd_and_hms(2026, 4, 29, 0, 0, 0).unwrap());
 
@@ -142,6 +142,10 @@ async fn discover_fetches_abs_dataflow_listing_over_http() {
 
     assert_eq!(jobs.len(), 1);
     assert_eq!(jobs[0].id, "abs:CPI:2.0.0:2026-04-28T00-00-00Z");
+    assert_eq!(
+        jobs[0].source_url,
+        format!("{base_url}/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD")
+    );
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -238,6 +242,36 @@ fn parse_dataflow_listing_rejects_missing_version() {
 }
 
 #[test]
+fn parse_dataflow_listing_skips_malformed_non_cpi_rows() {
+    let body = r#"{
+      "data": {
+        "dataflows": [
+          {
+            "id": "WPI",
+            "agencyID": "ABS",
+            "name": "Wage Price Index"
+          },
+          {
+            "id": "CPI",
+            "agencyID": "ABS",
+            "version": "2.0.0",
+            "name": "Consumer Price Index",
+            "updated": "2026-04-28T00:00:00Z",
+            "links": [
+              { "href": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0", "rel": "self" }
+            ]
+          }
+        ]
+      }
+    }"#;
+
+    let current = AbsAdapter::parse_dataflow_listing(body).expect("parse valid CPI");
+
+    assert_eq!(current.len(), 1);
+    assert_eq!(current[0].id, "CPI");
+}
+
+#[test]
 fn parse_dataflow_listing_rejects_missing_links() {
     let body = r#"{
       "data": {
@@ -289,6 +323,41 @@ fn parse_dataflow_listing_selects_canonical_dataflow_link_by_href_and_rel() {
         "https://data.api.abs.gov.au/rest/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD"
     );
     assert_eq!(current[0].name, "Consumer Price Index");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn discover_derives_fetch_url_from_configured_abs_base() {
+    let body = r#"{
+      "data": {
+        "dataflows": [
+          {
+            "id": "CPI",
+            "agencyID": "ABS",
+            "version": "2.0.0",
+            "name": "Consumer Price Index",
+            "updated": "2026-04-28T00:00:00Z",
+            "links": [
+              { "href": "https://metadata.example.test/rest/dataflow/ABS/CPI/2.0.0", "rel": "external" }
+            ]
+          }
+        ]
+      }
+    }"#;
+    let base_url = serve_once(body).await;
+    let adapter = AbsAdapter::builder().base_url(base_url.clone()).build();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = DiscoveryCtx::new(http, Utc.with_ymd_and_hms(2026, 4, 29, 0, 0, 0).unwrap());
+
+    let jobs = adapter.discover(&ctx).await.expect("discover CPI");
+
+    assert_eq!(
+        jobs[0].metadata["dataflow_url"],
+        "https://metadata.example.test/rest/dataflow/ABS/CPI/2.0.0"
+    );
+    assert_eq!(
+        jobs[0].source_url,
+        format!("{base_url}/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD")
+    );
 }
 
 #[test]

--- a/crates/adapters/abs/tests/snapshots/discover__parse_dataflow_listing_snapshot.snap
+++ b/crates/adapters/abs/tests/snapshots/discover__parse_dataflow_listing_snapshot.snap
@@ -9,7 +9,7 @@ expression: snapshot
     "id": "CPI",
     "last_updated": "2026-04-28T00:00:00Z",
     "name": "Consumer Price Index (CPI)",
-    "revision_key": "ABS:CPI:2.0.0",
+    "revision_key": "ABS:CPI",
     "source_url": "https://data.api.abs.gov.au/rest/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD",
     "version": "2.0.0"
   },
@@ -19,7 +19,7 @@ expression: snapshot
     "id": "WPI",
     "last_updated": "2026-04-20T00:00:00Z",
     "name": "Wage Price Index",
-    "revision_key": "ABS:WPI:1.0.0",
+    "revision_key": "ABS:WPI",
     "source_url": "https://data.api.abs.gov.au/rest/data/ABS,WPI,1.0.0/all?dimensionAtObservation=TIME_PERIOD",
     "version": "1.0.0"
   }

--- a/crates/adapters/abs/tests/snapshots/discover__parse_dataflow_listing_snapshot.snap
+++ b/crates/adapters/abs/tests/snapshots/discover__parse_dataflow_listing_snapshot.snap
@@ -9,6 +9,7 @@ expression: snapshot
     "id": "CPI",
     "last_updated": "2026-04-28T00:00:00Z",
     "name": "Consumer Price Index (CPI)",
+    "revision_key": "ABS:CPI:2.0.0",
     "source_url": "https://data.api.abs.gov.au/rest/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD",
     "version": "2.0.0"
   },
@@ -18,6 +19,7 @@ expression: snapshot
     "id": "WPI",
     "last_updated": "2026-04-20T00:00:00Z",
     "name": "Wage Price Index",
+    "revision_key": "ABS:WPI:1.0.0",
     "source_url": "https://data.api.abs.gov.au/rest/data/ABS,WPI,1.0.0/all?dimensionAtObservation=TIME_PERIOD",
     "version": "1.0.0"
   }

--- a/crates/adapters/abs/tests/snapshots/discover__parse_dataflow_listing_snapshot.snap
+++ b/crates/adapters/abs/tests/snapshots/discover__parse_dataflow_listing_snapshot.snap
@@ -1,0 +1,24 @@
+---
+source: crates/adapters/abs/tests/discover.rs
+expression: snapshot
+---
+[
+  {
+    "agency_id": "ABS",
+    "dataflow_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/CPI/2.0.0",
+    "id": "CPI",
+    "last_updated": "2026-04-28T00:00:00Z",
+    "name": "Consumer Price Index (CPI)",
+    "source_url": "https://data.api.abs.gov.au/rest/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD",
+    "version": "2.0.0"
+  },
+  {
+    "agency_id": "ABS",
+    "dataflow_url": "https://data.api.abs.gov.au/rest/dataflow/ABS/WPI/1.0.0",
+    "id": "WPI",
+    "last_updated": "2026-04-20T00:00:00Z",
+    "name": "Wage Price Index",
+    "source_url": "https://data.api.abs.gov.au/rest/data/ABS,WPI,1.0.0/all?dimensionAtObservation=TIME_PERIOD",
+    "version": "1.0.0"
+  }
+]

--- a/crates/au-kpis-adapter/src/lib.rs
+++ b/crates/au-kpis-adapter/src/lib.rs
@@ -175,13 +175,66 @@ pub struct DiscoveryCtx {
     pub http: AdapterHttpClient,
     /// Timestamp captured by the scheduler when discovery started.
     pub started_at: DateTime<Utc>,
+    /// Stored upstream revisions for this discovery run, keyed by adapter-defined upstream identity.
+    pub known_revisions: BTreeMap<String, UpstreamRevision>,
 }
 
 impl DiscoveryCtx {
     /// Construct a discovery context.
     #[must_use]
     pub fn new(http: AdapterHttpClient, started_at: DateTime<Utc>) -> Self {
-        Self { http, started_at }
+        Self {
+            http,
+            started_at,
+            known_revisions: BTreeMap::new(),
+        }
+    }
+
+    /// Add one stored upstream revision to this discovery run.
+    #[must_use]
+    pub fn with_known_revision(
+        mut self,
+        key: impl Into<String>,
+        revision: UpstreamRevision,
+    ) -> Self {
+        self.known_revisions.insert(key.into(), revision);
+        self
+    }
+
+    /// Borrow the stored upstream revisions for this discovery run.
+    #[must_use]
+    pub const fn known_revisions(&self) -> &BTreeMap<String, UpstreamRevision> {
+        &self.known_revisions
+    }
+}
+
+/// Stored upstream revision metadata supplied to adapter discovery.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpstreamRevision {
+    version: String,
+    last_updated: Option<String>,
+}
+
+impl UpstreamRevision {
+    /// Construct a stored upstream revision.
+    #[must_use]
+    pub fn new(version: impl Into<String>, last_updated: Option<impl Into<String>>) -> Self {
+        Self {
+            version: version.into(),
+            last_updated: last_updated.map(Into::into),
+        }
+    }
+
+    /// Upstream version string.
+    #[must_use]
+    pub fn version(&self) -> &str {
+        &self.version
+    }
+
+    /// Upstream update timestamp when exposed by the source.
+    #[must_use]
+    pub fn last_updated(&self) -> Option<&str> {
+        self.last_updated.as_deref()
     }
 }
 

--- a/crates/testing/tests/bench_scaffold.rs
+++ b/crates/testing/tests/bench_scaffold.rs
@@ -57,6 +57,24 @@ fn smoke_workflow_builds_server_before_readiness_polling() {
 }
 
 #[test]
+fn contract_workflow_builds_server_before_readiness_polling() {
+    let root = repo_root();
+    let pr_workflow =
+        fs::read_to_string(root.join(".github/workflows/pr.yml")).expect("read pr workflow");
+
+    assert!(
+        pr_workflow.contains("cargo build -p au-kpis-api-http --example contract_server --locked"),
+        "contract workflow should build the contract server before starting it"
+    );
+    assert!(
+        pr_workflow.contains(
+            "./target/debug/examples/contract_server > target/contract/server.log 2>&1 &"
+        ),
+        "contract workflow should start the prebuilt contract server binary"
+    );
+}
+
+#[test]
 fn bench_workflow_skips_missing_base_benchmark() {
     let root = repo_root();
     let pr_workflow =


### PR DESCRIPTION
Closes #24

## Pass requirements

- [x] Fetches the ABS SDMX dataflow listing needed for CPI discovery
- [x] Diffs against stored `last_updated` per dataflow
- [x] Emits `DiscoveredJob` entries for new or changed CPI releases
- [x] Fixture-driven unit tests cover diff logic and changed/unchanged cases
- [x] Integration coverage exercises the HTTP discovery path with deterministic fixtures, not a flaky live-upstream dependency

## Test plan

- `cargo fmt --all --check`
- `cargo test -p au-kpis-adapter-abs`
- `cargo clippy -p au-kpis-adapter-abs --all-targets -- -D warnings`
- `cargo check --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p au-kpis-api --test sigterm api_binary_honors_configured_shutdown_grace_period -- --nocapture`
- `cargo test -p au-kpis-api --test sigterm api_binary_serves_health_route -- --nocapture`

Note: `cargo test --workspace` was run but exposed an unrelated timing-sensitive `au-kpis-api` sigterm bound-address timeout. The failed sigterm cases passed when rerun individually; no ABS adapter tests failed.

## Spec impact

No Spec changes required. Implements `Spec.md § Source adapters` and `Spec.md § Phased rollout -> Phase 2` for ABS CPI discovery.