### PR TITLE
feat(adapter-abs): stream SDMX observations (#26)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -335,11 +335,15 @@ jobs:
             exit 1
           fi
 
-      - name: Enforce ABS fetch streaming memory budget
+      - name: Enforce ABS streaming memory budgets
         run: |
           cargo test -p au-kpis-adapter-abs \
             --features dhat-heap \
             --test fetch_memory \
+            -- --ignored --nocapture
+          cargo test -p au-kpis-adapter-abs \
+            --features dhat-heap \
+            --test parse_memory \
             -- --ignored --nocapture
 
   coverage:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -348,6 +348,10 @@ Every PR must add/update tests at the appropriate layer:
 8. **Don't bypass pre-commit hooks** with `--no-verify`. If a hook fails, fix the underlying issue.
 9. **Don't commit secrets, `.env`, production fixtures, or large binaries.** Fixtures >5 MB go to R2 with a reference in-repo.
 10. **When unsure about architecture**, open a draft PR with a `Spec.md` amendment — don't guess.
+11. **Validate artifact provenance in parsers.** If parsed observations carry `source_artifact_id`, verify the artifact id, persisted storage key, and parsed bytes are consistent before emitting rows. Do not trust an `ArtifactRef` whose fields could point at different blobs.
+12. **Reject ambiguous source/dataflow provenance.** Source-specific parsers must fail fast when the artifact cannot be tied to the expected upstream dataflow. Do not infer CPI/WPI/etc. only from payload shape or a mirrored filename.
+13. **Keep streaming fixes on the hot path.** Handling harmless format variations, such as JSON key reordering, should not introduce extra full-artifact scans unless the issue explicitly accepts that cost and tests cover it.
+14. **Make performance fixtures production-shaped.** Large-memory and streaming tests should use valid content-addressed artifact ids and storage keys so they exercise the same validation path as production parsing.
 
 ## 13. When stuck
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -219,6 +219,7 @@ dependencies = [
  "proptest",
  "serde",
  "serde_json",
+ "sha2",
  "tokio",
  "tracing",
 ]

--- a/Spec.md
+++ b/Spec.md
@@ -982,7 +982,7 @@ parallel:
   - typecheck       (cargo check + tsc)
   - lint            (clippy, `pnpm run lint` = biome + markdownlint, gitleaks, cargo-deny)
   - build           (sccache cargo + pnpm build)
-  - test            (nextest + vitest, testcontainers, source-specific streaming memory guardrails such as the ABS DHAT fetch profile)
+  - test            (nextest + vitest, testcontainers, source-specific streaming memory guardrails such as the ABS DHAT fetch/parse profiles)
   - coverage        (clean cargo-llvm-cov profile data with pinned nightly coverage toolchain → LCOV line/branch coverage → Codecov PR comment)
   - snapshot        (insta check)
   - openapi         (`cargo run -p au-kpis-openapi` export + oasdiff vs main)
@@ -1000,8 +1000,8 @@ not fail an otherwise valid PR gate.
 
 Source-specific memory guardrails may run as explicit PR blockers when they
 protect a pass requirement that normal unit/integration tests cannot observe;
-for example, the ABS fetch path runs its DHAT profile to enforce the streaming
-heap budget.
+for example, the ABS fetch and parse paths run DHAT profiles to enforce their
+streaming peak-heap budgets.
 
 Codex review is an additional review signal, not part of the 14 blocking gates by default. It runs only when `OPENAI_API_KEY` is configured for the repository and the PR originates from the same repository (not a fork). Default model: `gpt-5.5`; allow `CODEX_MODEL`, `CODEX_REVIEW_EFFORT`, and `CODEX_REVIEW_BLOCK_ON_INCORRECT` as repository variables for tuning.
 
@@ -1077,7 +1077,7 @@ Priority bench targets:
 | `au-kpis-domain` | Serialize 10k `Observation` to JSON | <50 ms |
 | `au-kpis-domain` | Serialize 10k `Observation` to Parquet (arrow-rs) | <20 ms |
 | `au-kpis-adapter` (helpers) | SDMX-JSON parse 100MB fixture → stream of observations | >500k obs/s |
-| `crates/adapters/abs` (`au-kpis-adapter-abs`) | Full CPI dataflow parse (real fixture) | <2 s, <100 MB RSS |
+| `crates/adapters/abs` (`au-kpis-adapter-abs`) | Full CPI dataflow parse (real fixture) | <2 s, <100 MB peak DHAT heap |
 | `crates/adapters/rba` (`au-kpis-adapter-rba`) | XLS parse (`calamine`) 10-sheet workbook | <500 ms |
 | `au-kpis-loader` | Batch upsert 10k observations via COPY | <500 ms |
 | `au-kpis-api-http` | Request handler end-to-end (in-process) | <5 ms overhead above DB |

--- a/crates/adapters/abs/Cargo.toml
+++ b/crates/adapters/abs/Cargo.toml
@@ -13,19 +13,21 @@ au-kpis-adapter = { workspace = true }
 au-kpis-domain = { workspace = true }
 au-kpis-error = { workspace = true }
 au-kpis-storage = { workspace = true }
+bytes = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
 dhat = { version = "0.3", optional = true }
 futures = "0.3"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["rt", "sync"] }
 tracing = "0.1"
 
 [features]
 dhat-heap = ["dep:dhat"]
 
 [dev-dependencies]
-bytes = "1"
 insta = { version = "1", features = ["json"] }
 object_store = "0.11"
 proptest = "1"
+sha2 = "0.10"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "rt-multi-thread"] }

--- a/crates/adapters/abs/src/lib.rs
+++ b/crates/adapters/abs/src/lib.rs
@@ -3,7 +3,12 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs, missing_debug_implementations)]
 
