### PR TITLE
feat(pdf-client): add extract client (#23)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -437,7 +437,8 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p target/contract
-          cargo run -p au-kpis-api-http --example contract_server > target/contract/server.log 2>&1 &
+          cargo build -p au-kpis-api-http --example contract_server --locked
+          ./target/debug/examples/contract_server > target/contract/server.log 2>&1 &
           echo $! > target/contract/server.pid
 
       - name: Wait for API readiness

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,8 @@ name = "au-kpis-pdf-client"
 version = "0.1.0"
 dependencies = [
  "au-kpis-error",
+ "bytes",
+ "futures",
  "reqwest",
  "reqwest-middleware",
  "reqwest-tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,11 +364,14 @@ version = "0.1.0"
 dependencies = [
  "au-kpis-error",
  "reqwest",
+ "reqwest-middleware",
+ "reqwest-tracing",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -3181,6 +3184,37 @@ dependencies = [
  "web-sys",
  "webpki-roots 0.26.11",
  "windows-registry",
+]
+
+[[package]]
+name = "reqwest-middleware"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57f17d28a6e6acfe1733fe24bcd30774d13bffa4b8a22535b4c8c98423088d4e"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "serde",
+ "thiserror 1.0.69",
+ "tower-service",
+]
+
+[[package]]
+name = "reqwest-tracing"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d70ea85f131b2ee9874f0b160ac5976f8af75f3c9badfe0d955880257d10bd83"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "getrandom 0.2.17",
+ "http",
+ "matchit 0.8.4",
+ "reqwest",
+ "reqwest-middleware",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -361,6 +361,15 @@ dependencies = [
 [[package]]
 name = "au-kpis-pdf-client"
 version = "0.1.0"
+dependencies = [
+ "au-kpis-error",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "au-kpis-queue"

--- a/crates/au-kpis-pdf-client/Cargo.toml
+++ b/crates/au-kpis-pdf-client/Cargo.toml
@@ -10,6 +10,8 @@ description = "HTTP client for Python PDF sidecar."
 [dependencies]
 au-kpis-error = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest-middleware = { version = "0.4", features = ["json"] }
+reqwest-tracing = "0.5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
@@ -18,3 +20,4 @@ tracing = "0.1"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread"] }
+tracing-subscriber = "0.3"

--- a/crates/au-kpis-pdf-client/Cargo.toml
+++ b/crates/au-kpis-pdf-client/Cargo.toml
@@ -9,7 +9,9 @@ description = "HTTP client for Python PDF sidecar."
 
 [dependencies]
 au-kpis-error = { workspace = true }
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+bytes = "1"
+futures = "0.3"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
 reqwest-middleware = { version = "0.4", features = ["json"] }
 reqwest-tracing = "0.5"
 serde = { version = "1", features = ["derive"] }

--- a/crates/au-kpis-pdf-client/Cargo.toml
+++ b/crates/au-kpis-pdf-client/Cargo.toml
@@ -8,3 +8,13 @@ repository.workspace = true
 description = "HTTP client for Python PDF sidecar."
 
 [dependencies]
+au-kpis-error = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+thiserror = "2"
+tokio = { version = "1", features = ["time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread"] }

--- a/crates/au-kpis-pdf-client/src/lib.rs
+++ b/crates/au-kpis-pdf-client/src/lib.rs
@@ -3,10 +3,21 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs, missing_debug_implementations)]
 
-use std::{collections::BTreeMap, time::Duration};
+use std::{
+    collections::BTreeMap,
+    fmt,
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 use au_kpis_error::{Classify, ErrorClass};
-use reqwest::{StatusCode, Url};
+use bytes::Bytes;
+use futures::{Stream, StreamExt};
+use reqwest::{
+    StatusCode, Url,
+    header::{HeaderMap, RETRY_AFTER},
+};
 use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
 use reqwest_tracing::{OtelName, TracingMiddleware};
 use serde::{Deserialize, Serialize};
@@ -45,11 +56,69 @@ impl PdfClient {
             .base_url
             .join("extract")
             .map_err(|err| PdfClientError::InvalidUrl(err.to_string()))?;
+        self.extract_with_retries(&url, &request).await
+    }
+
+    /// Request table extraction and return the sidecar response body as a byte stream.
+    #[tracing::instrument(skip(self, request), fields(s3_key = %request.s3_key))]
+    pub async fn extract_stream(
+        &self,
+        request: ExtractRequest,
+    ) -> Result<ExtractionStream, PdfClientError> {
+        let url = self
+            .base_url
+            .join("extract")
+            .map_err(|err| PdfClientError::InvalidUrl(err.to_string()))?;
+        let response = self.send_extract_with_retries(&url, &request).await?;
+        Ok(ExtractionStream::new(
+            response
+                .bytes_stream()
+                .map(|chunk| chunk.map_err(PdfClientError::Http)),
+        ))
+    }
+
+    async fn send_extract_with_retries(
+        &self,
+        url: &Url,
+        request: &ExtractRequest,
+    ) -> Result<reqwest::Response, PdfClientError> {
+        let mut attempt = 1;
+
+        loop {
+            let result = match tokio::time::timeout(
+                self.request_timeout,
+                self.send_extract_once(url, request),
+            )
+            .await
+            {
+                Ok(result) => result,
+                Err(_) => Err(PdfClientError::Timeout {
+                    timeout: self.request_timeout,
+                }),
+            };
+            match result {
+                Ok(response) => return Ok(response),
+                Err(err) => {
+                    let Some(delay) = self.retry_delay(attempt, &err) else {
+                        return Err(err);
+                    };
+                    tokio::time::sleep(delay).await;
+                    attempt += 1;
+                }
+            }
+        }
+    }
+
+    async fn extract_with_retries(
+        &self,
+        url: &Url,
+        request: &ExtractRequest,
+    ) -> Result<ExtractionResponse, PdfClientError> {
         let mut attempt = 1;
 
         loop {
             let result =
-                match tokio::time::timeout(self.request_timeout, self.post_extract(&url, &request))
+                match tokio::time::timeout(self.request_timeout, self.extract_once(url, request))
                     .await
                 {
                     Ok(result) => result,
@@ -59,22 +128,43 @@ impl PdfClient {
                 };
             match result {
                 Ok(response) => return Ok(response),
-                Err(err)
-                    if attempt < self.retry_policy.max_attempts && err.class().is_retryable() =>
-                {
-                    tokio::time::sleep(self.retry_policy.delay_for_attempt(attempt)).await;
+                Err(err) => {
+                    let Some(delay) = self.retry_delay(attempt, &err) else {
+                        return Err(err);
+                    };
+                    tokio::time::sleep(delay).await;
                     attempt += 1;
                 }
-                Err(err) => return Err(err),
             }
         }
     }
 
-    async fn post_extract(
+    async fn extract_once(
         &self,
         url: &Url,
         request: &ExtractRequest,
     ) -> Result<ExtractionResponse, PdfClientError> {
+        let response = self.send_extract_once(url, request).await?;
+        let body = response.bytes().await?;
+        Ok(serde_json::from_slice(&body)?)
+    }
+
+    fn retry_delay(&self, attempt: u32, err: &PdfClientError) -> Option<Duration> {
+        if attempt < self.retry_policy.max_attempts && err.class().is_retryable() {
+            Some(
+                err.retry_after()
+                    .unwrap_or_else(|| self.retry_policy.delay_for_attempt(attempt)),
+            )
+        } else {
+            None
+        }
+    }
+
+    async fn send_extract_once(
+        &self,
+        url: &Url,
+        request: &ExtractRequest,
+    ) -> Result<reqwest::Response, PdfClientError> {
         let response = self
             .client
             .post(url.clone())
@@ -84,11 +174,46 @@ impl PdfClient {
             .await?;
         let status = response.status();
         if status.is_success() {
-            return Ok(response.json().await?);
+            return Ok(response);
         }
 
+        let retry_after = retry_after_header(response.headers());
         let body = response.text().await.unwrap_or_default();
-        Err(PdfClientError::Status { status, body })
+        Err(PdfClientError::Status {
+            status,
+            body,
+            retry_after,
+        })
+    }
+}
+
+/// Streaming byte response from the PDF sidecar.
+pub struct ExtractionStream {
+    inner: Pin<Box<dyn Stream<Item = Result<Bytes, PdfClientError>> + Send + 'static>>,
+}
+
+impl ExtractionStream {
+    fn new<S>(stream: S) -> Self
+    where
+        S: Stream<Item = Result<Bytes, PdfClientError>> + Send + 'static,
+    {
+        Self {
+            inner: Box::pin(stream),
+        }
+    }
+}
+
+impl fmt::Debug for ExtractionStream {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ExtractionStream").finish_non_exhaustive()
+    }
+}
+
+impl Stream for ExtractionStream {
+    type Item = Result<Bytes, PdfClientError>;
+
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        self.get_mut().inner.as_mut().poll_next(cx)
     }
 }
 
@@ -354,6 +479,8 @@ pub enum PdfClientError {
         status: StatusCode,
         /// Response body, if available.
         body: String,
+        /// Parsed `Retry-After` hint when the sidecar supplied one.
+        retry_after: Option<Duration>,
     },
 
     /// Sidecar request exceeded the configured timeout.
@@ -366,6 +493,10 @@ pub enum PdfClientError {
     /// Caller supplied invalid configuration.
     #[error("validation: {0}")]
     Validation(String),
+
+    /// Sidecar response body did not match the expected response shape.
+    #[error("json: {0}")]
+    Json(#[from] serde_json::Error),
 }
 
 impl Classify for PdfClientError {
@@ -374,6 +505,7 @@ impl Classify for PdfClientError {
             Self::MissingBaseUrl | Self::InvalidUrl(_) | Self::Validation(_) => {
                 ErrorClass::Validation
             }
+            Self::Json(_) => ErrorClass::Permanent,
             Self::Http(err) => {
                 if err.is_decode() {
                     ErrorClass::Permanent
@@ -389,7 +521,7 @@ impl Classify for PdfClientError {
                 }
             }
             Self::Status { status, .. } => {
-                if status.is_server_error() {
+                if *status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
                     ErrorClass::Transient
                 } else {
                     ErrorClass::Permanent
@@ -398,6 +530,23 @@ impl Classify for PdfClientError {
             Self::Timeout { .. } => ErrorClass::Transient,
         }
     }
+
+    fn retry_after(&self) -> Option<Duration> {
+        match self {
+            Self::Status { retry_after, .. } => *retry_after,
+            _ => None,
+        }
+    }
+}
+
+fn retry_after_header(headers: &HeaderMap) -> Option<Duration> {
+    headers
+        .get(RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .parse::<u64>()
+        .ok()
+        .map(Duration::from_secs)
 }
 
 #[cfg(test)]
@@ -539,7 +688,8 @@ mod tests {
         assert_eq!(
             PdfClientError::Status {
                 status: StatusCode::BAD_REQUEST,
-                body: "bad request".to_string()
+                body: "bad request".to_string(),
+                retry_after: None,
             }
             .class(),
             ErrorClass::Permanent
@@ -547,10 +697,18 @@ mod tests {
         assert_eq!(
             PdfClientError::Status {
                 status: StatusCode::SERVICE_UNAVAILABLE,
-                body: "busy".to_string()
+                body: "busy".to_string(),
+                retry_after: None,
             }
             .class(),
             ErrorClass::Transient
         );
+        let rate_limited = PdfClientError::Status {
+            status: StatusCode::TOO_MANY_REQUESTS,
+            body: "rate limited".to_string(),
+            retry_after: Some(Duration::from_secs(7)),
+        };
+        assert_eq!(rate_limited.class(), ErrorClass::Transient);
+        assert_eq!(rate_limited.retry_after(), Some(Duration::from_secs(7)));
     }
 }

--- a/crates/au-kpis-pdf-client/src/lib.rs
+++ b/crates/au-kpis-pdf-client/src/lib.rs
@@ -20,6 +20,7 @@ pub struct PdfClient {
     client: ClientWithMiddleware,
     base_url: Url,
     retry_policy: RetryPolicy,
+    request_timeout: Duration,
 }
 
 impl PdfClient {
@@ -47,7 +48,15 @@ impl PdfClient {
         let mut attempt = 1;
 
         loop {
-            let result = self.post_extract(&url, &request).await;
+            let result =
+                match tokio::time::timeout(self.request_timeout, self.post_extract(&url, &request))
+                    .await
+                {
+                    Ok(result) => result,
+                    Err(_) => Err(PdfClientError::Timeout {
+                        timeout: self.request_timeout,
+                    }),
+                };
             match result {
                 Ok(response) => return Ok(response),
                 Err(err)
@@ -125,7 +134,7 @@ impl PdfClientBuilder {
         self
     }
 
-    /// Set the request timeout used by the default HTTP client.
+    /// Set the per-attempt request timeout.
     #[must_use]
     pub const fn timeout(mut self, request_timeout: Duration) -> Self {
         self.request_timeout = request_timeout;
@@ -150,6 +159,7 @@ impl PdfClientBuilder {
             client: traced_http_client(client),
             base_url,
             retry_policy: self.retry_policy,
+            request_timeout: self.request_timeout,
         })
     }
 }
@@ -346,6 +356,13 @@ pub enum PdfClientError {
         body: String,
     },
 
+    /// Sidecar request exceeded the configured timeout.
+    #[error("pdf sidecar request timed out after {timeout:?}")]
+    Timeout {
+        /// Configured per-attempt timeout.
+        timeout: Duration,
+    },
+
     /// Caller supplied invalid configuration.
     #[error("validation: {0}")]
     Validation(String),
@@ -378,6 +395,7 @@ impl Classify for PdfClientError {
                     ErrorClass::Permanent
                 }
             }
+            Self::Timeout { .. } => ErrorClass::Transient,
         }
     }
 }

--- a/crates/au-kpis-pdf-client/src/lib.rs
+++ b/crates/au-kpis-pdf-client/src/lib.rs
@@ -10,6 +10,8 @@ use reqwest::{StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// HTTP client for `POST /extract`.
 #[derive(Debug, Clone)]
 pub struct PdfClient {
@@ -76,17 +78,19 @@ impl PdfClient {
 /// Builder for [`PdfClient`].
 #[derive(Debug, Clone)]
 pub struct PdfClientBuilder {
-    client: reqwest::Client,
+    client: Option<reqwest::Client>,
     base_url: Option<String>,
     retry_policy: RetryPolicy,
+    request_timeout: Duration,
 }
 
 impl Default for PdfClientBuilder {
     fn default() -> Self {
         Self {
-            client: reqwest::Client::new(),
+            client: None,
             base_url: None,
             retry_policy: RetryPolicy::default(),
+            request_timeout: DEFAULT_REQUEST_TIMEOUT,
         }
     }
 }
@@ -95,7 +99,7 @@ impl PdfClientBuilder {
     /// Override the underlying HTTP client.
     #[must_use]
     pub fn http_client(mut self, client: reqwest::Client) -> Self {
-        self.client = client;
+        self.client = Some(client);
         self
     }
 
@@ -113,6 +117,13 @@ impl PdfClientBuilder {
         self
     }
 
+    /// Set the request timeout used by the default HTTP client.
+    #[must_use]
+    pub const fn timeout(mut self, request_timeout: Duration) -> Self {
+        self.request_timeout = request_timeout;
+        self
+    }
+
     /// Build the client.
     pub fn build(self) -> Result<PdfClient, PdfClientError> {
         let base_url = self
@@ -121,8 +132,14 @@ impl PdfClientBuilder {
             .and_then(|url| {
                 Url::parse(&url).map_err(|err| PdfClientError::InvalidUrl(err.to_string()))
             })?;
+        let client = match self.client {
+            Some(client) => client,
+            None => reqwest::Client::builder()
+                .timeout(self.request_timeout)
+                .build()?,
+        };
         Ok(PdfClient {
-            client: self.client,
+            client,
             base_url,
             retry_policy: self.retry_policy,
         })
@@ -178,8 +195,7 @@ impl RetryPolicy {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct ExtractRequest {
     s3_key: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    source_id: Option<String>,
+    source_id: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     artifact_date: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -187,22 +203,15 @@ pub struct ExtractRequest {
 }
 
 impl ExtractRequest {
-    /// Construct a request for the stored artifact key.
+    /// Construct a request for the stored artifact key and source id.
     #[must_use]
-    pub fn new(s3_key: impl Into<String>) -> Self {
+    pub fn new(s3_key: impl Into<String>, source_id: impl Into<String>) -> Self {
         Self {
             s3_key: s3_key.into(),
-            source_id: None,
+            source_id: source_id.into(),
             artifact_date: None,
             strategy: None,
         }
-    }
-
-    /// Set source id context.
-    #[must_use]
-    pub fn source_id(mut self, source_id: impl Into<String>) -> Self {
-        self.source_id = Some(source_id.into());
-        self
     }
 
     /// Set artifact publication date context.
@@ -275,9 +284,25 @@ pub struct TableCandidate {
     pub bbox: [f64; 4],
     /// Raw table cells, preserving sidecar row/column structure.
     pub cells: Vec<Vec<String>>,
+    /// Row/column span metadata for merged cells when available.
+    #[serde(default, alias = "cell_spans")]
+    pub spans: Vec<CellSpan>,
     /// Backend diagnostics such as confidence.
     #[serde(default)]
     pub diagnostics: BTreeMap<String, serde_json::Value>,
+}
+
+/// Row/column span metadata for a table cell.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+pub struct CellSpan {
+    /// Zero-indexed cell row.
+    pub row: u32,
+    /// Zero-indexed cell column.
+    pub column: u32,
+    /// Number of rows covered by the cell.
+    pub row_span: u32,
+    /// Number of columns covered by the cell.
+    pub column_span: u32,
 }
 
 /// Errors returned by the PDF client.
@@ -382,13 +407,16 @@ mod tests {
     }
 
     #[test]
-    fn extraction_request_omits_optional_fields_until_set() {
-        let minimal = serde_json::to_value(ExtractRequest::new("raw/report.pdf")).unwrap();
-        assert_eq!(minimal, serde_json::json!({ "s3_key": "raw/report.pdf" }));
+    fn extraction_request_requires_source_id_and_omits_optional_fields_until_set() {
+        let minimal =
+            serde_json::to_value(ExtractRequest::new("raw/report.pdf", "treasury")).unwrap();
+        assert_eq!(
+            minimal,
+            serde_json::json!({ "s3_key": "raw/report.pdf", "source_id": "treasury" })
+        );
 
         let enriched = serde_json::to_value(
-            ExtractRequest::new("raw/report.pdf")
-                .source_id("treasury")
+            ExtractRequest::new("raw/report.pdf", "treasury")
                 .artifact_date("2026-05-12")
                 .strategy(ExtractionStrategy::ModelFallback),
         )
@@ -415,6 +443,40 @@ mod tests {
         assert_eq!(response.backend.kind, ExtractionBackendKind::Model);
         assert_eq!(response.backend.model_sha256.as_deref(), Some("abc123"));
         assert!(response.tables.is_empty());
+    }
+
+    #[test]
+    fn extraction_response_preserves_cell_span_metadata() {
+        let response: ExtractionResponse = serde_json::from_value(serde_json::json!({
+            "artifact_key": "raw/report.pdf",
+            "backend": {
+                "kind": "deterministic",
+                "name": "camelot",
+                "version": "1.0.0",
+                "model_sha256": null
+            },
+            "tables": [
+                {
+                    "page": 3,
+                    "bbox": [10.0, 20.0, 30.0, 40.0],
+                    "cells": [["Year", "Revenue"]],
+                    "spans": [
+                        {
+                            "row": 0,
+                            "column": 0,
+                            "row_span": 1,
+                            "column_span": 2
+                        }
+                    ]
+                }
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(response.tables[0].spans[0].row, 0);
+        assert_eq!(response.tables[0].spans[0].column, 0);
+        assert_eq!(response.tables[0].spans[0].row_span, 1);
+        assert_eq!(response.tables[0].spans[0].column_span, 2);
     }
 
     #[test]

--- a/crates/au-kpis-pdf-client/src/lib.rs
+++ b/crates/au-kpis-pdf-client/src/lib.rs
@@ -7,6 +7,8 @@ use std::{collections::BTreeMap, time::Duration};
 
 use au_kpis_error::{Classify, ErrorClass};
 use reqwest::{StatusCode, Url};
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_tracing::{OtelName, TracingMiddleware};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -15,7 +17,7 @@ const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 /// HTTP client for `POST /extract`.
 #[derive(Debug, Clone)]
 pub struct PdfClient {
-    client: reqwest::Client,
+    client: ClientWithMiddleware,
     base_url: Url,
     retry_policy: RetryPolicy,
 }
@@ -64,7 +66,13 @@ impl PdfClient {
         url: &Url,
         request: &ExtractRequest,
     ) -> Result<ExtractionResponse, PdfClientError> {
-        let response = self.client.post(url.clone()).json(request).send().await?;
+        let response = self
+            .client
+            .post(url.clone())
+            .with_extension(OtelName("pdf.extract".into()))
+            .json(request)
+            .send()
+            .await?;
         let status = response.status();
         if status.is_success() {
             return Ok(response.json().await?);
@@ -139,11 +147,17 @@ impl PdfClientBuilder {
                 .build()?,
         };
         Ok(PdfClient {
-            client,
+            client: traced_http_client(client),
             base_url,
             retry_policy: self.retry_policy,
         })
     }
+}
+
+fn traced_http_client(client: reqwest::Client) -> ClientWithMiddleware {
+    ClientBuilder::new(client)
+        .with(TracingMiddleware::default())
+        .build()
 }
 
 /// Retry policy for transient sidecar failures.
@@ -248,7 +262,6 @@ pub struct ExtractionResponse {
     /// Backend that produced table candidates.
     pub backend: BackendInfo,
     /// Extracted table candidates.
-    #[serde(default)]
     pub tables: Vec<TableCandidate>,
 }
 
@@ -320,6 +333,10 @@ pub enum PdfClientError {
     #[error("http: {0}")]
     Http(#[from] reqwest::Error),
 
+    /// Middleware-wrapped HTTP request failed before a response was available.
+    #[error("http middleware: {0}")]
+    Middleware(#[from] reqwest_middleware::Error),
+
     /// Sidecar returned an unsuccessful status.
     #[error("pdf sidecar returned {status}: {body}")]
     Status {
@@ -341,6 +358,13 @@ impl Classify for PdfClientError {
                 ErrorClass::Validation
             }
             Self::Http(err) => {
+                if err.is_decode() {
+                    ErrorClass::Permanent
+                } else {
+                    ErrorClass::Transient
+                }
+            }
+            Self::Middleware(err) => {
                 if err.is_decode() {
                     ErrorClass::Permanent
                 } else {
@@ -427,8 +451,25 @@ mod tests {
     }
 
     #[test]
-    fn extraction_response_accepts_s3_key_alias_and_defaults_tables() {
+    fn extraction_response_accepts_s3_key_alias_and_requires_tables() {
         let response: ExtractionResponse = serde_json::from_value(serde_json::json!({
+            "s3_key": "raw/report.pdf",
+            "backend": {
+                "kind": "model",
+                "name": "layoutlm",
+                "version": "1.0.0",
+                "model_sha256": "abc123"
+            },
+            "tables": []
+        }))
+        .unwrap();
+
+        assert_eq!(response.artifact_key, "raw/report.pdf");
+        assert_eq!(response.backend.kind, ExtractionBackendKind::Model);
+        assert_eq!(response.backend.model_sha256.as_deref(), Some("abc123"));
+        assert!(response.tables.is_empty());
+
+        let err = serde_json::from_value::<ExtractionResponse>(serde_json::json!({
             "s3_key": "raw/report.pdf",
             "backend": {
                 "kind": "model",
@@ -437,12 +478,8 @@ mod tests {
                 "model_sha256": "abc123"
             }
         }))
-        .unwrap();
-
-        assert_eq!(response.artifact_key, "raw/report.pdf");
-        assert_eq!(response.backend.kind, ExtractionBackendKind::Model);
-        assert_eq!(response.backend.model_sha256.as_deref(), Some("abc123"));
-        assert!(response.tables.is_empty());
+        .expect_err("missing tables should be a response contract error");
+        assert!(err.to_string().contains("tables"));
     }
 
     #[test]

--- a/crates/au-kpis-pdf-client/src/lib.rs
+++ b/crates/au-kpis-pdf-client/src/lib.rs
@@ -6,6 +6,7 @@
 use std::{
     collections::BTreeMap,
     fmt,
+    future::Future,
     pin::Pin,
     task::{Context, Poll},
     time::Duration,
@@ -74,6 +75,7 @@ impl PdfClient {
             response
                 .bytes_stream()
                 .map(|chunk| chunk.map_err(PdfClientError::Http)),
+            self.request_timeout,
         ))
     }
 
@@ -190,15 +192,21 @@ impl PdfClient {
 /// Streaming byte response from the PDF sidecar.
 pub struct ExtractionStream {
     inner: Pin<Box<dyn Stream<Item = Result<Bytes, PdfClientError>> + Send + 'static>>,
+    timeout: Duration,
+    deadline: Option<Pin<Box<tokio::time::Sleep>>>,
+    finished: bool,
 }
 
 impl ExtractionStream {
-    fn new<S>(stream: S) -> Self
+    fn new<S>(stream: S, timeout: Duration) -> Self
     where
         S: Stream<Item = Result<Bytes, PdfClientError>> + Send + 'static,
     {
         Self {
             inner: Box::pin(stream),
+            timeout,
+            deadline: None,
+            finished: false,
         }
     }
 }
@@ -213,7 +221,38 @@ impl Stream for ExtractionStream {
     type Item = Result<Bytes, PdfClientError>;
 
     fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        self.get_mut().inner.as_mut().poll_next(cx)
+        let this = self.get_mut();
+        if this.finished {
+            return Poll::Ready(None);
+        }
+        if this.deadline.is_none() {
+            this.deadline = Some(Box::pin(tokio::time::sleep(this.timeout)));
+        }
+
+        match this.inner.as_mut().poll_next(cx) {
+            Poll::Ready(item) => {
+                this.deadline = None;
+                if item.is_none() {
+                    this.finished = true;
+                }
+                Poll::Ready(item)
+            }
+            Poll::Pending => {
+                let timed_out = this
+                    .deadline
+                    .as_mut()
+                    .is_some_and(|deadline| deadline.as_mut().poll(cx).is_ready());
+                if timed_out {
+                    this.deadline = None;
+                    this.finished = true;
+                    Poll::Ready(Some(Err(PdfClientError::Timeout {
+                        timeout: this.timeout,
+                    })))
+                } else {
+                    Poll::Pending
+                }
+            }
+        }
     }
 }
 
@@ -390,9 +429,9 @@ pub enum ExtractionStrategy {
 
 /// Response body returned by the PDF sidecar.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct ExtractionResponse {
     /// Artifact key extracted by the sidecar.
-    #[serde(alias = "s3_key")]
     pub artifact_key: String,
     /// Backend that produced table candidates.
     pub backend: BackendInfo,
@@ -402,6 +441,7 @@ pub struct ExtractionResponse {
 
 /// Backend metadata for extraction.
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct BackendInfo {
     /// Backend kind.
     pub kind: ExtractionBackendKind,
@@ -425,6 +465,7 @@ pub enum ExtractionBackendKind {
 
 /// Extracted table candidate.
 #[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TableCandidate {
     /// 1-indexed page number.
     pub page: u32,
@@ -433,7 +474,7 @@ pub struct TableCandidate {
     /// Raw table cells, preserving sidecar row/column structure.
     pub cells: Vec<Vec<String>>,
     /// Row/column span metadata for merged cells when available.
-    #[serde(default, alias = "cell_spans")]
+    #[serde(default)]
     pub spans: Vec<CellSpan>,
     /// Backend diagnostics such as confidence.
     #[serde(default)]
@@ -442,6 +483,7 @@ pub struct TableCandidate {
 
 /// Row/column span metadata for a table cell.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct CellSpan {
     /// Zero-indexed cell row.
     pub row: u32,
@@ -618,9 +660,9 @@ mod tests {
     }
 
     #[test]
-    fn extraction_response_accepts_s3_key_alias_and_requires_tables() {
+    fn extraction_response_requires_contract_fields() {
         let response: ExtractionResponse = serde_json::from_value(serde_json::json!({
-            "s3_key": "raw/report.pdf",
+            "artifact_key": "raw/report.pdf",
             "backend": {
                 "kind": "model",
                 "name": "layoutlm",
@@ -638,6 +680,19 @@ mod tests {
 
         let err = serde_json::from_value::<ExtractionResponse>(serde_json::json!({
             "s3_key": "raw/report.pdf",
+            "backend": {
+                "kind": "model",
+                "name": "layoutlm",
+                "version": "1.0.0",
+                "model_sha256": "abc123"
+            },
+            "tables": []
+        }))
+        .expect_err("s3_key is a request field, not a response field");
+        assert!(err.to_string().contains("artifact_key"));
+
+        let err = serde_json::from_value::<ExtractionResponse>(serde_json::json!({
+            "artifact_key": "raw/report.pdf",
             "backend": {
                 "kind": "model",
                 "name": "layoutlm",
@@ -681,6 +736,33 @@ mod tests {
         assert_eq!(response.tables[0].spans[0].column, 0);
         assert_eq!(response.tables[0].spans[0].row_span, 1);
         assert_eq!(response.tables[0].spans[0].column_span, 2);
+
+        let err = serde_json::from_value::<ExtractionResponse>(serde_json::json!({
+            "artifact_key": "raw/report.pdf",
+            "backend": {
+                "kind": "deterministic",
+                "name": "camelot",
+                "version": "1.0.0",
+                "model_sha256": null
+            },
+            "tables": [
+                {
+                    "page": 3,
+                    "bbox": [10.0, 20.0, 30.0, 40.0],
+                    "cells": [["Year", "Revenue"]],
+                    "cell_spans": [
+                        {
+                            "row": 0,
+                            "column": 0,
+                            "row_span": 1,
+                            "column_span": 2
+                        }
+                    ]
+                }
+            ]
+        }))
+        .expect_err("cell_spans is not part of the sidecar response contract");
+        assert!(err.to_string().contains("cell_spans"));
     }
 
     #[test]

--- a/crates/au-kpis-pdf-client/src/lib.rs
+++ b/crates/au-kpis-pdf-client/src/lib.rs
@@ -1,1 +1,334 @@
-//! HTTP client for Python PDF sidecar.
+//! HTTP client for the Python PDF extractor sidecar.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::{collections::BTreeMap, time::Duration};
+
+use au_kpis_error::{Classify, ErrorClass};
+use reqwest::{StatusCode, Url};
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// HTTP client for `POST /extract`.
+#[derive(Debug, Clone)]
+pub struct PdfClient {
+    client: reqwest::Client,
+    base_url: Url,
+    retry_policy: RetryPolicy,
+}
+
+impl PdfClient {
+    /// Start building a PDF client.
+    #[must_use]
+    pub fn builder() -> PdfClientBuilder {
+        PdfClientBuilder::default()
+    }
+
+    /// Construct a client with default retry policy.
+    pub fn new(base_url: impl AsRef<str>) -> Result<Self, PdfClientError> {
+        Self::builder().base_url(base_url).build()
+    }
+
+    /// Request table extraction for one stored PDF artifact.
+    #[tracing::instrument(skip(self, request), fields(s3_key = %request.s3_key))]
+    pub async fn extract(
+        &self,
+        request: ExtractRequest,
+    ) -> Result<ExtractionResponse, PdfClientError> {
+        let url = self
+            .base_url
+            .join("extract")
+            .map_err(|err| PdfClientError::InvalidUrl(err.to_string()))?;
+        let mut attempt = 1;
+
+        loop {
+            let result = self.post_extract(&url, &request).await;
+            match result {
+                Ok(response) => return Ok(response),
+                Err(err)
+                    if attempt < self.retry_policy.max_attempts && err.class().is_retryable() =>
+                {
+                    tokio::time::sleep(self.retry_policy.delay_for_attempt(attempt)).await;
+                    attempt += 1;
+                }
+                Err(err) => return Err(err),
+            }
+        }
+    }
+
+    async fn post_extract(
+        &self,
+        url: &Url,
+        request: &ExtractRequest,
+    ) -> Result<ExtractionResponse, PdfClientError> {
+        let response = self.client.post(url.clone()).json(request).send().await?;
+        let status = response.status();
+        if status.is_success() {
+            return Ok(response.json().await?);
+        }
+
+        let body = response.text().await.unwrap_or_default();
+        Err(PdfClientError::Status { status, body })
+    }
+}
+
+/// Builder for [`PdfClient`].
+#[derive(Debug, Clone)]
+pub struct PdfClientBuilder {
+    client: reqwest::Client,
+    base_url: Option<String>,
+    retry_policy: RetryPolicy,
+}
+
+impl Default for PdfClientBuilder {
+    fn default() -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: None,
+            retry_policy: RetryPolicy::default(),
+        }
+    }
+}
+
+impl PdfClientBuilder {
+    /// Override the underlying HTTP client.
+    #[must_use]
+    pub fn http_client(mut self, client: reqwest::Client) -> Self {
+        self.client = client;
+        self
+    }
+
+    /// Set the PDF sidecar base URL.
+    #[must_use]
+    pub fn base_url(mut self, base_url: impl AsRef<str>) -> Self {
+        self.base_url = Some(base_url.as_ref().trim_end_matches('/').to_string() + "/");
+        self
+    }
+
+    /// Set retry policy.
+    #[must_use]
+    pub const fn retry_policy(mut self, retry_policy: RetryPolicy) -> Self {
+        self.retry_policy = retry_policy;
+        self
+    }
+
+    /// Build the client.
+    pub fn build(self) -> Result<PdfClient, PdfClientError> {
+        let base_url = self
+            .base_url
+            .ok_or(PdfClientError::MissingBaseUrl)
+            .and_then(|url| {
+                Url::parse(&url).map_err(|err| PdfClientError::InvalidUrl(err.to_string()))
+            })?;
+        Ok(PdfClient {
+            client: self.client,
+            base_url,
+            retry_policy: self.retry_policy,
+        })
+    }
+}
+
+/// Retry policy for transient sidecar failures.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RetryPolicy {
+    max_attempts: u32,
+    initial_backoff: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 3,
+            initial_backoff: Duration::from_millis(100),
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// Construct a retry policy.
+    pub fn new(max_attempts: u32, initial_backoff: Duration) -> Result<Self, PdfClientError> {
+        if max_attempts == 0 {
+            return Err(PdfClientError::Validation(
+                "max_attempts must be greater than zero".to_string(),
+            ));
+        }
+        Ok(Self {
+            max_attempts,
+            initial_backoff,
+        })
+    }
+
+    /// Disable retries.
+    #[must_use]
+    pub const fn none() -> Self {
+        Self {
+            max_attempts: 1,
+            initial_backoff: Duration::ZERO,
+        }
+    }
+
+    fn delay_for_attempt(self, attempt: u32) -> Duration {
+        let multiplier = 1_u32 << attempt.saturating_sub(1).min(6);
+        self.initial_backoff.saturating_mul(multiplier)
+    }
+}
+
+/// Request body for `POST /extract`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ExtractRequest {
+    s3_key: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    source_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    artifact_date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    strategy: Option<ExtractionStrategy>,
+}
+
+impl ExtractRequest {
+    /// Construct a request for the stored artifact key.
+    #[must_use]
+    pub fn new(s3_key: impl Into<String>) -> Self {
+        Self {
+            s3_key: s3_key.into(),
+            source_id: None,
+            artifact_date: None,
+            strategy: None,
+        }
+    }
+
+    /// Set source id context.
+    #[must_use]
+    pub fn source_id(mut self, source_id: impl Into<String>) -> Self {
+        self.source_id = Some(source_id.into());
+        self
+    }
+
+    /// Set artifact publication date context.
+    #[must_use]
+    pub fn artifact_date(mut self, artifact_date: impl Into<String>) -> Self {
+        self.artifact_date = Some(artifact_date.into());
+        self
+    }
+
+    /// Set extraction strategy preference.
+    #[must_use]
+    pub const fn strategy(mut self, strategy: ExtractionStrategy) -> Self {
+        self.strategy = Some(strategy);
+        self
+    }
+}
+
+/// Extraction strategy requested from the sidecar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtractionStrategy {
+    /// Deterministic `pdfplumber`/`camelot` path.
+    Deterministic,
+    /// Local model fallback path.
+    ModelFallback,
+}
+
+/// Response body returned by the PDF sidecar.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct ExtractionResponse {
+    /// Artifact key extracted by the sidecar.
+    #[serde(alias = "s3_key")]
+    pub artifact_key: String,
+    /// Backend that produced table candidates.
+    pub backend: BackendInfo,
+    /// Extracted table candidates.
+    #[serde(default)]
+    pub tables: Vec<TableCandidate>,
+}
+
+/// Backend metadata for extraction.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct BackendInfo {
+    /// Backend kind.
+    pub kind: ExtractionBackendKind,
+    /// Backend name.
+    pub name: String,
+    /// Backend version.
+    pub version: String,
+    /// Optional model weights checksum.
+    pub model_sha256: Option<String>,
+}
+
+/// Backend family that produced extraction candidates.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExtractionBackendKind {
+    /// Deterministic backend.
+    Deterministic,
+    /// Model backend.
+    Model,
+}
+
+/// Extracted table candidate.
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+pub struct TableCandidate {
+    /// 1-indexed page number.
+    pub page: u32,
+    /// Bounding box `[x1, y1, x2, y2]`.
+    pub bbox: [f64; 4],
+    /// Raw table cells, preserving sidecar row/column structure.
+    pub cells: Vec<Vec<String>>,
+    /// Backend diagnostics such as confidence.
+    #[serde(default)]
+    pub diagnostics: BTreeMap<String, serde_json::Value>,
+}
+
+/// Errors returned by the PDF client.
+#[derive(Debug, Error)]
+pub enum PdfClientError {
+    /// Base URL was not configured.
+    #[error("pdf client base_url is required")]
+    MissingBaseUrl,
+
+    /// URL parsing or joining failed.
+    #[error("invalid url: {0}")]
+    InvalidUrl(String),
+
+    /// HTTP request failed before a response was available.
+    #[error("http: {0}")]
+    Http(#[from] reqwest::Error),
+
+    /// Sidecar returned an unsuccessful status.
+    #[error("pdf sidecar returned {status}: {body}")]
+    Status {
+        /// HTTP status code.
+        status: StatusCode,
+        /// Response body, if available.
+        body: String,
+    },
+
+    /// Caller supplied invalid configuration.
+    #[error("validation: {0}")]
+    Validation(String),
+}
+
+impl Classify for PdfClientError {
+    fn class(&self) -> ErrorClass {
+        match self {
+            Self::MissingBaseUrl | Self::InvalidUrl(_) | Self::Validation(_) => {
+                ErrorClass::Validation
+            }
+            Self::Http(err) => {
+                if err.is_decode() {
+                    ErrorClass::Permanent
+                } else {
+                    ErrorClass::Transient
+                }
+            }
+            Self::Status { status, .. } => {
+                if status.is_server_error() {
+                    ErrorClass::Transient
+                } else {
+                    ErrorClass::Permanent
+                }
+            }
+        }
+    }
+}

--- a/crates/au-kpis-pdf-client/src/lib.rs
+++ b/crates/au-kpis-pdf-client/src/lib.rs
@@ -332,3 +332,108 @@ impl Classify for PdfClientError {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn builder_requires_base_url_and_rejects_invalid_url() {
+        assert_eq!(
+            PdfClient::builder().build().unwrap_err().class(),
+            ErrorClass::Validation
+        );
+        assert_eq!(
+            PdfClient::new("not a url").unwrap_err().class(),
+            ErrorClass::Validation
+        );
+    }
+
+    #[test]
+    fn builder_normalizes_base_url_and_accepts_custom_http_client() {
+        let client = reqwest::Client::builder().build().unwrap();
+        let pdf_client = PdfClient::builder()
+            .http_client(client)
+            .base_url("http://127.0.0.1:3000////")
+            .retry_policy(RetryPolicy::none())
+            .build()
+            .unwrap();
+
+        assert_eq!(pdf_client.base_url.as_str(), "http://127.0.0.1:3000/");
+        assert_eq!(pdf_client.retry_policy, RetryPolicy::none());
+    }
+
+    #[test]
+    fn retry_policy_rejects_zero_attempts_and_caps_backoff() {
+        assert_eq!(
+            RetryPolicy::new(0, Duration::ZERO).unwrap_err().class(),
+            ErrorClass::Validation
+        );
+
+        let retry_policy = RetryPolicy::new(3, Duration::from_millis(10)).unwrap();
+        assert_eq!(retry_policy.delay_for_attempt(0), Duration::from_millis(10));
+        assert_eq!(retry_policy.delay_for_attempt(1), Duration::from_millis(10));
+        assert_eq!(retry_policy.delay_for_attempt(2), Duration::from_millis(20));
+        assert_eq!(
+            retry_policy.delay_for_attempt(99),
+            Duration::from_millis(640)
+        );
+        assert_eq!(RetryPolicy::none().delay_for_attempt(2), Duration::ZERO);
+    }
+
+    #[test]
+    fn extraction_request_omits_optional_fields_until_set() {
+        let minimal = serde_json::to_value(ExtractRequest::new("raw/report.pdf")).unwrap();
+        assert_eq!(minimal, serde_json::json!({ "s3_key": "raw/report.pdf" }));
+
+        let enriched = serde_json::to_value(
+            ExtractRequest::new("raw/report.pdf")
+                .source_id("treasury")
+                .artifact_date("2026-05-12")
+                .strategy(ExtractionStrategy::ModelFallback),
+        )
+        .unwrap();
+        assert_eq!(enriched["source_id"], "treasury");
+        assert_eq!(enriched["artifact_date"], "2026-05-12");
+        assert_eq!(enriched["strategy"], "model_fallback");
+    }
+
+    #[test]
+    fn extraction_response_accepts_s3_key_alias_and_defaults_tables() {
+        let response: ExtractionResponse = serde_json::from_value(serde_json::json!({
+            "s3_key": "raw/report.pdf",
+            "backend": {
+                "kind": "model",
+                "name": "layoutlm",
+                "version": "1.0.0",
+                "model_sha256": "abc123"
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(response.artifact_key, "raw/report.pdf");
+        assert_eq!(response.backend.kind, ExtractionBackendKind::Model);
+        assert_eq!(response.backend.model_sha256.as_deref(), Some("abc123"));
+        assert!(response.tables.is_empty());
+    }
+
+    #[test]
+    fn error_classification_separates_retryable_statuses() {
+        assert_eq!(
+            PdfClientError::Status {
+                status: StatusCode::BAD_REQUEST,
+                body: "bad request".to_string()
+            }
+            .class(),
+            ErrorClass::Permanent
+        );
+        assert_eq!(
+            PdfClientError::Status {
+                status: StatusCode::SERVICE_UNAVAILABLE,
+                body: "busy".to_string()
+            }
+            .class(),
+            ErrorClass::Transient
+        );
+    }
+}

--- a/crates/au-kpis-pdf-client/tests/client.rs
+++ b/crates/au-kpis-pdf-client/tests/client.rs
@@ -6,6 +6,7 @@ use std::{
     time::Duration,
 };
 
+use au_kpis_error::{Classify, ErrorClass};
 use au_kpis_pdf_client::{
     ExtractRequest, ExtractionBackendKind, ExtractionStrategy, PdfClient, RetryPolicy,
 };
@@ -53,8 +54,7 @@ async fn serve_responses(
 }
 
 fn request() -> ExtractRequest {
-    ExtractRequest::new("artifacts/abc123")
-        .source_id("treasury")
+    ExtractRequest::new("artifacts/abc123", "treasury")
         .artifact_date("2026-05-12")
         .strategy(ExtractionStrategy::Deterministic)
 }
@@ -74,6 +74,7 @@ async fn extract_posts_typed_request_and_parses_tables() {
           "page": 12,
           "bbox": [72.0, 120.0, 540.0, 720.0],
           "cells": [["Year", "Revenue"], ["2026-27", "123.4"]],
+          "spans": [{"row": 0, "column": 0, "row_span": 1, "column_span": 2}],
           "diagnostics": {"confidence": 0.98}
         }
       ]
@@ -92,6 +93,7 @@ async fn extract_posts_typed_request_and_parses_tables() {
     assert_eq!(extracted.backend.kind, ExtractionBackendKind::Deterministic);
     assert_eq!(extracted.tables[0].page, 12);
     assert_eq!(extracted.tables[0].cells[1][1], "123.4");
+    assert_eq!(extracted.tables[0].spans[0].column_span, 2);
     assert_eq!(extracted.tables[0].diagnostics["confidence"], 0.98);
 }
 
@@ -120,4 +122,37 @@ async fn extract_retries_5xx_with_backoff() {
     assert_eq!(attempts.load(Ordering::SeqCst), 2);
     assert_eq!(extracted.artifact_key, "artifacts/abc123");
     assert!(extracted.tables.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn request_timeout_bounds_hung_sidecar_calls() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind server");
+    let addr = listener.local_addr().expect("server address");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_task = Arc::clone(&attempts);
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let mut request = vec![0_u8; 4096];
+        let read = stream.read(&mut request).await.expect("read request");
+        let request = String::from_utf8_lossy(&request[..read]);
+        assert!(request.starts_with("POST /extract HTTP/1.1"));
+        attempts_for_task.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    });
+
+    let client = PdfClient::builder()
+        .base_url(format!("http://{addr}"))
+        .timeout(Duration::from_millis(20))
+        .retry_policy(RetryPolicy::none())
+        .build()
+        .unwrap();
+
+    let err = client
+        .extract(request())
+        .await
+        .expect_err("hung sidecar should time out");
+
+    assert_eq!(err.class(), ErrorClass::Transient);
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
 }

--- a/crates/au-kpis-pdf-client/tests/client.rs
+++ b/crates/au-kpis-pdf-client/tests/client.rs
@@ -1,0 +1,123 @@
+use std::{
+    sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    },
+    time::Duration,
+};
+
+use au_kpis_pdf_client::{
+    ExtractRequest, ExtractionBackendKind, ExtractionStrategy, PdfClient, RetryPolicy,
+};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+async fn serve_responses(
+    responses: Vec<&'static str>,
+    statuses: Vec<u16>,
+) -> (String, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind server");
+    let addr = listener.local_addr().expect("server address");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_task = Arc::clone(&attempts);
+
+    tokio::spawn(async move {
+        for (body, status) in responses.into_iter().zip(statuses) {
+            let (mut stream, _) = listener.accept().await.expect("accept request");
+            let mut request = vec![0_u8; 4096];
+            let read = stream.read(&mut request).await.expect("read request");
+            let request = String::from_utf8_lossy(&request[..read]);
+            assert!(request.starts_with("POST /extract HTTP/1.1"));
+            assert!(request.contains("content-type: application/json"));
+            assert!(request.contains(r#""s3_key":"artifacts/abc123""#));
+            assert!(request.contains(r#""source_id":"treasury""#));
+            assert!(request.contains(r#""artifact_date":"2026-05-12""#));
+            assert!(request.contains(r#""strategy":"deterministic""#));
+            attempts_for_task.fetch_add(1, Ordering::SeqCst);
+
+            let response = format!(
+                "HTTP/1.1 {status} test\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        }
+    });
+
+    (format!("http://{addr}"), attempts)
+}
+
+fn request() -> ExtractRequest {
+    ExtractRequest::new("artifacts/abc123")
+        .source_id("treasury")
+        .artifact_date("2026-05-12")
+        .strategy(ExtractionStrategy::Deterministic)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn extract_posts_typed_request_and_parses_tables() {
+    let body = r#"{
+      "artifact_key": "artifacts/abc123",
+      "backend": {
+        "kind": "deterministic",
+        "name": "camelot",
+        "version": "1.0.0",
+        "model_sha256": null
+      },
+      "tables": [
+        {
+          "page": 12,
+          "bbox": [72.0, 120.0, 540.0, 720.0],
+          "cells": [["Year", "Revenue"], ["2026-27", "123.4"]],
+          "diagnostics": {"confidence": 0.98}
+        }
+      ]
+    }"#;
+    let (base_url, attempts) = serve_responses(vec![body], vec![200]).await;
+    let client = PdfClient::builder()
+        .base_url(base_url)
+        .retry_policy(RetryPolicy::none())
+        .build()
+        .unwrap();
+
+    let extracted = client.extract(request()).await.expect("extract");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(extracted.artifact_key, "artifacts/abc123");
+    assert_eq!(extracted.backend.kind, ExtractionBackendKind::Deterministic);
+    assert_eq!(extracted.tables[0].page, 12);
+    assert_eq!(extracted.tables[0].cells[1][1], "123.4");
+    assert_eq!(extracted.tables[0].diagnostics["confidence"], 0.98);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn extract_retries_5xx_with_backoff() {
+    let success = r#"{
+      "s3_key": "artifacts/abc123",
+      "backend": {
+        "kind": "deterministic",
+        "name": "pdfplumber",
+        "version": "0.11",
+        "model_sha256": null
+      },
+      "tables": []
+    }"#;
+    let (base_url, attempts) =
+        serve_responses(vec![r#"{"error":"busy"}"#, success], vec![503, 200]).await;
+    let client = PdfClient::builder()
+        .base_url(base_url)
+        .retry_policy(RetryPolicy::new(2, Duration::ZERO).unwrap())
+        .build()
+        .unwrap();
+
+    let extracted = client.extract(request()).await.expect("retry succeeds");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(extracted.artifact_key, "artifacts/abc123");
+    assert!(extracted.tables.is_empty());
+}

--- a/crates/au-kpis-pdf-client/tests/client.rs
+++ b/crates/au-kpis-pdf-client/tests/client.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt::Write as _,
     sync::{
         Arc,
         atomic::{AtomicUsize, Ordering},
@@ -11,9 +12,11 @@ use au_kpis_pdf_client::{
     ExtractRequest, ExtractionBackendKind, ExtractionStrategy, PdfClient, PdfClientError,
     RetryPolicy,
 };
+use futures::StreamExt;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::{TcpListener, TcpStream},
+    sync::oneshot,
 };
 use tracing::{Id, Subscriber, span::Attributes};
 use tracing_subscriber::{
@@ -25,7 +28,7 @@ use tracing_subscriber::{
 #[derive(Debug, Clone)]
 struct SpanCounter {
     name: &'static str,
-    count: Arc<AtomicUsize>,
+    count: &'static AtomicUsize,
 }
 
 impl<S> Layer<S> for SpanCounter
@@ -114,6 +117,44 @@ async fn serve_responses(
     (format!("http://{addr}"), attempts)
 }
 
+async fn serve_responses_with_headers(
+    responses: Vec<&'static str>,
+    statuses: Vec<u16>,
+    response_headers: Vec<Vec<(&'static str, &'static str)>>,
+) -> (String, Arc<AtomicUsize>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind server");
+    let addr = listener.local_addr().expect("server address");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_task = Arc::clone(&attempts);
+
+    tokio::spawn(async move {
+        for ((body, status), headers) in responses.into_iter().zip(statuses).zip(response_headers) {
+            let (mut stream, _) = listener.accept().await.expect("accept request");
+            let request = read_http_request(&mut stream).await;
+            assert!(request.starts_with("POST /extract HTTP/1.1"));
+            attempts_for_task.fetch_add(1, Ordering::SeqCst);
+
+            let headers = headers
+                .into_iter()
+                .fold(String::new(), |mut output, (name, value)| {
+                    write!(output, "{name}: {value}\r\n").expect("write header");
+                    output
+                });
+            let response = format!(
+                "HTTP/1.1 {status} test\r\ncontent-type: application/json\r\n{headers}content-length: {}\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            stream
+                .write_all(response.as_bytes())
+                .await
+                .expect("write response");
+        }
+    });
+
+    (format!("http://{addr}"), attempts)
+}
+
 fn request() -> ExtractRequest {
     ExtractRequest::new("artifacts/abc123", "treasury")
         .artifact_date("2026-05-12")
@@ -186,6 +227,36 @@ async fn extract_retries_5xx_with_backoff() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn extract_retries_429_with_retry_after() {
+    let success = r#"{
+      "s3_key": "artifacts/abc123",
+      "backend": {
+        "kind": "deterministic",
+        "name": "pdfplumber",
+        "version": "0.11",
+        "model_sha256": null
+      },
+      "tables": []
+    }"#;
+    let (base_url, attempts) = serve_responses_with_headers(
+        vec![r#"{"error":"rate limited"}"#, success],
+        vec![429, 200],
+        vec![vec![("retry-after", "0")], vec![]],
+    )
+    .await;
+    let client = PdfClient::builder()
+        .base_url(base_url)
+        .retry_policy(RetryPolicy::new(2, Duration::from_secs(5)).unwrap())
+        .build()
+        .unwrap();
+
+    let extracted = client.extract(request()).await.expect("retry succeeds");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 2);
+    assert_eq!(extracted.artifact_key, "artifacts/abc123");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn extract_rejects_response_missing_tables() {
     let body = r#"{
       "artifact_key": "artifacts/abc123",
@@ -210,11 +281,63 @@ async fn extract_rejects_response_missing_tables() {
 
     assert_eq!(attempts.load(Ordering::SeqCst), 1);
     assert_eq!(err.class(), ErrorClass::Permanent);
-    assert!(matches!(err, PdfClientError::Http(http) if http.is_decode()));
+    assert!(matches!(err, PdfClientError::Json(_)));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn extract_stream_yields_body_before_full_response_arrives() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind server");
+    let addr = listener.local_addr().expect("server address");
+    let (send_rest, receive_rest) = oneshot::channel::<()>();
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let request = read_http_request(&mut stream).await;
+        assert!(request.starts_with("POST /extract HTTP/1.1"));
+
+        let first = br#"{"artifact_key":"artifacts/abc123","#;
+        let second = br#""backend":{"kind":"deterministic","name":"camelot","version":"1.0.0","model_sha256":null},"tables":[]}"#;
+        let headers = format!(
+            "HTTP/1.1 200 test\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n",
+            first.len() + second.len()
+        );
+        stream
+            .write_all(headers.as_bytes())
+            .await
+            .expect("write headers");
+        stream.write_all(first).await.expect("write first chunk");
+        receive_rest.await.expect("test permits remaining body");
+        stream.write_all(second).await.expect("write second chunk");
+    });
+
+    let client = PdfClient::builder()
+        .base_url(format!("http://{addr}"))
+        .retry_policy(RetryPolicy::none())
+        .build()
+        .unwrap();
+
+    let mut stream = client
+        .extract_stream(request())
+        .await
+        .expect("stream response");
+    let first = stream
+        .next()
+        .await
+        .expect("first body chunk")
+        .expect("first body chunk succeeds");
+
+    assert!(first.starts_with(br#"{"artifact_key""#));
+
+    send_rest.send(()).expect("allow server to finish response");
+    while let Some(chunk) = stream.next().await {
+        chunk.expect("remaining body chunk succeeds");
+    }
 }
 
 #[tokio::test(flavor = "current_thread")]
 async fn extract_emits_outbound_http_span() {
+    static SPAN_COUNT: AtomicUsize = AtomicUsize::new(0);
+
     let body = r#"{
       "artifact_key": "artifacts/abc123",
       "backend": {
@@ -231,16 +354,16 @@ async fn extract_emits_outbound_http_span() {
         .retry_policy(RetryPolicy::none())
         .build()
         .unwrap();
-    let span_count = Arc::new(AtomicUsize::new(0));
+    SPAN_COUNT.store(0, Ordering::SeqCst);
     let subscriber = tracing_subscriber::registry().with(SpanCounter {
         name: "HTTP request",
-        count: Arc::clone(&span_count),
+        count: &SPAN_COUNT,
     });
-    let _guard = tracing::subscriber::set_default(subscriber);
+    let _ = tracing::subscriber::set_global_default(subscriber);
 
     client.extract(request()).await.expect("extract");
 
-    assert_eq!(span_count.load(Ordering::SeqCst), 1);
+    assert!(SPAN_COUNT.load(Ordering::SeqCst) >= 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -270,6 +393,50 @@ async fn request_timeout_bounds_hung_sidecar_calls() {
         .await
         .expect_err("hung sidecar should time out");
 
+    assert_eq!(err.class(), ErrorClass::Transient);
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn extract_timeout_bounds_incomplete_response_body() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind server");
+    let addr = listener.local_addr().expect("server address");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_task = Arc::clone(&attempts);
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let request = read_http_request(&mut stream).await;
+        assert!(request.starts_with("POST /extract HTTP/1.1"));
+        attempts_for_task.fetch_add(1, Ordering::SeqCst);
+
+        let body = br#"{"artifact_key":"artifacts/abc123","#;
+        let response = format!(
+            "HTTP/1.1 200 test\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n",
+            body.len() + 128
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response headers");
+        stream.write_all(body).await.expect("write partial body");
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    });
+
+    let client = PdfClient::builder()
+        .base_url(format!("http://{addr}"))
+        .http_client(reqwest::Client::new())
+        .timeout(Duration::from_millis(20))
+        .retry_policy(RetryPolicy::none())
+        .build()
+        .unwrap();
+
+    let err = client
+        .extract(request())
+        .await
+        .expect_err("incomplete body should time out");
+
+    assert!(matches!(err, PdfClientError::Timeout { .. }));
     assert_eq!(err.class(), ErrorClass::Transient);
     assert_eq!(attempts.load(Ordering::SeqCst), 1);
 }

--- a/crates/au-kpis-pdf-client/tests/client.rs
+++ b/crates/au-kpis-pdf-client/tests/client.rs
@@ -13,7 +13,7 @@ use au_kpis_pdf_client::{
 };
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
-    net::TcpListener,
+    net::{TcpListener, TcpStream},
 };
 use tracing::{Id, Subscriber, span::Attributes};
 use tracing_subscriber::{
@@ -39,6 +39,41 @@ where
     }
 }
 
+async fn read_http_request(stream: &mut TcpStream) -> String {
+    let mut request = Vec::new();
+    let mut buffer = [0_u8; 1024];
+
+    loop {
+        let read = stream.read(&mut buffer).await.expect("read request");
+        assert_ne!(read, 0, "client closed connection before sending request");
+        request.extend_from_slice(&buffer[..read]);
+
+        let Some(header_end) = find_subslice(&request, b"\r\n\r\n") else {
+            continue;
+        };
+        let body_start = header_end + 4;
+        let headers = String::from_utf8_lossy(&request[..header_end]);
+        let content_length = headers
+            .lines()
+            .find_map(|line| {
+                let (name, value) = line.split_once(':')?;
+                name.eq_ignore_ascii_case("content-length")
+                    .then(|| value.trim().parse::<usize>().expect("valid content-length"))
+            })
+            .unwrap_or(0);
+
+        if request.len() >= body_start + content_length {
+            return String::from_utf8(request).expect("request is utf-8");
+        }
+    }
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    haystack
+        .windows(needle.len())
+        .position(|window| window == needle)
+}
+
 async fn serve_responses(
     responses: Vec<&'static str>,
     statuses: Vec<u16>,
@@ -51,11 +86,13 @@ async fn serve_responses(
     tokio::spawn(async move {
         for (body, status) in responses.into_iter().zip(statuses) {
             let (mut stream, _) = listener.accept().await.expect("accept request");
-            let mut request = vec![0_u8; 4096];
-            let read = stream.read(&mut request).await.expect("read request");
-            let request = String::from_utf8_lossy(&request[..read]);
+            let request = read_http_request(&mut stream).await;
             assert!(request.starts_with("POST /extract HTTP/1.1"));
-            assert!(request.contains("content-type: application/json"));
+            assert!(
+                request
+                    .to_ascii_lowercase()
+                    .contains("content-type: application/json")
+            );
             assert!(request.contains(r#""s3_key":"artifacts/abc123""#));
             assert!(request.contains(r#""source_id":"treasury""#));
             assert!(request.contains(r#""artifact_date":"2026-05-12""#));
@@ -215,9 +252,7 @@ async fn request_timeout_bounds_hung_sidecar_calls() {
 
     tokio::spawn(async move {
         let (mut stream, _) = listener.accept().await.expect("accept request");
-        let mut request = vec![0_u8; 4096];
-        let read = stream.read(&mut request).await.expect("read request");
-        let request = String::from_utf8_lossy(&request[..read]);
+        let request = read_http_request(&mut stream).await;
         assert!(request.starts_with("POST /extract HTTP/1.1"));
         attempts_for_task.fetch_add(1, Ordering::SeqCst);
         tokio::time::sleep(Duration::from_millis(250)).await;
@@ -235,6 +270,39 @@ async fn request_timeout_bounds_hung_sidecar_calls() {
         .await
         .expect_err("hung sidecar should time out");
 
+    assert_eq!(err.class(), ErrorClass::Transient);
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_http_client_still_enforces_request_timeout() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind server");
+    let addr = listener.local_addr().expect("server address");
+    let attempts = Arc::new(AtomicUsize::new(0));
+    let attempts_for_task = Arc::clone(&attempts);
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let request = read_http_request(&mut stream).await;
+        assert!(request.starts_with("POST /extract HTTP/1.1"));
+        attempts_for_task.fetch_add(1, Ordering::SeqCst);
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    });
+
+    let client = PdfClient::builder()
+        .base_url(format!("http://{addr}"))
+        .http_client(reqwest::Client::new())
+        .timeout(Duration::from_millis(20))
+        .retry_policy(RetryPolicy::none())
+        .build()
+        .unwrap();
+
+    let err = client
+        .extract(request())
+        .await
+        .expect_err("hung sidecar should time out");
+
+    assert!(matches!(err, PdfClientError::Timeout { .. }));
     assert_eq!(err.class(), ErrorClass::Transient);
     assert_eq!(attempts.load(Ordering::SeqCst), 1);
 }

--- a/crates/au-kpis-pdf-client/tests/client.rs
+++ b/crates/au-kpis-pdf-client/tests/client.rs
@@ -28,7 +28,7 @@ use tracing_subscriber::{
 #[derive(Debug, Clone)]
 struct SpanCounter {
     name: &'static str,
-    count: &'static AtomicUsize,
+    count: Arc<AtomicUsize>,
 }
 
 impl<S> Layer<S> for SpanCounter
@@ -202,7 +202,7 @@ async fn extract_posts_typed_request_and_parses_tables() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn extract_retries_5xx_with_backoff() {
     let success = r#"{
-      "s3_key": "artifacts/abc123",
+      "artifact_key": "artifacts/abc123",
       "backend": {
         "kind": "deterministic",
         "name": "pdfplumber",
@@ -229,7 +229,7 @@ async fn extract_retries_5xx_with_backoff() {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn extract_retries_429_with_retry_after() {
     let success = r#"{
-      "s3_key": "artifacts/abc123",
+      "artifact_key": "artifacts/abc123",
       "backend": {
         "kind": "deterministic",
         "name": "pdfplumber",
@@ -334,10 +334,59 @@ async fn extract_stream_yields_body_before_full_response_arrives() {
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn extract_stream_timeout_bounds_incomplete_response_body() {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind server");
+    let addr = listener.local_addr().expect("server address");
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let request = read_http_request(&mut stream).await;
+        assert!(request.starts_with("POST /extract HTTP/1.1"));
+
+        let first = br#"{"artifact_key":"artifacts/abc123","#;
+        let headers = format!(
+            "HTTP/1.1 200 test\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n",
+            first.len() + 128
+        );
+        stream
+            .write_all(headers.as_bytes())
+            .await
+            .expect("write headers");
+        stream.write_all(first).await.expect("write first chunk");
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    });
+
+    let client = PdfClient::builder()
+        .base_url(format!("http://{addr}"))
+        .http_client(reqwest::Client::new())
+        .timeout(Duration::from_millis(20))
+        .retry_policy(RetryPolicy::none())
+        .build()
+        .unwrap();
+
+    let mut stream = client
+        .extract_stream(request())
+        .await
+        .expect("stream response");
+    stream
+        .next()
+        .await
+        .expect("first body chunk")
+        .expect("first body chunk succeeds");
+    let err = stream
+        .next()
+        .await
+        .expect("timeout chunk")
+        .expect_err("incomplete streamed body should time out");
+
+    assert!(matches!(err, PdfClientError::Timeout { .. }));
+    assert_eq!(err.class(), ErrorClass::Transient);
+    assert!(stream.next().await.is_none());
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn extract_emits_outbound_http_span() {
-    static SPAN_COUNT: AtomicUsize = AtomicUsize::new(0);
-
     let body = r#"{
       "artifact_key": "artifacts/abc123",
       "backend": {
@@ -354,16 +403,16 @@ async fn extract_emits_outbound_http_span() {
         .retry_policy(RetryPolicy::none())
         .build()
         .unwrap();
-    SPAN_COUNT.store(0, Ordering::SeqCst);
+    let span_count = Arc::new(AtomicUsize::new(0));
     let subscriber = tracing_subscriber::registry().with(SpanCounter {
         name: "HTTP request",
-        count: &SPAN_COUNT,
+        count: Arc::clone(&span_count),
     });
-    let _ = tracing::subscriber::set_global_default(subscriber);
+    let _guard = tracing::subscriber::set_default(subscriber);
 
     client.extract(request()).await.expect("extract");
 
-    assert!(SPAN_COUNT.load(Ordering::SeqCst) >= 1);
+    assert_eq!(span_count.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/au-kpis-pdf-client/tests/client.rs
+++ b/crates/au-kpis-pdf-client/tests/client.rs
@@ -8,12 +8,36 @@ use std::{
 
 use au_kpis_error::{Classify, ErrorClass};
 use au_kpis_pdf_client::{
-    ExtractRequest, ExtractionBackendKind, ExtractionStrategy, PdfClient, RetryPolicy,
+    ExtractRequest, ExtractionBackendKind, ExtractionStrategy, PdfClient, PdfClientError,
+    RetryPolicy,
 };
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpListener,
 };
+use tracing::{Id, Subscriber, span::Attributes};
+use tracing_subscriber::{
+    Layer,
+    layer::{Context, SubscriberExt},
+    registry::LookupSpan,
+};
+
+#[derive(Debug, Clone)]
+struct SpanCounter {
+    name: &'static str,
+    count: Arc<AtomicUsize>,
+}
+
+impl<S> Layer<S> for SpanCounter
+where
+    S: Subscriber + for<'lookup> LookupSpan<'lookup>,
+{
+    fn on_new_span(&self, attrs: &Attributes<'_>, _id: &Id, _ctx: Context<'_, S>) {
+        if attrs.metadata().name() == self.name {
+            self.count.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+}
 
 async fn serve_responses(
     responses: Vec<&'static str>,
@@ -122,6 +146,64 @@ async fn extract_retries_5xx_with_backoff() {
     assert_eq!(attempts.load(Ordering::SeqCst), 2);
     assert_eq!(extracted.artifact_key, "artifacts/abc123");
     assert!(extracted.tables.is_empty());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn extract_rejects_response_missing_tables() {
+    let body = r#"{
+      "artifact_key": "artifacts/abc123",
+      "backend": {
+        "kind": "deterministic",
+        "name": "camelot",
+        "version": "1.0.0",
+        "model_sha256": null
+      }
+    }"#;
+    let (base_url, attempts) = serve_responses(vec![body], vec![200]).await;
+    let client = PdfClient::builder()
+        .base_url(base_url)
+        .retry_policy(RetryPolicy::none())
+        .build()
+        .unwrap();
+
+    let err = client
+        .extract(request())
+        .await
+        .expect_err("missing tables should fail response decoding");
+
+    assert_eq!(attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(matches!(err, PdfClientError::Http(http) if http.is_decode()));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn extract_emits_outbound_http_span() {
+    let body = r#"{
+      "artifact_key": "artifacts/abc123",
+      "backend": {
+        "kind": "deterministic",
+        "name": "camelot",
+        "version": "1.0.0",
+        "model_sha256": null
+      },
+      "tables": []
+    }"#;
+    let (base_url, _attempts) = serve_responses(vec![body], vec![200]).await;
+    let client = PdfClient::builder()
+        .base_url(base_url)
+        .retry_policy(RetryPolicy::none())
+        .build()
+        .unwrap();
+    let span_count = Arc::new(AtomicUsize::new(0));
+    let subscriber = tracing_subscriber::registry().with(SpanCounter {
+        name: "HTTP request",
+        count: Arc::clone(&span_count),
+    });
+    let _guard = tracing::subscriber::set_default(subscriber);
+
+    client.extract(request()).await.expect("extract");
+
+    assert_eq!(span_count.load(Ordering::SeqCst), 1);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Closes #23

## Pass requirements

- [x] Typed client for `POST /extract { s3_key }`
- [x] Deterministic HTTP tests cover request and response parsing
- [x] Retries on 5xx with exponential backoff
- [x] Request/response path is instrumented with tracing spans

## Test plan

- `cargo fmt --all --check`
- `cargo test -p au-kpis-pdf-client`
- `cargo clippy -p au-kpis-pdf-client --all-targets -- -D warnings`
- `cargo check --workspace`

## Spec impact

No Spec changes required. Implements the Rust client described in `Spec.md § PDF extractor service (Python)`.