-use std::{collections::BTreeMap, time::Duration};
+use std::{
+    collections::BTreeMap,
+    io::{self, Read},
+    sync::{Arc, Mutex},
+    time::Duration,
+};
 
 use async_trait::async_trait;
 use au_kpis_adapter::{
@@ -11,12 +16,19 @@ use au_kpis_adapter::{
     ObservationStream, ParseCtx, RateLimit, SourceAdapter, UpstreamRevision,
     capture_response_headers, retry_after_delta,
 };
-use au_kpis_domain::{Artifact, DataflowId, SourceId};
+use au_kpis_domain::{
+    Artifact, CodeId, DataflowId, DimensionId, MeasureId, Observation, ObservationStatus,
+    SeriesDescriptor, SeriesKey, SourceId, TimePrecision,
+};
 use au_kpis_error::CoreError;
-use au_kpis_storage::StorageKey;
-use chrono::Utc;
+use au_kpis_storage::{BlobStore, StorageError, StorageKey};
+use bytes::Bytes;
+use chrono::{DateTime, NaiveDate, Utc};
 use futures::{StreamExt, stream};
-use serde::Deserialize;
+use serde::{
+    Deserialize,
+    de::{self, DeserializeSeed, IgnoredAny, MapAccess, SeqAccess, Visitor},
+};
 
 const DEFAULT_BASE_URL: &str = "https://data.api.abs.gov.au/rest";
 const STRUCTURE_JSON_ACCEPT: &str = "application/vnd.sdmx.structure+json";
@@ -256,12 +268,1261 @@ impl SourceAdapter for AbsAdapter {
         persist_expected_artifact(ctx, artifact, &storage_key, Some(&storage_key)).await
     }
 
-    fn parse<'a>(&'a self, _artifact: ArtifactRef, _ctx: &'a ParseCtx) -> ObservationStream<'a> {
-        Box::pin(stream::once(async {
-            Err(AdapterError::Validation(
-                "ABS parse is implemented in issue #26".to_string(),
+    fn parse<'a>(&'a self, artifact: ArtifactRef, ctx: &'a ParseCtx) -> ObservationStream<'a> {
+        parse_artifact_stream(artifact, ctx)
+    }
+}
+
+fn parse_artifact_stream(artifact: ArtifactRef, ctx: &ParseCtx) -> ObservationStream<'_> {
+    if let Err(err) = validate_cpi_parse_artifact(&artifact) {
+        return Box::pin(stream::once(async move { Err(err) }));
+    }
+
+    let blob_store = ctx.blob_store.clone();
+    let started_at = ctx.started_at;
+    let (row_tx, row_rx) = tokio::sync::mpsc::channel(64);
+
+    tokio::spawn(async move {
+        let key = StorageKey::from_persisted(artifact.storage_key.clone());
+        if let Err(err) = verify_parse_artifact_identity(&blob_store, &key, &artifact).await {
+            let _ = row_tx.send(Err(err)).await;
+            return;
+        }
+
+        let parse_tx = row_tx.clone();
+        let artifact_for_full_parse = artifact.clone();
+        let result = match parse_blob_stream(blob_store.clone(), key.clone(), move |reader| {
+            parse_sdmx_json(reader, artifact_for_full_parse, started_at, parse_tx)
+        })
+        .await
+        {
+            Ok(ParseOutcome::Complete) => Ok(()),
+            Ok(ParseOutcome::DataSetsBeforeStructure(structure)) => {
+                let parse_tx = row_tx.clone();
+                parse_blob_stream(blob_store, key, move |reader| {
+                    parse_sdmx_data_sets_with_structure(
+                        reader, structure, artifact, started_at, parse_tx,
+                    )
+                })
+                .await
+            }
+            Err(err) => Err(err),
+        };
+
+        if let Err(err) = result {
+            let _ = row_tx.send(Err(err)).await;
+        }
+    });
+
+    Box::pin(stream::unfold(row_rx, |mut row_rx| async {
+        row_rx.recv().await.map(|item| (item, row_rx))
+    }))
+}
+
+fn validate_cpi_parse_artifact(artifact: &ArtifactRef) -> Result<(), AdapterError> {
+    if artifact.source_id.as_str() != "abs" {
+        return Err(AdapterError::Validation(format!(
+            "ABS parse received artifact for source `{}`",
+            artifact.source_id.as_str()
+        )));
+    }
+
+    match abs_data_url_provenance(&artifact.source_url) {
+        Some(("ABS", CPI_DATAFLOW_ID)) => {}
+        Some(_) => {
+            return Err(AdapterError::Validation(format!(
+                "ABS parse artifact `{}` does not match CPI dataflow",
+                artifact.source_url
+            )));
+        }
+        None => {
+            return Err(AdapterError::Validation(format!(
+                "ABS parse artifact `{}` is missing CPI dataflow provenance",
+                artifact.source_url
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn abs_data_url_provenance(source_url: &str) -> Option<(&str, &str)> {
+    let (_, data_path) = source_url.rsplit_once("/data/")?;
+    let artifact_ref = data_path
+        .split_once('/')
+        .map_or(data_path, |(artifact_ref, _)| artifact_ref);
+    let mut parts = artifact_ref.split(',');
+    let agency_id = parts.next()?;
+    let dataflow_id = parts.next()?;
+    if agency_id.is_empty() || dataflow_id.is_empty() {
+        None
+    } else {
+        Some((agency_id, dataflow_id))
+    }
+}
+
+async fn verify_parse_artifact_identity(
+    blob_store: &BlobStore,
+    key: &StorageKey,
+    artifact: &ArtifactRef,
+) -> Result<(), AdapterError> {
+    let canonical_key = StorageKey::canonical_for(&artifact.id).to_string();
+    if artifact.storage_key == canonical_key {
+        return Ok(());
+    }
+
+    if artifact.storage_key.starts_with("artifacts/") {
+        return Err(AdapterError::Validation(format!(
+            "ABS parse artifact storage key `{}` does not match artifact id `{}`",
+            artifact.storage_key, artifact.id
+        )));
+    }
+
+    if blob_store.matches_artifact_id(key, artifact.id).await? {
+        Ok(())
+    } else {
+        Err(AdapterError::Validation(format!(
+            "ABS parse artifact storage key `{}` does not match artifact id `{}`",
+            artifact.storage_key, artifact.id
+        )))
+    }
+}
+
+async fn parse_blob_stream<T, F>(
+    blob_store: BlobStore,
+    key: StorageKey,
+    parser: F,
+) -> Result<T, AdapterError>
+where
+    T: Send + 'static,
+    F: FnOnce(ChannelReader) -> Result<T, AdapterError> + Send + 'static,
+{
+    let mut chunks = blob_store.get(&key).await?;
+    let (byte_tx, byte_rx) = tokio::sync::mpsc::channel(8);
+    let read_error = Arc::new(Mutex::new(None));
+    let reader_error = Arc::clone(&read_error);
+    let parser =
+        tokio::task::spawn_blocking(move || parser(ChannelReader::new(byte_rx, reader_error)));
+
+    while let Some(chunk) = chunks.next().await {
+        if byte_tx.send(chunk).await.is_err() {
+            break;
+        }
+    }
+    drop(byte_tx);
+
+    match parser.await {
+        Ok(Err(err)) => match read_error.lock().expect("read error mutex poisoned").take() {
+            Some(storage_err) => Err(AdapterError::Storage(storage_err)),
+            None => Err(err),
+        },
+        Ok(Ok(result)) => Ok(result),
+        Err(err) => Err(parse_worker_error(err)),
+    }
+}
+
+fn parse_worker_error(err: tokio::task::JoinError) -> AdapterError {
+    CoreError::Io(io::Error::other(format!("ABS parse worker failed: {err}"))).into()
+}
+
+fn parse_sdmx_data_sets_with_structure<R: Read>(
+    reader: R,
+    structure: ParsedStructure,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+) -> Result<(), AdapterError> {
+    let mut deserializer = serde_json::Deserializer::from_reader(reader);
+    DataSetsOnlyTopLevelSeed {
+        structure,
+        artifact,
+        ingested_at,
+        tx,
+    }
+    .deserialize(&mut deserializer)
+    .map_err(map_sdmx_json_error)?;
+    deserializer.end().map_err(map_sdmx_json_error)?;
+    Ok(())
+}
+
+fn parse_sdmx_json<R: Read>(
+    reader: R,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+) -> Result<ParseOutcome, AdapterError> {
+    let mut deserializer = serde_json::Deserializer::from_reader(reader);
+    let outcome = TopLevelSeed {
+        artifact,
+        ingested_at,
+        tx,
+    }
+    .deserialize(&mut deserializer)
+    .map_err(map_sdmx_json_error)?;
+    deserializer.end().map_err(map_sdmx_json_error)?;
+    Ok(outcome)
+}
+
+fn map_sdmx_json_error(err: serde_json::Error) -> AdapterError {
+    AdapterError::FormatDrift(err.to_string())
+}
+
+struct ChannelReader {
+    rx: tokio::sync::mpsc::Receiver<Result<Bytes, StorageError>>,
+    read_error: Arc<Mutex<Option<StorageError>>>,
+    current: Option<Bytes>,
+    offset: usize,
+}
+
+impl ChannelReader {
+    fn new(
+        rx: tokio::sync::mpsc::Receiver<Result<Bytes, StorageError>>,
+        read_error: Arc<Mutex<Option<StorageError>>>,
+    ) -> Self {
+        Self {
+            rx,
+            read_error,
+            current: None,
+            offset: 0,
+        }
+    }
+}
+
+impl Read for ChannelReader {
+    fn read(&mut self, out: &mut [u8]) -> io::Result<usize> {
+        if out.is_empty() {
+            return Ok(0);
+        }
+
+        loop {
+            if let Some(current) = &self.current {
+                if self.offset < current.len() {
+                    let available = &current[self.offset..];
+                    let len = available.len().min(out.len());
+                    out[..len].copy_from_slice(&available[..len]);
+                    self.offset += len;
+                    if self.offset == current.len() {
+                        self.current = None;
+                        self.offset = 0;
+                    }
+                    return Ok(len);
+                }
+                self.current = None;
+                self.offset = 0;
+            }
+
+            match self.rx.blocking_recv() {
+                Some(Ok(chunk)) if chunk.is_empty() => {}
+                Some(Ok(chunk)) => {
+                    self.current = Some(chunk);
+                }
+                Some(Err(err)) => {
+                    *self.read_error.lock().expect("read error mutex poisoned") = Some(err);
+                    return Err(io::Error::other("storage read failed"));
+                }
+                None => return Ok(0),
+            }
+        }
+    }
+}
+
+#[derive(Debug)]
+enum ParseOutcome {
+    Complete,
+    DataSetsBeforeStructure(ParsedStructure),
+}
+
+struct TopLevelSeed {
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> DeserializeSeed<'de> for TopLevelSeed {
+    type Value = ParseOutcome;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(TopLevelVisitor {
+            artifact: self.artifact,
+            ingested_at: self.ingested_at,
+            tx: self.tx,
+        })
+    }
+}
+
+struct TopLevelVisitor {
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> Visitor<'de> for TopLevelVisitor {
+    type Value = ParseOutcome;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ABS SDMX-JSON top-level object")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut outcome = None;
+        while let Some(key) = map.next_key::<String>()? {
+            if key == "data" {
+                outcome = Some(map.next_value_seed(DataSeed {
+                    artifact: self.artifact.clone(),
+                    ingested_at: self.ingested_at,
+                    tx: self.tx.clone(),
+                })?);
+            } else {
+                map.next_value::<IgnoredAny>()?;
+            }
+        }
+        outcome.ok_or_else(|| de::Error::custom("ABS SDMX payload is missing `data`"))
+    }
+}
+
+struct DataSetsOnlyTopLevelSeed {
+    structure: ParsedStructure,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> DeserializeSeed<'de> for DataSetsOnlyTopLevelSeed {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(DataSetsOnlyTopLevelVisitor {
+            structure: self.structure,
+            artifact: self.artifact,
+            ingested_at: self.ingested_at,
+            tx: self.tx,
+        })
+    }
+}
+
+struct DataSetsOnlyTopLevelVisitor {
+    structure: ParsedStructure,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> Visitor<'de> for DataSetsOnlyTopLevelVisitor {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ABS SDMX-JSON top-level object")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut saw_data = false;
+        while let Some(key) = map.next_key::<String>()? {
+            if key == "data" {
+                saw_data = true;
+                map.next_value_seed(DataSetsOnlyDataSeed {
+                    structure: self.structure.clone(),
+                    artifact: self.artifact.clone(),
+                    ingested_at: self.ingested_at,
+                    tx: self.tx.clone(),
+                })?;
+            } else {
+                map.next_value::<IgnoredAny>()?;
+            }
+        }
+        if saw_data {
+            Ok(())
+        } else {
+            Err(de::Error::custom("ABS SDMX payload is missing `data`"))
+        }
+    }
+}
+
+struct DataSetsOnlyDataSeed {
+    structure: ParsedStructure,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> DeserializeSeed<'de> for DataSetsOnlyDataSeed {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(DataSetsOnlyDataVisitor {
+            structure: self.structure,
+            artifact: self.artifact,
+            ingested_at: self.ingested_at,
+            tx: self.tx,
+        })
+    }
+}
+
+struct DataSetsOnlyDataVisitor {
+    structure: ParsedStructure,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> Visitor<'de> for DataSetsOnlyDataVisitor {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ABS SDMX `data` object")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut saw_data_sets = false;
+        while let Some(key) = map.next_key::<String>()? {
+            if key == "dataSets" {
+                saw_data_sets = true;
+                map.next_value_seed(DataSetsSeed {
+                    structure: self.structure.clone(),
+                    artifact: self.artifact.clone(),
+                    ingested_at: self.ingested_at,
+                    tx: self.tx.clone(),
+                })?;
+            } else {
+                map.next_value::<IgnoredAny>()?;
+            }
+        }
+        if saw_data_sets {
+            Ok(())
+        } else {
+            Err(de::Error::custom("ABS SDMX data is missing `dataSets`"))
+        }
+    }
+}
+
+struct DataSeed {
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> DeserializeSeed<'de> for DataSeed {
+    type Value = ParseOutcome;
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(DataVisitor {
+            artifact: self.artifact,
+            ingested_at: self.ingested_at,
+            tx: self.tx,
+        })
+    }
+}
+
+struct DataVisitor {
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> Visitor<'de> for DataVisitor {
+    type Value = ParseOutcome;
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ABS SDMX `data` object")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut structure = None;
+        let mut data_sets_before_structure = false;
+        let mut saw_data_sets = false;
+
+        while let Some(key) = map.next_key::<String>()? {
+            match key.as_str() {
+                "structure" => {
+                    structure = Some(
+                        map.next_value::<SdmxStructure>()?
+                            .into_parsed()
+                            .map_err(de::Error::custom)?,
+                    );
+                }
+                "dataSets" => {
+                    saw_data_sets = true;
+                    if let Some(parsed_structure) = structure.clone() {
+                        map.next_value_seed(DataSetsSeed {
+                            structure: parsed_structure,
+                            artifact: self.artifact.clone(),
+                            ingested_at: self.ingested_at,
+                            tx: self.tx.clone(),
+                        })?;
+                    } else {
+                        data_sets_before_structure = true;
+                        map.next_value::<IgnoredAny>()?;
+                    }
+                }
+                _ => {
+                    map.next_value::<IgnoredAny>()?;
+                }
+            }
+        }
+
+        if structure.is_none() {
+            return Err(de::Error::custom("ABS SDMX data is missing `structure`"));
+        }
+        if !saw_data_sets {
+            return Err(de::Error::custom("ABS SDMX data is missing `dataSets`"));
+        }
+        if data_sets_before_structure {
+            return Ok(ParseOutcome::DataSetsBeforeStructure(
+                structure.expect("structure presence checked above"),
+            ));
+        }
+        Ok(ParseOutcome::Complete)
+    }
+}
+
+struct DataSetsSeed {
+    structure: ParsedStructure,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> DeserializeSeed<'de> for DataSetsSeed {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_seq(DataSetsVisitor {
+            structure: self.structure,
+            artifact: self.artifact,
+            ingested_at: self.ingested_at,
+            tx: self.tx,
+        })
+    }
+}
+
+struct DataSetsVisitor {
+    structure: ParsedStructure,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> Visitor<'de> for DataSetsVisitor {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ABS SDMX dataSets array")
+    }
+
+    fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+    where
+        A: SeqAccess<'de>,
+    {
+        while seq
+            .next_element_seed(DataSetSeed {
+                structure: self.structure.clone(),
+                artifact: self.artifact.clone(),
+                ingested_at: self.ingested_at,
+                tx: self.tx.clone(),
+            })?
+            .is_some()
+        {}
+        Ok(())
+    }
+}
+
+struct DataSetSeed {
+    structure: ParsedStructure,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> DeserializeSeed<'de> for DataSetSeed {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(DataSetVisitor {
+            structure: self.structure,
+            artifact: self.artifact,
+            ingested_at: self.ingested_at,
+            tx: self.tx,
+        })
+    }
+}
+
+struct DataSetVisitor {
+    structure: ParsedStructure,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> Visitor<'de> for DataSetVisitor {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ABS SDMX dataSet object")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut saw_series = false;
+        while let Some(key) = map.next_key::<String>()? {
+            if key == "series" {
+                saw_series = true;
+                map.next_value_seed(SeriesMapSeed {
+                    structure: self.structure.clone(),
+                    artifact: self.artifact.clone(),
+                    ingested_at: self.ingested_at,
+                    tx: self.tx.clone(),
+                })?;
+            } else {
+                map.next_value::<IgnoredAny>()?;
+            }
+        }
+        if saw_series {
+            Ok(())
+        } else {
+            Err(de::Error::custom(
+                "ABS SDMX dataSet is missing `series`; all-dim observations are not supported yet",
             ))
-        }))
+        }
+    }
+}
+
+struct SeriesMapSeed {
+    structure: ParsedStructure,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> DeserializeSeed<'de> for SeriesMapSeed {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(SeriesMapVisitor {
+            structure: self.structure,
+            artifact: self.artifact,
+            ingested_at: self.ingested_at,
+            tx: self.tx,
+        })
+    }
+}
+
+struct SeriesMapVisitor {
+    structure: ParsedStructure,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> Visitor<'de> for SeriesMapVisitor {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ABS SDMX series map")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        while let Some(series_index_key) = map.next_key::<String>()? {
+            let descriptor = self
+                .structure
+                .series_descriptor(&series_index_key)
+                .map_err(de::Error::custom)?;
+            map.next_value_seed(SeriesValueSeed {
+                structure: self.structure.clone(),
+                descriptor,
+                artifact: self.artifact.clone(),
+                ingested_at: self.ingested_at,
+                tx: self.tx.clone(),
+            })?;
+        }
+        Ok(())
+    }
+}
+
+struct SeriesValueSeed {
+    structure: ParsedStructure,
+    descriptor: SeriesDescriptor,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> DeserializeSeed<'de> for SeriesValueSeed {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(SeriesValueVisitor {
+            structure: self.structure,
+            descriptor: self.descriptor,
+            artifact: self.artifact,
+            ingested_at: self.ingested_at,
+            tx: self.tx,
+        })
+    }
+}
+
+struct SeriesValueVisitor {
+    structure: ParsedStructure,
+    descriptor: SeriesDescriptor,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> Visitor<'de> for SeriesValueVisitor {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ABS SDMX series value object")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        let mut saw_observations = false;
+        while let Some(key) = map.next_key::<String>()? {
+            if key == "observations" {
+                saw_observations = true;
+                map.next_value_seed(ObservationsSeed {
+                    structure: self.structure.clone(),
+                    descriptor: self.descriptor.clone(),
+                    artifact: self.artifact.clone(),
+                    ingested_at: self.ingested_at,
+                    tx: self.tx.clone(),
+                })?;
+            } else {
+                map.next_value::<IgnoredAny>()?;
+            }
+        }
+        if saw_observations {
+            Ok(())
+        } else {
+            Err(de::Error::custom(
+                "ABS SDMX series is missing `observations`",
+            ))
+        }
+    }
+}
+
+struct ObservationsSeed {
+    structure: ParsedStructure,
+    descriptor: SeriesDescriptor,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> DeserializeSeed<'de> for ObservationsSeed {
+    type Value = ();
+
+    fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        deserializer.deserialize_map(ObservationsVisitor {
+            structure: self.structure,
+            descriptor: self.descriptor,
+            artifact: self.artifact,
+            ingested_at: self.ingested_at,
+            tx: self.tx,
+        })
+    }
+}
+
+struct ObservationsVisitor {
+    structure: ParsedStructure,
+    descriptor: SeriesDescriptor,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+}
+
+impl<'de> Visitor<'de> for ObservationsVisitor {
+    type Value = ();
+
+    fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.write_str("ABS SDMX observations map")
+    }
+
+    fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+    where
+        A: MapAccess<'de>,
+    {
+        while let Some(observation_index_key) = map.next_key::<String>()? {
+            let tuple = map.next_value::<ObservationTuple>()?;
+            let observation = self
+                .structure
+                .observation(
+                    &self.descriptor,
+                    &observation_index_key,
+                    tuple,
+                    &self.artifact,
+                    self.ingested_at,
+                )
+                .map_err(de::Error::custom)?;
+            self.tx
+                .blocking_send(Ok((self.descriptor.clone(), observation)))
+                .map_err(|_| de::Error::custom("ABS parse receiver was dropped"))?;
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SdmxStructure {
+    dimensions: SdmxDimensions,
+    #[serde(default)]
+    attributes: SdmxAttributes,
+}
+
+impl SdmxStructure {
+    fn into_parsed(self) -> Result<ParsedStructure, String> {
+        Ok(ParsedStructure {
+            series_dimensions: self
+                .dimensions
+                .series
+                .into_iter()
+                .map(ParsedDimension::from_series)
+                .collect::<Result<_, _>>()
+                .map_err(|err| err.to_string())?,
+            observation_dimensions: self
+                .dimensions
+                .observation
+                .into_iter()
+                .map(ParsedDimension::try_from)
+                .collect::<Result<_, _>>()
+                .map_err(|err| err.to_string())?,
+            observation_attributes: self
+                .attributes
+                .observation
+                .into_iter()
+                .map(ParsedDimension::try_from)
+                .collect::<Result<_, _>>()
+                .map_err(|err| err.to_string())?,
+        })
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SdmxDimensions {
+    #[serde(default)]
+    series: Vec<SdmxDimension>,
+    #[serde(default)]
+    observation: Vec<SdmxDimension>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SdmxAttributes {
+    #[serde(default)]
+    observation: Vec<SdmxDimension>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SdmxDimension {
+    id: String,
+    #[serde(default)]
+    values: Vec<SdmxCode>,
+}
+
+#[derive(Debug, Deserialize)]
+struct SdmxCode {
+    id: String,
+}
+
+#[derive(Debug, Clone)]
+struct ParsedStructure {
+    series_dimensions: Vec<ParsedDimension>,
+    observation_dimensions: Vec<ParsedDimension>,
+    observation_attributes: Vec<ParsedDimension>,
+}
+
+impl ParsedStructure {
+    fn series_descriptor(&self, key: &str) -> Result<SeriesDescriptor, String> {
+        let indexes = parse_colon_indexes(key)?;
+        if indexes.len() != self.series_dimensions.len() {
+            return Err(format!(
+                "series key `{key}` has {} dimensions, expected {}",
+                indexes.len(),
+                self.series_dimensions.len()
+            ));
+        }
+
+        let dataflow_id = DataflowId::new("abs.cpi").expect("static dataflow id is valid");
+        let mut dimensions = BTreeMap::new();
+        let mut measure_id = None;
+        for (dimension, index) in self.series_dimensions.iter().zip(indexes) {
+            let code = dimension
+                .values
+                .get(index)
+                .ok_or_else(|| format!("series key `{key}` references missing code {index}"))?
+                .clone();
+            if dimension.id.as_str() == "measure"
+                && measure_id
+                    .replace(MeasureId::new(code.as_str()).map_err(|err| err.to_string())?)
+                    .is_some()
+            {
+                return Err("ABS SDMX series structure has duplicate `MEASURE` dimensions".into());
+            }
+            if dimensions.insert(dimension.id.clone(), code).is_some() {
+                return Err(format!(
+                    "ABS SDMX series structure has duplicate `{}` dimensions",
+                    dimension.id.as_str()
+                ));
+            }
+        }
+        let measure_id = measure_id.ok_or_else(|| {
+            "ABS SDMX series structure is missing `MEASURE` dimension".to_string()
+        })?;
+        let series_key = SeriesKey::derive(
+            &dataflow_id,
+            dimensions
+                .iter()
+                .map(|(dimension, code)| (dimension.as_str(), code.as_str())),
+        );
+
+        Ok(SeriesDescriptor {
+            series_key,
+            dataflow_id,
+            unit: measure_id.as_str().to_string(),
+            measure_id,
+            dimensions,
+        })
+    }
+
+    fn observation(
+        &self,
+        descriptor: &SeriesDescriptor,
+        key: &str,
+        tuple: ObservationTuple,
+        artifact: &ArtifactRef,
+        ingested_at: DateTime<Utc>,
+    ) -> Result<Observation, String> {
+        if self.observation_dimensions.len() != 1 {
+            return Err(format!(
+                "expected one ABS observation dimension, got {}",
+                self.observation_dimensions.len()
+            ));
+        }
+        let indexes = parse_colon_indexes(key)?;
+        if indexes.len() != 1 {
+            return Err(format!(
+                "observation key `{key}` has {} dimensions, expected 1",
+                indexes.len()
+            ));
+        }
+        let time_dimension = &self.observation_dimensions[0];
+        if !time_dimension
+            .id
+            .as_str()
+            .eq_ignore_ascii_case("TIME_PERIOD")
+        {
+            return Err(format!(
+                "expected ABS observation dimension `TIME_PERIOD`, got `{}`",
+                time_dimension.id.as_str()
+            ));
+        }
+        let period = time_dimension
+            .values
+            .get(indexes[0])
+            .ok_or_else(|| format!("observation key `{key}` references missing time period"))?;
+        let (time, time_precision) = parse_time_period(period.as_str())?;
+        let attributes = self.attributes(&tuple)?;
+        let status = observation_status(tuple.value, attributes.get("OBS_STATUS"))?;
+        let value = if status == ObservationStatus::Missing {
+            None
+        } else {
+            tuple.value
+        };
+
+        Ok(Observation {
+            series_key: descriptor.series_key,
+            time,
+            time_precision,
+            value,
+            status,
+            revision_no: 0,
+            attributes,
+            ingested_at,
+            source_artifact_id: artifact.id,
+        })
+    }
+
+    fn attributes(&self, tuple: &ObservationTuple) -> Result<BTreeMap<String, String>, String> {
+        if tuple.attribute_indexes.len() > self.observation_attributes.len() {
+            return Err(format!(
+                "observation tuple has {} attribute indexes, expected at most {}",
+                tuple.attribute_indexes.len(),
+                self.observation_attributes.len()
+            ));
+        }
+        let mut attributes = BTreeMap::new();
+        for (attribute, index) in self
+            .observation_attributes
+            .iter()
+            .zip(tuple.attribute_indexes.iter().copied())
+        {
+            let Some(index) = index else {
+                continue;
+            };
+            let code = attribute
+                .values
+                .get(index)
+                .ok_or_else(|| format!("observation attribute references missing code {index}"))?;
+            let attribute_id = if attribute.id.as_str().eq_ignore_ascii_case("OBS_STATUS") {
+                "OBS_STATUS".to_string()
+            } else {
+                attribute.id.to_string()
+            };
+            if attributes
+                .insert(attribute_id.clone(), code.to_string())
+                .is_some()
+            {
+                return Err(format!(
+                    "observation tuple has duplicate `{attribute_id}` attributes"
+                ));
+            }
+        }
+        Ok(attributes)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ParsedDimension {
+    id: DimensionId,
+    values: Vec<CodeId>,
+}
+
+impl ParsedDimension {
+    fn from_series(value: SdmxDimension) -> Result<Self, String> {
+        let canonical_id = value.id.to_ascii_lowercase();
+        let is_measure = canonical_id == "measure";
+        Ok(Self {
+            id: DimensionId::new(canonical_id).map_err(|err| err.to_string())?,
+            values: value
+                .values
+                .into_iter()
+                .map(|code| {
+                    let code_id = if is_measure {
+                        code.id.to_ascii_lowercase()
+                    } else {
+                        code.id
+                    };
+                    CodeId::new(code_id).map_err(|err| err.to_string())
+                })
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
+impl TryFrom<SdmxDimension> for ParsedDimension {
+    type Error = String;
+
+    fn try_from(value: SdmxDimension) -> Result<Self, Self::Error> {
+        Ok(Self {
+            id: DimensionId::new(value.id).map_err(|err| err.to_string())?,
+            values: value
+                .values
+                .into_iter()
+                .map(|code| CodeId::new(code.id).map_err(|err| err.to_string()))
+                .collect::<Result<_, _>>()?,
+        })
+    }
+}
+
+#[derive(Debug)]
+struct ObservationTuple {
+    value: Option<f64>,
+    attribute_indexes: Vec<Option<usize>>,
+}
+
+impl<'de> Deserialize<'de> for ObservationTuple {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        struct ObservationTupleVisitor;
+
+        impl<'de> Visitor<'de> for ObservationTupleVisitor {
+            type Value = ObservationTuple;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                formatter.write_str("an SDMX observation tuple array")
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+            where
+                A: SeqAccess<'de>,
+            {
+                let value = seq
+                    .next_element::<Option<f64>>()?
+                    .ok_or_else(|| de::Error::custom("observation tuple is missing value"))?;
+                let mut attribute_indexes = Vec::new();
+                while let Some(index) = seq.next_element::<Option<usize>>()? {
+                    attribute_indexes.push(index);
+                }
+                Ok(ObservationTuple {
+                    value,
+                    attribute_indexes,
+                })
+            }
+        }
+
+        deserializer.deserialize_seq(ObservationTupleVisitor)
+    }
+}
+
+fn parse_colon_indexes(key: &str) -> Result<Vec<usize>, String> {
+    key.split(':')
+        .map(|part| {
+            part.parse::<usize>()
+                .map_err(|err| format!("invalid SDMX index `{part}` in `{key}`: {err}"))
+        })
+        .collect()
+}
+
+fn parse_time_period(period: &str) -> Result<(DateTime<Utc>, TimePrecision), String> {
+    if let Some((year, quarter)) = period.split_once("-Q") {
+        let year = year
+            .parse::<i32>()
+            .map_err(|err| format!("invalid SDMX year `{year}`: {err}"))?;
+        let quarter = quarter
+            .parse::<u32>()
+            .map_err(|err| format!("invalid SDMX quarter `{quarter}`: {err}"))?;
+        let month = match quarter {
+            1 => 1,
+            2 => 4,
+            3 => 7,
+            4 => 10,
+            _ => return Err(format!("invalid SDMX quarter `{quarter}`")),
+        };
+        return date_at_midnight(year, month, 1).map(|time| (time, TimePrecision::Quarter));
+    }
+
+    if let Some((year, month)) = period.split_once('-') {
+        if period.len() == 7 {
+            let year = year
+                .parse::<i32>()
+                .map_err(|err| format!("invalid SDMX year `{year}`: {err}"))?;
+            let month = month
+                .parse::<u32>()
+                .map_err(|err| format!("invalid SDMX month `{month}`: {err}"))?;
+            return date_at_midnight(year, month, 1).map(|time| (time, TimePrecision::Month));
+        }
+        return Err(format!(
+            "unsupported ABS CPI TIME_PERIOD `{period}`; expected quarterly `YYYY-Qn` or monthly `YYYY-MM`"
+        ));
+    }
+
+    Err(format!(
+        "unsupported ABS CPI TIME_PERIOD `{period}`; expected quarterly `YYYY-Qn` or monthly `YYYY-MM`"
+    ))
+}
+
+fn date_at_midnight(year: i32, month: u32, day: u32) -> Result<DateTime<Utc>, String> {
+    NaiveDate::from_ymd_opt(year, month, day)
+        .ok_or_else(|| format!("invalid SDMX date components `{year}-{month}-{day}`"))?
+        .and_hms_opt(0, 0, 0)
+        .ok_or_else(|| format!("invalid SDMX time components for `{year}-{month}-{day}`"))
+        .map(|time| time.and_utc())
+}
+
+fn observation_status(
+    value: Option<f64>,
+    status: Option<&String>,
+) -> Result<ObservationStatus, String> {
+    match status.map(String::as_str) {
+        None => Ok(if value.is_none() {
+            ObservationStatus::Missing
+        } else {
+            ObservationStatus::Normal
+        }),
+        Some(status) if status.eq_ignore_ascii_case("A") => {
+            if value.is_none() {
+                Err("OBS_STATUS `A` cannot be attached to a null observation value".into())
+            } else {
+                Ok(ObservationStatus::Normal)
+            }
+        }
+        Some(status) if status.eq_ignore_ascii_case("E") => {
+            non_missing_status(value, status, ObservationStatus::Estimated)
+        }
+        Some(status) if status.eq_ignore_ascii_case("F") => {
+            non_missing_status(value, status, ObservationStatus::Forecast)
+        }
+        Some(status) if status.eq_ignore_ascii_case("I") => {
+            non_missing_status(value, status, ObservationStatus::Imputed)
+        }
+        Some(status) if status.eq_ignore_ascii_case("M") => {
+            if value.is_some() {
+                Err("OBS_STATUS `M` cannot carry a numeric observation value".into())
+            } else {
+                Ok(ObservationStatus::Missing)
+            }
+        }
+        Some(status) if status.eq_ignore_ascii_case("P") => {
+            non_missing_status(value, status, ObservationStatus::Provisional)
+        }
+        Some(status) if status.eq_ignore_ascii_case("R") => {
+            non_missing_status(value, status, ObservationStatus::Revised)
+        }
+        Some(status) if status.eq_ignore_ascii_case("B") => {
+            non_missing_status(value, status, ObservationStatus::Break)
+        }
+        Some(status) => Err(format!("unknown ABS OBS_STATUS `{status}`")),
+    }
+}
+
+fn non_missing_status(
+    value: Option<f64>,
+    status: &str,
+    observation_status: ObservationStatus,
+) -> Result<ObservationStatus, String> {
+    if value.is_none() {
+        Err(format!(
+            "OBS_STATUS `{status}` cannot be attached to a null observation value"
+        ))
+    } else {
+        Ok(observation_status)
     }
 }
 
@@ -557,4 +1818,33 @@ fn revision_token(last_updated: Option<&str>) -> String {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use au_kpis_error::{Classify, ErrorClass};
+    use object_store::memory::InMemory;
+
+    #[tokio::test]
+    async fn parse_blob_stream_reports_worker_panic_as_internal_error() {
+        let blob_store = BlobStore::new(InMemory::new());
+        let artifact_id = blob_store
+            .put_artifact_stream(stream::iter([Ok::<_, io::Error>(Bytes::from_static(
+                b"{}",
+            ))]))
+            .await
+            .expect("store fixture artifact");
+        let key = StorageKey::canonical_for(&artifact_id);
+
+        let err = parse_blob_stream(blob_store, key, |_reader| -> Result<(), AdapterError> {
+            panic!("synthetic parse worker panic")
+        })
+        .await
+        .expect_err("worker panic should be returned as an adapter error");
+
+        assert!(matches!(err, AdapterError::Core(CoreError::Io(_))));
+        assert_eq!(err.class(), ErrorClass::Transient);
+        assert!(err.to_string().contains("ABS parse worker failed"));
+    }
 }

--- a/crates/adapters/abs/tests/fixtures/cpi_sdmx.json
+++ b/crates/adapters/abs/tests/fixtures/cpi_sdmx.json
@@ -1,0 +1,52 @@
+{
+  "data": {
+    "structure": {
+      "dimensions": {
+        "series": [
+          {
+            "id": "REGION",
+            "values": [{ "id": "AUS" }, { "id": "VIC" }]
+          },
+          {
+            "id": "MEASURE",
+            "values": [{ "id": "INDEX" }]
+          }
+        ],
+        "observation": [
+          {
+            "id": "TIME_PERIOD",
+            "values": [{ "id": "2023-Q4" }, { "id": "2024-Q1" }, { "id": "2024-02" }]
+          }
+        ]
+      },
+      "attributes": {
+        "observation": [
+          {
+            "id": "OBS_STATUS",
+            "values": [{ "id": "A" }, { "id": "M" }]
+          }
+        ]
+      }
+    },
+    "dataSets": [
+      {
+        "series": {
+          "0:0": {
+            "observations": {
+              "0": [136.1, 0],
+              "1": [137.4, 0],
+              "2": [138.0, 0]
+            }
+          },
+          "1:0": {
+            "observations": {
+              "0": [135.6, 0],
+              "1": [null, 1],
+              "2": [136.2, 0]
+            }
+          }
+        }
+      }
+    ]
+  }
+}

--- a/crates/adapters/abs/tests/parse.rs
+++ b/crates/adapters/abs/tests/parse.rs
@@ -1,0 +1,907 @@
+use std::{
+    collections::BTreeMap,
+    fmt, io,
+    time::{Duration, Instant},
+};
+
+use async_trait::async_trait;
+use au_kpis_adapter::{AdapterError, AdapterHttpClient, ArtifactRef, ParseCtx, SourceAdapter};
+use au_kpis_adapter_abs::AbsAdapter;
+use au_kpis_domain::{
+    ArtifactId, DataflowId, DimensionId, Observation, ObservationStatus, SeriesDescriptor,
+    SeriesKey, SourceId, TimePrecision,
+};
+use au_kpis_error::{Classify, ErrorClass};
+use au_kpis_storage::{BlobStore, StorageKey};
+use bytes::Bytes;
+use chrono::{DateTime, Utc};
+use futures::{FutureExt, StreamExt, stream, stream::BoxStream};
+use object_store::memory::InMemory;
+use object_store::{
+    Attributes, Error as ObjectStoreError, GetOptions, GetResult, GetResultPayload, ListResult,
+    MultipartUpload, ObjectMeta, ObjectStore, PutMultipartOpts, PutOptions, PutPayload, PutResult,
+    Result as ObjectStoreResult, UploadPart, path::Path,
+};
+use proptest::prelude::*;
+use serde::Serialize;
+
+const CPI_FIXTURE: &[u8] = include_bytes!("fixtures/cpi_sdmx.json");
+const REORDERED_FIXTURE: &[u8] = br#"{
+  "data": {
+    "dataSets": [
+      {
+        "series": {
+          "0:0": {
+            "observations": {
+              "0": [136.1, 0]
+            }
+          }
+        }
+      }
+    ],
+    "structure": {
+      "dimensions": {
+        "series": [
+          { "id": "REGION", "values": [{ "id": "AUS" }] },
+          { "id": "MEASURE", "values": [{ "id": "INDEX" }] }
+        ],
+        "observation": [
+          { "id": "TIME_PERIOD", "values": [{ "id": "2024-Q1" }] }
+        ]
+      },
+      "attributes": {
+        "observation": [
+          { "id": "OBS_STATUS", "values": [{ "id": "A" }] }
+        ]
+      }
+    }
+  }
+}"#;
+const EXTRA_ATTRIBUTE_FIXTURE: &[u8] = br#"{
+  "data": {
+    "structure": {
+      "dimensions": {
+        "series": [
+          { "id": "REGION", "values": [{ "id": "AUS" }] },
+          { "id": "MEASURE", "values": [{ "id": "INDEX" }] }
+        ],
+        "observation": [
+          { "id": "TIME_PERIOD", "values": [{ "id": "2024-Q1" }] }
+        ]
+      },
+      "attributes": {
+        "observation": [
+          { "id": "OBS_STATUS", "values": [{ "id": "A" }] }
+        ]
+      }
+    },
+    "dataSets": [
+      {
+        "series": {
+          "0:0": {
+            "observations": {
+              "0": [136.1, 0, 0]
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#;
+const MISSING_STRUCTURE_FIXTURE: &[u8] = br#"{
+  "data": {
+    "dataSets": []
+  }
+}"#;
+const MISSING_MEASURE_FIXTURE: &[u8] = br#"{
+  "data": {
+    "structure": {
+      "dimensions": {
+        "series": [
+          { "id": "REGION", "values": [{ "id": "AUS" }] }
+        ],
+        "observation": [
+          { "id": "TIME_PERIOD", "values": [{ "id": "2024-Q1" }] }
+        ]
+      },
+      "attributes": {
+        "observation": [
+          { "id": "OBS_STATUS", "values": [{ "id": "A" }] }
+        ]
+      }
+    },
+    "dataSets": [
+      {
+        "series": {
+          "0": {
+            "observations": {
+              "0": [136.1, 0]
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#;
+const DUPLICATE_SERIES_DIMENSION_FIXTURE: &[u8] = br#"{
+  "data": {
+    "structure": {
+      "dimensions": {
+        "series": [
+          { "id": "REGION", "values": [{ "id": "AUS" }] },
+          { "id": "region", "values": [{ "id": "NSW" }] },
+          { "id": "MEASURE", "values": [{ "id": "INDEX" }] }
+        ],
+        "observation": [
+          { "id": "TIME_PERIOD", "values": [{ "id": "2024-Q1" }] }
+        ]
+      },
+      "attributes": {
+        "observation": [
+          { "id": "OBS_STATUS", "values": [{ "id": "A" }] }
+        ]
+      }
+    },
+    "dataSets": [
+      {
+        "series": {
+          "0:0:0": {
+            "observations": {
+              "0": [136.1, 0]
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#;
+const NON_TIME_OBSERVATION_DIMENSION_FIXTURE: &[u8] = br#"{
+  "data": {
+    "structure": {
+      "dimensions": {
+        "series": [
+          { "id": "REGION", "values": [{ "id": "AUS" }] },
+          { "id": "MEASURE", "values": [{ "id": "INDEX" }] }
+        ],
+        "observation": [
+          { "id": "PERIOD", "values": [{ "id": "2024-Q1" }] }
+        ]
+      },
+      "attributes": {
+        "observation": [
+          { "id": "OBS_STATUS", "values": [{ "id": "A" }] }
+        ]
+      }
+    },
+    "dataSets": [
+      {
+        "series": {
+          "0:0": {
+            "observations": {
+              "0": [136.1, 0]
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#;
+const UNKNOWN_STATUS_FIXTURE: &[u8] = br#"{
+  "data": {
+    "structure": {
+      "dimensions": {
+        "series": [
+          { "id": "REGION", "values": [{ "id": "AUS" }] },
+          { "id": "MEASURE", "values": [{ "id": "INDEX" }] }
+        ],
+        "observation": [
+          { "id": "TIME_PERIOD", "values": [{ "id": "2024-Q1" }] }
+        ]
+      },
+      "attributes": {
+        "observation": [
+          { "id": "OBS_STATUS", "values": [{ "id": "X" }] }
+        ]
+      }
+    },
+    "dataSets": [
+      {
+        "series": {
+          "0:0": {
+            "observations": {
+              "0": [136.1, 0]
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#;
+const MISSING_STATUS_WITH_VALUE_FIXTURE: &[u8] = br#"{
+  "data": {
+    "structure": {
+      "dimensions": {
+        "series": [
+          { "id": "REGION", "values": [{ "id": "AUS" }] },
+          { "id": "MEASURE", "values": [{ "id": "INDEX" }] }
+        ],
+        "observation": [
+          { "id": "TIME_PERIOD", "values": [{ "id": "2024-Q1" }] }
+        ]
+      },
+      "attributes": {
+        "observation": [
+          { "id": "OBS_STATUS", "values": [{ "id": "M" }] }
+        ]
+      }
+    },
+    "dataSets": [
+      {
+        "series": {
+          "0:0": {
+            "observations": {
+              "0": [136.1, 0]
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#;
+const LOWERCASE_STATUS_ATTRIBUTE_FIXTURE: &[u8] = br#"{
+  "data": {
+    "structure": {
+      "dimensions": {
+        "series": [
+          { "id": "REGION", "values": [{ "id": "AUS" }] },
+          { "id": "MEASURE", "values": [{ "id": "INDEX" }] }
+        ],
+        "observation": [
+          { "id": "TIME_PERIOD", "values": [{ "id": "2024-Q1" }] }
+        ]
+      },
+      "attributes": {
+        "observation": [
+          { "id": "obs_status", "values": [{ "id": "M" }] }
+        ]
+      }
+    },
+    "dataSets": [
+      {
+        "series": {
+          "0:0": {
+            "observations": {
+              "0": [136.1, 0]
+            }
+          }
+        }
+      }
+    ]
+  }
+}"#;
+
+#[derive(Debug, Serialize)]
+struct ParsedRow {
+    series_key: String,
+    dataflow_id: String,
+    measure_id: String,
+    dimensions: BTreeMap<String, String>,
+    time: String,
+    time_precision: String,
+    value: Option<f64>,
+    status: String,
+    attributes: BTreeMap<String, String>,
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_streams_cpi_sdmx_observations_from_artifact() {
+    let rows = parse_fixture_rows().await;
+
+    insta::assert_json_snapshot!(rows);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_cpi_fixture_stays_under_runtime_budget() {
+    let started = Instant::now();
+    let rows = parse_fixture_raw(CPI_FIXTURE).await.expect("parse fixture");
+    let elapsed = started.elapsed();
+
+    assert_eq!(rows.len(), 6);
+    assert!(
+        elapsed < Duration::from_secs(2),
+        "CPI fixture parse took {elapsed:?}, exceeding 2s budget"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_maps_null_observations_to_missing_status() {
+    let rows = parse_fixture_rows().await;
+
+    let missing = rows
+        .iter()
+        .find(|row| row.dimensions["region"] == "VIC" && row.time == "2024-01-01T00:00:00+00:00")
+        .expect("fixture contains missing VIC observation");
+    assert_eq!(missing.value, None);
+    assert_eq!(missing.status, "missing");
+    assert_eq!(missing.attributes["OBS_STATUS"], "M");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_emits_canonical_series_key_boundary_ids() {
+    let rows = parse_fixture_raw(CPI_FIXTURE).await.expect("parse fixture");
+    let (series, observation) = rows.first().expect("fixture has observations");
+    let dataflow = DataflowId::new("abs.cpi").expect("static dataflow id is valid");
+
+    assert_eq!(series.measure_id.as_str(), "index");
+    assert_eq!(series.unit, "index");
+    assert_eq!(
+        series.dimensions[&DimensionId::new("region").expect("valid dimension")].as_str(),
+        "AUS"
+    );
+    assert_eq!(
+        series.dimensions[&DimensionId::new("measure").expect("valid dimension")].as_str(),
+        "index"
+    );
+    assert_eq!(
+        series.series_key,
+        SeriesKey::derive(&dataflow, [("measure", "index"), ("region", "AUS")])
+    );
+    assert_eq!(observation.series_key, series.series_key);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_uses_measure_code_for_series_unit() {
+    let fixture = String::from_utf8(CPI_FIXTURE.to_vec())
+        .expect("fixture is utf-8")
+        .replace(r#""INDEX""#, r#""PCT""#)
+        .into_bytes();
+    let rows = parse_fixture_owned(fixture).await.expect("parse fixture");
+    let (series, _) = rows.first().expect("fixture has observations");
+
+    assert_eq!(series.measure_id.as_str(), "pct");
+    assert_eq!(series.unit, "pct");
+    assert_eq!(
+        series.dimensions[&DimensionId::new("measure").expect("valid dimension")].as_str(),
+        "pct"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_accepts_data_sets_before_structure() {
+    let rows = parse_fixture_raw(REORDERED_FIXTURE)
+        .await
+        .expect("parse reordered fixture");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(
+        rows[0].0.dimensions[&DimensionId::new("region").expect("valid dimension")].as_str(),
+        "AUS"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_extra_observation_attribute_indexes() {
+    let err = parse_fixture_raw(EXTRA_ATTRIBUTE_FIXTURE)
+        .await
+        .expect_err("extra observation attribute index should be format drift");
+
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(
+        err.to_string()
+            .contains("observation tuple has 2 attribute indexes, expected at most 1"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_reports_sdmx_shape_drift_as_format_drift() {
+    let err = parse_fixture_raw(MISSING_STRUCTURE_FIXTURE)
+        .await
+        .expect_err("missing structure should be format drift");
+
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(
+        err.to_string()
+            .contains("ABS SDMX data is missing `structure`"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_series_without_measure_dimension() {
+    let err = parse_fixture_raw(MISSING_MEASURE_FIXTURE)
+        .await
+        .expect_err("missing measure dimension should be format drift");
+
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(
+        err.to_string()
+            .contains("ABS SDMX series structure is missing `MEASURE` dimension"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_duplicate_series_dimensions() {
+    let err = parse_fixture_raw(DUPLICATE_SERIES_DIMENSION_FIXTURE)
+        .await
+        .expect_err("duplicate series dimension should be format drift");
+
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(
+        err.to_string()
+            .contains("ABS SDMX series structure has duplicate `region` dimensions"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_non_time_observation_dimension() {
+    let err = parse_fixture_raw(NON_TIME_OBSERVATION_DIMENSION_FIXTURE)
+        .await
+        .expect_err("non-time observation dimension should be format drift");
+
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(
+        err.to_string()
+            .contains("expected ABS observation dimension `TIME_PERIOD`, got `PERIOD`"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_non_cpi_artifact_url() {
+    let err = parse_fixture_owned_with_url(
+        CPI_FIXTURE.to_vec(),
+        "https://data.api.abs.gov.au/rest/data/ABS,WPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD",
+    )
+    .await
+    .expect_err("non-CPI artifact should be rejected before parsing");
+
+    assert!(matches!(err, AdapterError::Validation(_)));
+    assert_eq!(err.class(), ErrorClass::Validation);
+    assert!(
+        err.to_string().contains("does not match CPI dataflow"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_artifact_url_without_cpi_dataflow_provenance() {
+    let err = parse_fixture_owned_with_url(
+        CPI_FIXTURE.to_vec(),
+        "https://mirror.example.test/archive/cpi_sdmx.json",
+    )
+    .await
+    .expect_err("mirrored artifact without dataflow provenance should be rejected");
+
+    assert!(matches!(err, AdapterError::Validation(_)));
+    assert_eq!(err.class(), ErrorClass::Validation);
+    assert!(
+        err.to_string().contains("missing CPI dataflow provenance"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_accepts_cpi_artifact_url_with_harmless_query_changes() {
+    let rows = parse_fixture_owned_with_url(
+        CPI_FIXTURE.to_vec(),
+        "https://mirror.example.test/archive/data/ABS,CPI,2.0.0/all?detail=full&dimensionAtObservation=TIME_PERIOD",
+    )
+    .await
+    .expect("parse CPI artifact with reordered query");
+
+    assert_eq!(rows.len(), 6);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_artifact_id_storage_key_mismatch() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let actual_id = blob_store
+        .put_artifact_stream(stream::iter([Ok::<_, std::io::Error>(Bytes::from_static(
+            CPI_FIXTURE,
+        ))]))
+        .await
+        .expect("store fixture artifact");
+    let wrong_id = ArtifactId::of_content(b"different ABS artifact");
+    assert_ne!(actual_id, wrong_id);
+
+    let artifact = ArtifactRef {
+        id: wrong_id,
+        source_id: SourceId::new("abs").expect("static source id is valid"),
+        source_url: "https://data.api.abs.gov.au/rest/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD".into(),
+        content_type: "application/vnd.sdmx.data+json".into(),
+        response_headers: BTreeMap::new(),
+        storage_key: StorageKey::canonical_for(&actual_id).to_string(),
+        size_bytes: CPI_FIXTURE.len() as u64,
+        fetched_at: DateTime::parse_from_rfc3339("2024-04-24T00:00:00Z")
+            .expect("valid fixture date")
+            .with_timezone(&Utc),
+    };
+
+    let adapter = AbsAdapter::default();
+    let ctx = ParseCtx::new(
+        AdapterHttpClient::new(adapter.manifest().rate_limit),
+        blob_store,
+        DateTime::parse_from_rfc3339("2024-04-30T00:00:00Z")
+            .expect("valid fixture date")
+            .with_timezone(&Utc),
+    );
+
+    let mut rows = adapter.parse(artifact, &ctx);
+    let err = rows
+        .next()
+        .await
+        .expect("parse should emit validation error")
+        .expect_err("mismatched storage key should fail");
+
+    assert!(matches!(err, AdapterError::Validation(_)));
+    assert_eq!(err.class(), ErrorClass::Validation);
+    assert!(
+        err.to_string().contains("does not match artifact id"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_unknown_observation_status() {
+    let err = parse_fixture_raw(UNKNOWN_STATUS_FIXTURE)
+        .await
+        .expect_err("unknown observation status should be format drift");
+
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(
+        err.to_string().contains("unknown ABS OBS_STATUS `X`"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_treats_obs_status_attribute_case_insensitively() {
+    let err = parse_fixture_raw(LOWERCASE_STATUS_ATTRIBUTE_FIXTURE)
+        .await
+        .expect_err("lowercase OBS_STATUS should still drive status validation");
+
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(
+        err.to_string()
+            .contains("OBS_STATUS `M` cannot carry a numeric observation value"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_unsupported_cpi_time_period_shapes() {
+    let fixture = String::from_utf8(CPI_FIXTURE.to_vec())
+        .expect("fixture is utf-8")
+        .replace(r#""2023-Q4""#, r#""2023-12-31""#)
+        .into_bytes();
+    let err = parse_fixture_owned(fixture)
+        .await
+        .expect_err("daily CPI time periods should be format drift");
+
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(
+        err.to_string()
+            .contains("unsupported ABS CPI TIME_PERIOD `2023-12-31`"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_missing_status_with_numeric_value() {
+    let err = parse_fixture_raw(MISSING_STATUS_WITH_VALUE_FIXTURE)
+        .await
+        .expect_err("missing status with numeric value should be format drift");
+
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(
+        err.to_string()
+            .contains("OBS_STATUS `M` cannot carry a numeric observation value"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_preserves_transient_storage_read_classification() {
+    let blob_store = BlobStore::new(FailingReadObjectStore);
+    let artifact = ArtifactRef {
+        id: ArtifactId::of_content(b"partial"),
+        source_id: SourceId::new("abs").expect("static source id is valid"),
+        source_url: "https://data.api.abs.gov.au/rest/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD".into(),
+        content_type: "application/vnd.sdmx.data+json".into(),
+        response_headers: BTreeMap::new(),
+        storage_key: "cold/partial".into(),
+        size_bytes: 128,
+        fetched_at: DateTime::parse_from_rfc3339("2024-04-24T00:00:00Z")
+            .expect("valid fixture date")
+            .with_timezone(&Utc),
+    };
+    let adapter = AbsAdapter::default();
+    let ctx = ParseCtx::new(
+        AdapterHttpClient::new(adapter.manifest().rate_limit),
+        blob_store,
+        DateTime::parse_from_rfc3339("2024-04-30T00:00:00Z")
+            .expect("valid fixture date")
+            .with_timezone(&Utc),
+    );
+
+    let mut stream = adapter.parse(artifact, &ctx);
+    let err = stream
+        .next()
+        .await
+        .expect("stream yields storage failure")
+        .expect_err("storage failure should fail parse");
+
+    assert!(matches!(err, AdapterError::Storage(_)));
+    assert_eq!(err.class(), ErrorClass::Transient);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_trailing_bytes_after_json_document() {
+    let mut fixture = CPI_FIXTURE.to_vec();
+    fixture.extend_from_slice(b" trailing");
+
+    let err = parse_fixture_owned(fixture)
+        .await
+        .expect_err("trailing bytes should be rejected");
+
+    assert!(matches!(err, AdapterError::FormatDrift(_)));
+    assert_eq!(err.class(), ErrorClass::Permanent);
+    assert!(err.to_string().contains("trailing characters"), "{err}");
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+    #[test]
+    fn series_key_is_deterministic_for_dimension_order(
+        region in "[A-Z]{2,4}",
+        measure in "[A-Z]{2,8}",
+    ) {
+        let dataflow = DataflowId::new("abs.cpi").expect("static dataflow id is valid");
+        let measure = measure.to_ascii_lowercase();
+        let forward = SeriesKey::derive(&dataflow, [("region", region.as_str()), ("measure", measure.as_str())]);
+        let reverse = SeriesKey::derive(&dataflow, [("measure", measure.as_str()), ("region", region.as_str())]);
+
+        prop_assert_eq!(forward, reverse);
+    }
+
+    #[test]
+    fn observation_json_roundtrips(
+        value in prop::option::of(-1_000_000_i32..1_000_000),
+        revision_no in 0_u32..32,
+    ) {
+        let dataflow = DataflowId::new("abs.cpi").expect("static dataflow id is valid");
+        let series_key = SeriesKey::derive(&dataflow, [("region", "AUS"), ("measure", "index")]);
+        let observation = Observation {
+            series_key,
+            time: DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+                .expect("valid fixture date")
+                .with_timezone(&Utc),
+            time_precision: TimePrecision::Quarter,
+            value: value.map(|value| f64::from(value) / 10.0),
+            status: if value.is_some() {
+                ObservationStatus::Normal
+            } else {
+                ObservationStatus::Missing
+            },
+            revision_no,
+            attributes: BTreeMap::from([("OBS_STATUS".to_string(), "A".to_string())]),
+            ingested_at: DateTime::parse_from_rfc3339("2024-04-30T00:00:00Z")
+                .expect("valid fixture date")
+                .with_timezone(&Utc),
+            source_artifact_id: ArtifactId::of_content(CPI_FIXTURE),
+        };
+
+        let json = serde_json::to_string(&observation).expect("serialize observation");
+        let roundtrip: Observation = serde_json::from_str(&json).expect("deserialize observation");
+
+        prop_assert_eq!(observation, roundtrip);
+    }
+}
+
+async fn parse_fixture_rows() -> Vec<ParsedRow> {
+    parse_fixture_raw(CPI_FIXTURE)
+        .await
+        .expect("parse fixture")
+        .into_iter()
+        .map(|(series, observation)| ParsedRow {
+            series_key: series.series_key.to_string(),
+            dataflow_id: series.dataflow_id.to_string(),
+            measure_id: series.measure_id.to_string(),
+            dimensions: series
+                .dimensions
+                .into_iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect(),
+            time: observation.time.to_rfc3339(),
+            time_precision: format!("{:?}", observation.time_precision).to_lowercase(),
+            value: observation.value,
+            status: format!("{:?}", observation.status).to_lowercase(),
+            attributes: observation.attributes,
+        })
+        .collect()
+}
+
+async fn parse_fixture_raw(
+    fixture: &'static [u8],
+) -> Result<Vec<(SeriesDescriptor, Observation)>, AdapterError> {
+    parse_fixture_owned(fixture.to_vec()).await
+}
+
+async fn parse_fixture_owned(
+    fixture: Vec<u8>,
+) -> Result<Vec<(SeriesDescriptor, Observation)>, AdapterError> {
+    parse_fixture_owned_with_url(
+        fixture,
+        "https://data.api.abs.gov.au/rest/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD",
+    )
+    .await
+}
+
+async fn parse_fixture_owned_with_url(
+    fixture: Vec<u8>,
+    source_url: &str,
+) -> Result<Vec<(SeriesDescriptor, Observation)>, AdapterError> {
+    let blob_store = BlobStore::new(InMemory::new());
+    let artifact_id_expected = ArtifactId::of_content(&fixture);
+    let size_bytes = fixture.len() as u64;
+    let artifact_id = blob_store
+        .put_artifact_stream(stream::iter([Ok::<_, std::io::Error>(Bytes::from(
+            fixture.clone(),
+        ))]))
+        .await
+        .expect("store fixture artifact");
+
+    let artifact = ArtifactRef {
+        id: artifact_id,
+        source_id: SourceId::new("abs").expect("static source id is valid"),
+        source_url: source_url.into(),
+        content_type: "application/vnd.sdmx.data+json".into(),
+        response_headers: BTreeMap::new(),
+        storage_key: StorageKey::canonical_for(&artifact_id).to_string(),
+        size_bytes,
+        fetched_at: DateTime::parse_from_rfc3339("2024-04-24T00:00:00Z")
+            .expect("valid fixture date")
+            .with_timezone(&Utc),
+    };
+    assert_eq!(artifact.id, artifact_id_expected);
+
+    let adapter = AbsAdapter::default();
+    let ctx = ParseCtx::new(
+        AdapterHttpClient::new(adapter.manifest().rate_limit),
+        blob_store,
+        DateTime::parse_from_rfc3339("2024-04-30T00:00:00Z")
+            .expect("valid fixture date")
+            .with_timezone(&Utc),
+    );
+
+    let mut stream = adapter.parse(artifact, &ctx);
+    let mut rows = Vec::new();
+    while let Some(next) = stream.next().await {
+        rows.push(next?);
+    }
+    Ok(rows)
+}
+
+#[derive(Debug)]
+struct FailingReadObjectStore;
+
+impl fmt::Display for FailingReadObjectStore {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("FailingReadObjectStore")
+    }
+}
+
+#[async_trait]
+impl ObjectStore for FailingReadObjectStore {
+    async fn put_opts(
+        &self,
+        _location: &Path,
+        _payload: PutPayload,
+        _opts: PutOptions,
+    ) -> ObjectStoreResult<PutResult> {
+        Ok(put_result())
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        _location: &Path,
+        _opts: PutMultipartOpts,
+    ) -> ObjectStoreResult<Box<dyn MultipartUpload>> {
+        Ok(Box::new(UnsupportedMultipartUpload))
+    }
+
+    async fn get_opts(
+        &self,
+        location: &Path,
+        _options: GetOptions,
+    ) -> ObjectStoreResult<GetResult> {
+        let stream = stream::iter([
+            Ok(Bytes::from_static(br#"{"data":{"structure":"#)),
+            Err(ObjectStoreError::Generic {
+                store: "failing-read",
+                source: io::Error::other("backend reset").into(),
+            }),
+        ]);
+
+        Ok(GetResult {
+            payload: GetResultPayload::Stream(stream.boxed()),
+            meta: ObjectMeta {
+                location: location.clone(),
+                last_modified: Utc::now(),
+                size: 128,
+                e_tag: None,
+                version: None,
+            },
+            range: 0..128,
+            attributes: Attributes::new(),
+        })
+    }
+
+    async fn head(&self, location: &Path) -> ObjectStoreResult<ObjectMeta> {
+        Err(ObjectStoreError::NotFound {
+            path: location.to_string(),
+            source: "not persisted in failing read store".into(),
+        })
+    }
+
+    async fn delete(&self, _location: &Path) -> ObjectStoreResult<()> {
+        Ok(())
+    }
+
+    fn list(&self, _prefix: Option<&Path>) -> BoxStream<'_, ObjectStoreResult<ObjectMeta>> {
+        stream::empty().boxed()
+    }
+
+    async fn list_with_delimiter(&self, _prefix: Option<&Path>) -> ObjectStoreResult<ListResult> {
+        Ok(ListResult {
+            common_prefixes: Vec::new(),
+            objects: Vec::new(),
+        })
+    }
+
+    async fn copy(&self, _from: &Path, _to: &Path) -> ObjectStoreResult<()> {
+        Ok(())
+    }
+
+    async fn copy_if_not_exists(&self, _from: &Path, _to: &Path) -> ObjectStoreResult<()> {
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct UnsupportedMultipartUpload;
+
+#[async_trait]
+impl MultipartUpload for UnsupportedMultipartUpload {
+    fn put_part(&mut self, _data: PutPayload) -> UploadPart {
+        async { Ok(()) }.boxed()
+    }
+
+    async fn complete(&mut self) -> ObjectStoreResult<PutResult> {
+        Ok(put_result())
+    }
+
+    async fn abort(&mut self) -> ObjectStoreResult<()> {
+        Ok(())
+    }
+}
+
+fn put_result() -> PutResult {
+    PutResult {
+        e_tag: None,
+        version: None,
+    }
+}

--- a/crates/adapters/abs/tests/parse_memory.rs
+++ b/crates/adapters/abs/tests/parse_memory.rs
@@ -1,0 +1,156 @@
+#![cfg(feature = "dhat-heap")]
+
+use std::{
+    collections::BTreeMap,
+    fs::{self, File},
+    io::{self, BufWriter, Write},
+    path::Path,
+};
+
+use au_kpis_adapter::{AdapterHttpClient, ArtifactRef, ParseCtx, SourceAdapter};
+use au_kpis_adapter_abs::AbsAdapter;
+use au_kpis_domain::{ArtifactId, Sha256Digest, SourceId};
+use au_kpis_storage::BlobStore;
+use chrono::{DateTime, Utc};
+use futures::StreamExt;
+use object_store::local::LocalFileSystem;
+use sha2::{Digest, Sha256};
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+const PAYLOAD_BYTES: usize = 500 * 1024 * 1024;
+const MAX_HEAP_BYTES: usize = 100 * 1024 * 1024;
+const VALUE_FRACTION_BYTES: usize = 16 * 1024;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "500 MB DHAT memory profile for issue #26"]
+async fn parse_500mb_stays_below_100mb_peak_heap_under_dhat() {
+    let root =
+        std::env::temp_dir().join(format!("au-kpis-abs-parse-memory-{}", std::process::id()));
+    let source_path = root.join("parse-large.json");
+    let artifact_id =
+        write_large_sdmx_fixture(&source_path, PAYLOAD_BYTES).expect("write large fixture");
+    let storage_key = format!("artifacts/{}", artifact_id.to_hex());
+    let artifact_path = root.join(&storage_key);
+    fs::create_dir_all(
+        artifact_path
+            .parent()
+            .expect("canonical artifact path has parent"),
+    )
+    .expect("create artifact dir");
+    fs::rename(&source_path, &artifact_path).expect("move fixture to canonical storage key");
+
+    let adapter = AbsAdapter::default();
+    let blob_store = BlobStore::new(LocalFileSystem::new_with_prefix(&root).expect("local store"));
+    let payload_bytes = fs::metadata(&artifact_path)
+        .expect("large fixture metadata")
+        .len();
+    let artifact = ArtifactRef {
+        id: artifact_id,
+        source_id: SourceId::new("abs").expect("static source id is valid"),
+        source_url: "https://data.api.abs.gov.au/rest/data/ABS,CPI,2.0.0/all?dimensionAtObservation=TIME_PERIOD".into(),
+        content_type: "application/vnd.sdmx.data+json".into(),
+        response_headers: BTreeMap::new(),
+        storage_key,
+        size_bytes: payload_bytes,
+        fetched_at: DateTime::parse_from_rfc3339("2024-04-24T00:00:00Z")
+            .expect("valid fixture date")
+            .with_timezone(&Utc),
+    };
+    let ctx = ParseCtx::new(
+        AdapterHttpClient::new(adapter.manifest().rate_limit),
+        blob_store,
+        DateTime::parse_from_rfc3339("2024-04-30T00:00:00Z")
+            .expect("valid fixture date")
+            .with_timezone(&Utc),
+    );
+
+    let profiler = dhat::Profiler::builder().testing().build();
+    let mut stream = adapter.parse(artifact, &ctx);
+    let mut observations = 0_u64;
+    while let Some(next) = stream.next().await {
+        next.expect("parse large fixture row");
+        observations += 1;
+    }
+
+    let stats = dhat::HeapStats::get();
+    println!(
+        "dhat abs parse: payload_bytes={} max_bytes={} total_bytes={} observations={}",
+        payload_bytes, stats.max_bytes, stats.total_bytes, observations
+    );
+    assert!(payload_bytes >= PAYLOAD_BYTES as u64);
+    assert!(observations > 1_000);
+    assert!(
+        stats.max_bytes < MAX_HEAP_BYTES,
+        "peak heap {} bytes exceeded {} byte budget",
+        stats.max_bytes,
+        MAX_HEAP_BYTES
+    );
+    drop(profiler);
+    fs::remove_dir_all(root).expect("remove large fixture dir");
+}
+
+fn write_large_sdmx_fixture(path: &Path, target_bytes: usize) -> io::Result<ArtifactId> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let file = File::create(path)?;
+    let mut writer = CountingWriter::new(BufWriter::new(file));
+
+    let observation_count = (target_bytes / (VALUE_FRACTION_BYTES + 32)).max(1_001) + 16;
+    let fractional_digits = vec![b'0'; VALUE_FRACTION_BYTES];
+
+    writer.write_all(br#"{"data":{"structure":{"dimensions":{"series":[{"id":"REGION","values":[{"id":"AUS"}]},{"id":"MEASURE","values":[{"id":"INDEX"}]}],"observation":[{"id":"TIME_PERIOD","values":["#)?;
+    for index in 0..observation_count {
+        if index > 0 {
+            writer.write_all(b",")?;
+        }
+        write!(writer, r#"{{"id":"2024-Q{}"}}"#, (index % 4) + 1)?;
+    }
+    writer.write_all(br#"]}]},"attributes":{"observation":[{"id":"OBS_STATUS","values":[{"id":"A"}]}]}},"dataSets":[{"series":{"0:0":{"observations":{"#)?;
+    for index in 0..observation_count {
+        if index > 0 {
+            writer.write_all(b",")?;
+        }
+        write!(writer, r#""{index}":[1."#)?;
+        writer.write_all(&fractional_digits)?;
+        writer.write_all(b",0]")?;
+    }
+    writer.write_all(br#"}}}}]}}"#)?;
+    writer.flush()?;
+    Ok(writer.artifact_id())
+}
+
+struct CountingWriter<W> {
+    inner: W,
+    bytes_written: usize,
+    hasher: Sha256,
+}
+
+impl<W> CountingWriter<W> {
+    fn new(inner: W) -> Self {
+        Self {
+            inner,
+            bytes_written: 0,
+            hasher: Sha256::new(),
+        }
+    }
+
+    fn artifact_id(self) -> ArtifactId {
+        ArtifactId::from_digest(Sha256Digest::from_bytes(self.hasher.finalize().into()))
+    }
+}
+
+impl<W: Write> Write for CountingWriter<W> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let written = self.inner.write(buf)?;
+        self.hasher.update(&buf[..written]);
+        self.bytes_written += written;
+        Ok(written)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}

--- a/crates/adapters/abs/tests/snapshots/parse__parse_streams_cpi_sdmx_observations_from_artifact.snap
+++ b/crates/adapters/abs/tests/snapshots/parse__parse_streams_cpi_sdmx_observations_from_artifact.snap
@@ -1,0 +1,102 @@
+---
+source: crates/adapters/abs/tests/parse.rs
+expression: rows
+---
+[
+  {
+    "series_key": "214d5af143911f8196e7b803a6a735e84f5964dd3cc8bfa7f6aedaf845aa2c8e",
+    "dataflow_id": "abs.cpi",
+    "measure_id": "index",
+    "dimensions": {
+      "measure": "index",
+      "region": "AUS"
+    },
+    "time": "2023-10-01T00:00:00+00:00",
+    "time_precision": "quarter",
+    "value": 136.1,
+    "status": "normal",
+    "attributes": {
+      "OBS_STATUS": "A"
+    }
+  },
+  {
+    "series_key": "214d5af143911f8196e7b803a6a735e84f5964dd3cc8bfa7f6aedaf845aa2c8e",
+    "dataflow_id": "abs.cpi",
+    "measure_id": "index",
+    "dimensions": {
+      "measure": "index",
+      "region": "AUS"
+    },
+    "time": "2024-01-01T00:00:00+00:00",
+    "time_precision": "quarter",
+    "value": 137.4,
+    "status": "normal",
+    "attributes": {
+      "OBS_STATUS": "A"
+    }
+  },
+  {
+    "series_key": "214d5af143911f8196e7b803a6a735e84f5964dd3cc8bfa7f6aedaf845aa2c8e",
+    "dataflow_id": "abs.cpi",
+    "measure_id": "index",
+    "dimensions": {
+      "measure": "index",
+      "region": "AUS"
+    },
+    "time": "2024-02-01T00:00:00+00:00",
+    "time_precision": "month",
+    "value": 138.0,
+    "status": "normal",
+    "attributes": {
+      "OBS_STATUS": "A"
+    }
+  },
+  {
+    "series_key": "140f81487a04649b0284511b2f820989271a16005bfd62ecb93d1e9a4f4d759d",
+    "dataflow_id": "abs.cpi",
+    "measure_id": "index",
+    "dimensions": {
+      "measure": "index",
+      "region": "VIC"
+    },
+    "time": "2023-10-01T00:00:00+00:00",
+    "time_precision": "quarter",
+    "value": 135.6,
+    "status": "normal",
+    "attributes": {
+      "OBS_STATUS": "A"
+    }
+  },
+  {
+    "series_key": "140f81487a04649b0284511b2f820989271a16005bfd62ecb93d1e9a4f4d759d",
+    "dataflow_id": "abs.cpi",
+    "measure_id": "index",
+    "dimensions": {
+      "measure": "index",
+      "region": "VIC"
+    },
+    "time": "2024-01-01T00:00:00+00:00",
+    "time_precision": "quarter",
+    "value": null,
+    "status": "missing",
+    "attributes": {
+      "OBS_STATUS": "M"
+    }
+  },
+  {
+    "series_key": "140f81487a04649b0284511b2f820989271a16005bfd62ecb93d1e9a4f4d759d",
+    "dataflow_id": "abs.cpi",
+    "measure_id": "index",
+    "dimensions": {
+      "measure": "index",
+      "region": "VIC"
+    },
+    "time": "2024-02-01T00:00:00+00:00",
+    "time_precision": "month",
+    "value": 136.2,
+    "status": "normal",
+    "attributes": {
+      "OBS_STATUS": "A"
+    }
+  }
+]


### PR DESCRIPTION
## Summary

Implements the ABS SDMX-JSON parse stage for issue #26. The adapter now reads persisted artifacts through `BlobStore::get`, parses SDMX structure plus series observations, and emits `(SeriesDescriptor, Observation)` rows through the existing `ObservationStream` API.

Follow-up fixes from automated review canonicalize emitted series boundary IDs, derive series units from parsed measure codes, reject observation tuples with unexpected attribute indexes, reject absent `MEASURE` dimensions, reject unknown or contradictory `OBS_STATUS` values, classify parse-time SDMX shape drift as `FormatDrift`, preserve transient storage read failures through the parser stream, tolerate harmless JSON key reordering without buffering `dataSets`, reject trailing JSON bytes, avoid blocking Tokio workers while forwarding blob chunks, and make the memory profile exercise real observation tuples. The snapshot CI gate now runs the original workspace-wide `cargo insta test --workspace --check` command instead of a package-discovery heuristic.

Closes #26

## Pass requirements

- [x] Streaming parse via `BoxStream`
- [x] `insta` snapshot matches for CPI fixture
- [x] Property tests: deterministic `SeriesKey`, parse/serialize round-trip
- [x] Peak memory <100 MB on 500 MB input measured with `dhat`
- [x] Handles missing/null observations per SDMX conventions

## Test plan

- [x] `cargo test -p au-kpis-adapter-abs`
- [x] `cargo test -p au-kpis-adapter-abs --test parse`
- [x] `cargo clippy -p au-kpis-adapter-abs --all-targets -- -D warnings`
- [x] `cargo clippy -p au-kpis-adapter-abs --all-targets --features dhat-heap -- -D warnings`
- [x] `pnpm run lint`
- [x] `cargo test -p au-kpis-adapter-abs --features dhat-heap --test fetch_memory -- --ignored --nocapture`
- [x] `cargo test -p au-kpis-adapter-abs --features dhat-heap --test parse_memory -- --ignored --nocapture`
- [ ] `cargo insta test --workspace --check` (local run reached the restored workspace-wide gate and failed in pre-existing `au-kpis-api --test sigterm` startup-address tests after ABS/OpenAPI snapshots passed; CI is the authoritative environment)

DHAT parse result: `payload_bytes=524529643 max_bytes=6127568 total_bytes=588475293 observations=31953`.
DHAT fetch result: `payload_bytes=524288000 max_bytes=6814923 total_bytes=526168702 artifact_size=524288000`.

## Spec impact

No Spec changes required. This implements the existing `Spec.md § Source adapters`, `§ Testing strategy`, and Phase 2 ABS parser requirements.
