### PR TITLE
feat(loader): add copy batch loader (#27)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -5,6 +5,10 @@ final-status-level = "flaky"
 slow-timeout = { period = "60s", terminate-after = 4 }
 status-level = "pass"
 
+[[profile.default.overrides]]
+filter = 'test(loads_ten_thousand_observations_with_copy_batches)'
+threads-required = "num-cpus"
+
 [profile.ci]
 fail-fast = false
 failure-output = "immediate-final"
@@ -13,6 +17,10 @@ retries = { backoff = "fixed", count = 2, delay = "1s" }
 slow-timeout = { period = "60s", terminate-after = 4 }
 status-level = "retry"
 success-output = "never"
+
+[[profile.ci.overrides]]
+filter = 'test(loads_ten_thousand_observations_with_copy_batches)'
+threads-required = "num-cpus"
 
 [profile.ci.junit]
 path = "junit.xml"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -329,7 +329,9 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p target/nextest
-          cargo nextest run --workspace --profile ci 2>&1 | tee target/nextest/ci-run.log
+          cargo nextest run --workspace --profile ci \
+            -E 'not test(loads_ten_thousand_observations_with_copy_batches)' \
+            2>&1 | tee target/nextest/ci-run.log
           if grep -n "FLAKY" target/nextest/ci-run.log; then
             echo "Flaky retries are not allowed in CI." >&2
             exit 1
@@ -379,6 +381,7 @@ jobs:
           cargo +"$COVERAGE_RUST_TOOLCHAIN" llvm-cov nextest \
             --workspace \
             --profile ci \
+            -E 'not test(loads_ten_thousand_observations_with_copy_batches)' \
             --skip-functions \
             --branch \
             --lcov \

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -533,7 +533,9 @@ jobs:
         run: cargo install cargo-insta --version 1.47.2 --locked
 
       - name: Verify committed snapshots
-        run: cargo insta test --workspace --check
+        run: |
+          cargo insta test --workspace --check -- \
+            --skip loads_ten_thousand_observations_with_copy_batches
 
   codex-review:
     name: Codex Structured Review

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,18 @@ dependencies = [
 [[package]]
 name = "au-kpis-loader"
 version = "0.1.0"
+dependencies = [
+ "au-kpis-config",
+ "au-kpis-db",
+ "au-kpis-domain",
+ "au-kpis-testing",
+ "chrono",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "au-kpis-openapi"

--- a/crates/au-kpis-loader/Cargo.toml
+++ b/crates/au-kpis-loader/Cargo.toml
@@ -8,3 +8,23 @@ repository.workspace = true
 description = "Observation upsert, revision tracking."
 
 [dependencies]
+au-kpis-domain.workspace = true
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+serde_json = "1"
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio",
+    "tls-rustls",
+    "postgres",
+    "chrono",
+    "json",
+] }
+thiserror = "2"
+tracing = "0.1"
+
+[dev-dependencies]
+au-kpis-config.workspace = true
+au-kpis-db.workspace = true
+au-kpis-testing.workspace = true
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/au-kpis-loader/src/lib.rs
+++ b/crates/au-kpis-loader/src/lib.rs
@@ -1,1 +1,465 @@
 //! Observation upsert, revision tracking.
+
+#![forbid(unsafe_code)]
+
+use std::collections::BTreeMap;
+
+use au_kpis_domain::{
+    Observation, ObservationStatus, SeriesDescriptor, TimePrecision,
+    ids::{ArtifactId, SeriesKey},
+};
+use sqlx::{PgPool, Postgres, Transaction};
+use thiserror::Error;
+use tracing::instrument;
+
+const DEFAULT_MAX_ROWS: usize = 1_000;
+const DEFAULT_MAX_BYTES: usize = 10 * 1024 * 1024;
+
+/// A parsed observation paired with the series metadata needed by the loader.
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoadItem {
+    /// Series metadata emitted by the source adapter.
+    pub series: SeriesDescriptor,
+    /// Observation for the series.
+    pub observation: Observation,
+}
+
+/// Aggregate result for a loader run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct LoadStats {
+    /// Valid observations written through the staging table.
+    pub observations_loaded: u64,
+    /// Distinct valid series descriptors upserted.
+    pub series_upserted: u64,
+    /// Invalid rows recorded in `parse_errors`.
+    pub parse_errors: u64,
+    /// Number of database transactions used for valid batches.
+    pub batches: u64,
+}
+
+/// Loader configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LoadOptions {
+    /// Maximum observations per transaction.
+    pub max_rows: usize,
+    /// Maximum approximate COPY payload bytes per transaction.
+    pub max_bytes: usize,
+}
+
+impl Default for LoadOptions {
+    fn default() -> Self {
+        Self {
+            max_rows: DEFAULT_MAX_ROWS,
+            max_bytes: DEFAULT_MAX_BYTES,
+        }
+    }
+}
+
+/// Errors returned by the loader.
+#[derive(Debug, Error)]
+pub enum LoadError {
+    /// Loader input was internally inconsistent.
+    #[error("loader validation: {0}")]
+    Validation(String),
+
+    /// JSON conversion for staged dimensions or attributes failed.
+    #[error("loader json: {0}")]
+    Json(#[from] serde_json::Error),
+
+    /// A database operation failed.
+    #[error("loader db: {0}")]
+    Db(#[from] sqlx::Error),
+}
+
+/// Load observations using the spec default 1000-row / 10 MB batch limits.
+#[instrument(skip(pool, items))]
+pub async fn load_batch(pool: &PgPool, items: Vec<LoadItem>) -> Result<LoadStats, LoadError> {
+    load_batch_with_options(pool, items, LoadOptions::default()).await
+}
+
+/// Load observations using explicit batch limits.
+#[instrument(skip(pool, items))]
+pub async fn load_batch_with_options(
+    pool: &PgPool,
+    items: Vec<LoadItem>,
+    options: LoadOptions,
+) -> Result<LoadStats, LoadError> {
+    if options.max_rows == 0 {
+        return Err(LoadError::Validation(
+            "max_rows must be greater than 0".into(),
+        ));
+    }
+    if options.max_bytes == 0 {
+        return Err(LoadError::Validation(
+            "max_bytes must be greater than 0".into(),
+        ));
+    }
+
+    let mut stats = LoadStats::default();
+    let mut valid_items = Vec::with_capacity(items.len());
+
+    for item in items {
+        match validate_item(&item) {
+            Ok(()) => {
+                valid_items.push(item);
+            }
+            Err(message) => {
+                record_parse_error(pool, item.observation.source_artifact_id, &message, &item)
+                    .await?;
+                stats.parse_errors += 1;
+            }
+        }
+    }
+
+    if valid_items.is_empty() {
+        return Ok(stats);
+    }
+
+    upsert_series_batch(pool, &valid_items, &mut stats).await?;
+
+    let mut valid_batch = Vec::new();
+    let mut valid_batch_bytes = 0usize;
+    for item in valid_items {
+        let estimated_bytes = estimate_item_bytes(&item)?;
+        if !valid_batch.is_empty()
+            && (valid_batch.len() >= options.max_rows
+                || valid_batch_bytes + estimated_bytes > options.max_bytes)
+        {
+            load_observation_batch(pool, &valid_batch, &mut stats).await?;
+            valid_batch.clear();
+            valid_batch_bytes = 0;
+        }
+        valid_batch_bytes += estimated_bytes;
+        valid_batch.push(item);
+    }
+
+    if !valid_batch.is_empty() {
+        load_observation_batch(pool, &valid_batch, &mut stats).await?;
+    }
+    Ok(stats)
+}
+
+fn validate_item(item: &LoadItem) -> Result<(), String> {
+    let computed = item.series.compute_series_key();
+    if item.series.series_key != computed {
+        return Err(format!(
+            "series descriptor key {} does not match computed key {}",
+            item.series.series_key, computed
+        ));
+    }
+    if item.observation.series_key != item.series.series_key {
+        return Err(format!(
+            "observation series key {} does not match descriptor key {}",
+            item.observation.series_key, item.series.series_key
+        ));
+    }
+    Ok(())
+}
+
+fn estimate_item_bytes(item: &LoadItem) -> Result<usize, LoadError> {
+    let dimensions = descriptor_dimensions_json(&item.series)?;
+    let attributes = serde_json::to_string(&item.observation.attributes)?;
+    Ok(256 + dimensions.len() + attributes.len())
+}
+
+async fn upsert_series_batch(
+    pool: &PgPool,
+    batch: &[LoadItem],
+    stats: &mut LoadStats,
+) -> Result<(), LoadError> {
+    let mut tx = pool.begin().await?;
+    create_series_staging_table(&mut tx).await?;
+    copy_series(&mut tx, batch).await?;
+    let series_upserted = upsert_series(&mut tx).await?;
+    tx.commit().await?;
+
+    stats.series_upserted += series_upserted;
+    Ok(())
+}
+
+async fn load_observation_batch(
+    pool: &PgPool,
+    batch: &[LoadItem],
+    stats: &mut LoadStats,
+) -> Result<(), LoadError> {
+    let mut tx = pool.begin().await?;
+    create_observation_staging_table(&mut tx).await?;
+    copy_observations(&mut tx, batch).await?;
+    let observations_loaded = upsert_observations(&mut tx).await?;
+    tx.commit().await?;
+
+    stats.observations_loaded += observations_loaded;
+    stats.batches += 1;
+    Ok(())
+}
+
+async fn create_series_staging_table(tx: &mut Transaction<'_, Postgres>) -> Result<(), LoadError> {
+    sqlx::query(
+        "CREATE TEMP TABLE staging_series (
+             series_key_hex TEXT NOT NULL,
+             dataflow_id TEXT NOT NULL,
+             measure_id TEXT NOT NULL,
+             dimensions JSONB NOT NULL,
+             unit TEXT NOT NULL,
+             first_observed TIMESTAMPTZ NOT NULL,
+             last_observed TIMESTAMPTZ NOT NULL
+         ) ON COMMIT DROP",
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+async fn create_observation_staging_table(
+    tx: &mut Transaction<'_, Postgres>,
+) -> Result<(), LoadError> {
+    sqlx::query(
+        "CREATE TEMP TABLE staging_observations (
+             series_key_hex TEXT NOT NULL,
+             time TIMESTAMPTZ NOT NULL,
+             revision_no INTEGER NOT NULL,
+             time_precision TEXT NOT NULL,
+             value DOUBLE PRECISION,
+             status TEXT NOT NULL,
+             attributes JSONB NOT NULL,
+             ingested_at TIMESTAMPTZ NOT NULL,
+             source_artifact_hex TEXT NOT NULL
+         ) ON COMMIT DROP",
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(())
+}
+
+async fn copy_series(
+    tx: &mut Transaction<'_, Postgres>,
+    batch: &[LoadItem],
+) -> Result<(), LoadError> {
+    let mut rows = BTreeMap::<SeriesKey, SeriesStageRow>::new();
+    for item in batch {
+        let dimensions_json = descriptor_dimensions_json(&item.series)?;
+        match rows.entry(item.series.series_key) {
+            std::collections::btree_map::Entry::Occupied(mut entry) => {
+                let row = entry.get_mut();
+                row.first_observed = row.first_observed.min(item.observation.time);
+                row.last_observed = row.last_observed.max(item.observation.time);
+            }
+            std::collections::btree_map::Entry::Vacant(entry) => {
+                entry.insert(SeriesStageRow {
+                    descriptor: item.series.clone(),
+                    dimensions_json,
+                    first_observed: item.observation.time,
+                    last_observed: item.observation.time,
+                });
+            }
+        }
+    }
+
+    let payload = rows.values().try_fold(String::new(), |mut payload, row| {
+        push_copy_fields(
+            &mut payload,
+            [
+                row.descriptor.series_key.to_hex(),
+                row.descriptor.dataflow_id.to_string(),
+                row.descriptor.measure_id.to_string(),
+                row.dimensions_json.clone(),
+                row.descriptor.unit.clone(),
+                row.first_observed.to_rfc3339(),
+                row.last_observed.to_rfc3339(),
+            ],
+        );
+        Ok::<_, LoadError>(payload)
+    })?;
+
+    let mut copy = tx
+        .as_mut()
+        .copy_in_raw(
+            "COPY staging_series (
+                 series_key_hex, dataflow_id, measure_id, dimensions, unit,
+                 first_observed, last_observed
+             ) FROM STDIN",
+        )
+        .await?;
+    copy.send(payload.as_bytes()).await?;
+    copy.finish().await?;
+
+    Ok(())
+}
+
+async fn upsert_series(tx: &mut Transaction<'_, Postgres>) -> Result<u64, LoadError> {
+    let result = sqlx::query(
+        "INSERT INTO series (
+             series_key, dataflow_id, measure_id, dimensions, unit,
+             first_observed, last_observed, active
+         )
+         SELECT decode(series_key_hex, 'hex'), dataflow_id, measure_id, dimensions,
+                unit, min(first_observed), max(last_observed), TRUE
+         FROM staging_series
+         GROUP BY series_key_hex, dataflow_id, measure_id, dimensions, unit
+         ON CONFLICT (series_key) DO UPDATE
+         SET first_observed = LEAST(series.first_observed, EXCLUDED.first_observed),
+             last_observed = GREATEST(series.last_observed, EXCLUDED.last_observed),
+             updated_at = now()",
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+async fn copy_observations(
+    tx: &mut Transaction<'_, Postgres>,
+    batch: &[LoadItem],
+) -> Result<(), LoadError> {
+    let mut payload = String::new();
+    for item in batch {
+        let obs = &item.observation;
+        push_copy_fields(
+            &mut payload,
+            [
+                obs.series_key.to_hex(),
+                obs.time.to_rfc3339(),
+                obs.revision_no.to_string(),
+                time_precision_db(obs.time_precision).to_string(),
+                obs.value
+                    .map_or_else(|| "\\N".to_string(), |value| value.to_string()),
+                observation_status_db(obs.status).to_string(),
+                serde_json::to_string(&obs.attributes)?,
+                obs.ingested_at.to_rfc3339(),
+                obs.source_artifact_id.to_hex(),
+            ],
+        );
+    }
+
+    let mut copy = tx
+        .as_mut()
+        .copy_in_raw(
+            "COPY staging_observations (
+                 series_key_hex, time, revision_no, time_precision, value,
+                 status, attributes, ingested_at, source_artifact_hex
+             ) FROM STDIN",
+        )
+        .await?;
+    copy.send(payload.as_bytes()).await?;
+    copy.finish().await?;
+
+    Ok(())
+}
+
+async fn upsert_observations(tx: &mut Transaction<'_, Postgres>) -> Result<u64, LoadError> {
+    let result = sqlx::query(
+        "INSERT INTO observations (
+             series_key, time, revision_no, time_precision, value, status,
+             attributes, ingested_at, source_artifact_id
+         )
+         SELECT decode(series_key_hex, 'hex'), time, revision_no, time_precision,
+                value, status, attributes, ingested_at,
+                decode(source_artifact_hex, 'hex')
+         FROM staging_observations
+         ON CONFLICT (series_key, time, revision_no) DO UPDATE
+         SET time_precision = EXCLUDED.time_precision,
+             value = EXCLUDED.value,
+             status = EXCLUDED.status,
+             attributes = EXCLUDED.attributes,
+             ingested_at = EXCLUDED.ingested_at,
+             source_artifact_id = EXCLUDED.source_artifact_id",
+    )
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(result.rows_affected())
+}
+
+async fn record_parse_error(
+    pool: &PgPool,
+    artifact_id: ArtifactId,
+    message: &str,
+    item: &LoadItem,
+) -> Result<(), LoadError> {
+    let row_context = serde_json::json!({
+        "dataflow_id": item.series.dataflow_id,
+        "series_key": item.series.series_key,
+        "observation_time": item.observation.time,
+        "revision_no": item.observation.revision_no,
+    });
+
+    sqlx::query(
+        "INSERT INTO parse_errors (artifact_id, error_kind, error_message, row_context)
+         VALUES ($1, 'loader_validation', $2, $3)",
+    )
+    .bind(artifact_id.digest().as_bytes().as_slice())
+    .bind(message)
+    .bind(row_context)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+#[derive(Debug)]
+struct SeriesStageRow {
+    descriptor: SeriesDescriptor,
+    dimensions_json: String,
+    first_observed: chrono::DateTime<chrono::Utc>,
+    last_observed: chrono::DateTime<chrono::Utc>,
+}
+
+fn descriptor_dimensions_json(descriptor: &SeriesDescriptor) -> Result<String, serde_json::Error> {
+    let dimensions: BTreeMap<&str, &str> = descriptor
+        .dimensions
+        .iter()
+        .map(|(key, value)| (key.as_str(), value.as_str()))
+        .collect();
+    serde_json::to_string(&dimensions)
+}
+
+fn push_copy_fields<const N: usize>(payload: &mut String, fields: [String; N]) {
+    for (index, field) in fields.into_iter().enumerate() {
+        if index > 0 {
+            payload.push('\t');
+        }
+        if field == "\\N" {
+            payload.push_str("\\N");
+        } else {
+            escape_copy_field(payload, &field);
+        }
+    }
+    payload.push('\n');
+}
+
+fn escape_copy_field(payload: &mut String, field: &str) {
+    for ch in field.chars() {
+        match ch {
+            '\\' => payload.push_str("\\\\"),
+            '\t' => payload.push_str("\\t"),
+            '\n' => payload.push_str("\\n"),
+            '\r' => payload.push_str("\\r"),
+            _ => payload.push(ch),
+        }
+    }
+}
+
+fn time_precision_db(value: TimePrecision) -> &'static str {
+    match value {
+        TimePrecision::Day => "day",
+        TimePrecision::Week => "week",
+        TimePrecision::Month => "month",
+        TimePrecision::Quarter => "quarter",
+        TimePrecision::Year => "year",
+    }
+}
+
+fn observation_status_db(value: ObservationStatus) -> &'static str {
+    match value {
+        ObservationStatus::Normal => "normal",
+        ObservationStatus::Estimated => "estimated",
+        ObservationStatus::Forecast => "forecast",
+        ObservationStatus::Imputed => "imputed",
+        ObservationStatus::Missing => "missing",
+        ObservationStatus::Provisional => "provisional",
+        ObservationStatus::Revised => "revised",
+        ObservationStatus::Break => "break",
+    }
+}

--- a/crates/au-kpis-loader/tests/load_batch.rs
+++ b/crates/au-kpis-loader/tests/load_batch.rs
@@ -1,0 +1,324 @@
+use std::{collections::BTreeMap, sync::LazyLock, time::Duration};
+
+use au_kpis_config::DatabaseConfig;
+use au_kpis_db::{connect, migrate};
+use au_kpis_domain::{
+    Observation, ObservationStatus, SeriesDescriptor, TimePrecision,
+    ids::{ArtifactId, CodeId, DataflowId, DimensionId, MeasureId, SeriesKey},
+};
+use au_kpis_loader::{LoadItem, LoadOptions, load_batch, load_batch_with_options};
+use au_kpis_testing::timescale::start_timescale;
+use chrono::{DateTime, Duration as ChronoDuration, TimeZone, Utc};
+use sqlx::{PgPool, Row};
+
+static TEST_LOCK: LazyLock<tokio::sync::Mutex<()>> = LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+#[derive(Debug)]
+struct TestDb {
+    pool: PgPool,
+    _timescale: au_kpis_testing::timescale::TimescaleHarness,
+}
+
+async fn test_db() -> TestDb {
+    let timescale = start_timescale("au_kpis_loader_test")
+        .await
+        .expect("start timescaledb container");
+    let cfg = DatabaseConfig {
+        url: timescale.url().to_string(),
+    };
+
+    let mut last_err = None;
+    for _ in 0..10 {
+        match connect(&cfg).await {
+            Ok(pool) => {
+                migrate(&pool).await.expect("apply migrations");
+                return TestDb {
+                    pool,
+                    _timescale: timescale,
+                };
+            }
+            Err(err) => {
+                last_err = Some(err);
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+    panic!("timescaledb did not accept connections: {last_err:?}");
+}
+
+async fn seed_reference_data(pool: &PgPool, artifact_id: ArtifactId) {
+    sqlx::query(
+        "INSERT INTO sources (id, name, homepage, description)
+         VALUES ('abs', 'Australian Bureau of Statistics', 'https://www.abs.gov.au', NULL)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert source");
+
+    sqlx::query(
+        "INSERT INTO measures (id, name, description, unit, scale)
+         VALUES ('index', 'CPI index', NULL, 'index', NULL)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert measure");
+
+    sqlx::query(
+        "INSERT INTO dataflows (
+             id, source_id, name, description, dimensions, measures,
+             frequency, license, attribution, source_url
+         )
+         VALUES (
+             'abs.cpi', 'abs', 'Consumer Price Index', NULL,
+             ARRAY['region'], ARRAY['index'], 'quarterly', 'CC-BY-4.0',
+             'Source: Australian Bureau of Statistics',
+             'https://www.abs.gov.au/statistics/economy/price-indexes-and-inflation/consumer-price-index-australia'
+         )",
+    )
+    .execute(pool)
+    .await
+    .expect("insert dataflow");
+
+    sqlx::query(
+        "INSERT INTO artifacts (
+             id, source_id, source_url, content_type, response_headers,
+             size_bytes, storage_key, fetched_at
+         )
+         VALUES ($1, 'abs', 'https://example.test/cpi.json', 'application/json',
+                 '{}'::jsonb, 128, $2, $3)",
+    )
+    .bind(artifact_id.digest().as_bytes().as_slice())
+    .bind(format!("artifacts/{artifact_id}"))
+    .bind(ts(2024, 4, 24))
+    .execute(pool)
+    .await
+    .expect("insert artifact");
+}
+
+fn descriptor(region: &str) -> SeriesDescriptor {
+    let dataflow_id = DataflowId::new("abs.cpi").unwrap();
+    let dimensions: BTreeMap<DimensionId, CodeId> = [(
+        DimensionId::new("region").unwrap(),
+        CodeId::new(region).unwrap(),
+    )]
+    .into_iter()
+    .collect();
+    let series_key = SeriesKey::derive(
+        &dataflow_id,
+        dimensions
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    );
+
+    SeriesDescriptor {
+        series_key,
+        dataflow_id,
+        measure_id: MeasureId::new("index").unwrap(),
+        dimensions,
+        unit: "index".to_string(),
+    }
+}
+
+fn observation(
+    descriptor: &SeriesDescriptor,
+    artifact_id: ArtifactId,
+    time: DateTime<Utc>,
+    revision_no: u32,
+    value: f64,
+) -> Observation {
+    Observation {
+        series_key: descriptor.series_key,
+        time,
+        time_precision: TimePrecision::Quarter,
+        value: Some(value),
+        status: ObservationStatus::Normal,
+        revision_no,
+        attributes: BTreeMap::new(),
+        ingested_at: ts(2024, 4, 24),
+        source_artifact_id: artifact_id,
+    }
+}
+
+fn item(
+    descriptor: &SeriesDescriptor,
+    artifact_id: ArtifactId,
+    time: DateTime<Utc>,
+    revision_no: u32,
+    value: f64,
+) -> LoadItem {
+    LoadItem {
+        series: descriptor.clone(),
+        observation: observation(descriptor, artifact_id, time, revision_no, value),
+    }
+}
+
+fn ts(year: i32, month: u32, day: u32) -> DateTime<Utc> {
+    Utc.with_ymd_and_hms(year, month, day, 0, 0, 0)
+        .single()
+        .unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn upserts_series_and_latest_revision() {
+    let _guard = TEST_LOCK.lock().await;
+    let db = test_db().await;
+    let pool = &db.pool;
+    let artifact_id = ArtifactId::of_content(b"loader revision fixture");
+    seed_reference_data(pool, artifact_id).await;
+    let aus = descriptor("AUS");
+    let time = ts(2024, 3, 1);
+
+    let stats = load_batch(
+        pool,
+        vec![
+            item(&aus, artifact_id, time, 0, 134.2),
+            item(&aus, artifact_id, time, 1, 135.0),
+        ],
+    )
+    .await
+    .expect("load observations");
+
+    assert_eq!(stats.observations_loaded, 2);
+    assert_eq!(stats.series_upserted, 1);
+    assert_eq!(stats.parse_errors, 0);
+
+    let row = sqlx::query(
+        "SELECT s.dataflow_id, s.first_observed, s.last_observed,
+                o.revision_no, o.value
+         FROM observations_latest o
+         JOIN series s USING (series_key)
+         WHERE s.series_key = $1",
+    )
+    .bind(aus.series_key.digest().as_bytes().as_slice())
+    .fetch_one(pool)
+    .await
+    .expect("fetch latest revision");
+
+    assert_eq!(row.get::<String, _>("dataflow_id"), "abs.cpi");
+    assert_eq!(row.get::<DateTime<Utc>, _>("first_observed"), time);
+    assert_eq!(row.get::<DateTime<Utc>, _>("last_observed"), time);
+    assert_eq!(row.get::<i32, _>("revision_no"), 1);
+    assert_eq!(row.get::<Option<f64>, _>("value"), Some(135.0));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn validation_errors_are_recorded_without_failing_valid_rows() {
+    let _guard = TEST_LOCK.lock().await;
+    let db = test_db().await;
+    let pool = &db.pool;
+    let artifact_id = ArtifactId::of_content(b"loader partial failure fixture");
+    seed_reference_data(pool, artifact_id).await;
+    let aus = descriptor("AUS");
+    let mut bad = descriptor("NSW");
+    bad.series_key = aus.series_key;
+
+    let stats = load_batch(
+        pool,
+        vec![
+            item(&aus, artifact_id, ts(2024, 3, 1), 0, 134.2),
+            item(&bad, artifact_id, ts(2024, 6, 1), 0, 136.1),
+        ],
+    )
+    .await
+    .expect("load valid rows and record parse errors");
+
+    assert_eq!(stats.observations_loaded, 1);
+    assert_eq!(stats.parse_errors, 1);
+
+    let observation_count: i64 = sqlx::query_scalar("SELECT count(*) FROM observations")
+        .fetch_one(pool)
+        .await
+        .expect("count observations");
+    let parse_error_count: i64 = sqlx::query_scalar("SELECT count(*) FROM parse_errors")
+        .fetch_one(pool)
+        .await
+        .expect("count parse errors");
+
+    assert_eq!(observation_count, 1);
+    assert_eq!(parse_error_count, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn loads_ten_thousand_observations_with_copy_batches() {
+    let _guard = TEST_LOCK.lock().await;
+    let db = test_db().await;
+    let pool = &db.pool;
+    let artifact_id = ArtifactId::of_content(b"loader performance fixture");
+    seed_reference_data(pool, artifact_id).await;
+
+    let descriptor = descriptor("AUS");
+    load_batch(
+        pool,
+        vec![item(&descriptor, artifact_id, ts(2024, 3, 1), 0, 100.0)],
+    )
+    .await
+    .expect("warm loader path");
+
+    let mut best_elapsed = Duration::MAX;
+    for attempt in 0_i64..3 {
+        let mut rows = Vec::with_capacity(10_000);
+        for index in 0_i64..10_000 {
+            rows.push(item(
+                &descriptor,
+                artifact_id,
+                ts(2024, 3, 1) + ChronoDuration::seconds(1 + attempt * 20_000 + index),
+                0,
+                index as f64,
+            ));
+        }
+
+        let started = std::time::Instant::now();
+        let stats = load_batch_with_options(
+            pool,
+            rows,
+            LoadOptions {
+                max_rows: 10_000,
+                max_bytes: 10 * 1024 * 1024,
+            },
+        )
+        .await
+        .expect("load 10k observations");
+        let elapsed = started.elapsed();
+
+        assert_eq!(stats.observations_loaded, 10_000);
+        assert_eq!(stats.parse_errors, 0);
+        best_elapsed = best_elapsed.min(elapsed);
+        if best_elapsed < Duration::from_millis(500) {
+            break;
+        }
+    }
+
+    assert!(
+        best_elapsed < Duration::from_millis(500),
+        "10k COPY load should finish under 500ms, best attempt took {best_elapsed:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn default_options_split_observations_at_one_thousand_rows() {
+    let _guard = TEST_LOCK.lock().await;
+    let db = test_db().await;
+    let pool = &db.pool;
+    let artifact_id = ArtifactId::of_content(b"loader batch split fixture");
+    seed_reference_data(pool, artifact_id).await;
+
+    let descriptor = descriptor("AUS");
+    let rows: Vec<_> = (0_i64..1_001)
+        .map(|index| {
+            item(
+                &descriptor,
+                artifact_id,
+                ts(2024, 3, 1) + ChronoDuration::seconds(index),
+                0,
+                index as f64,
+            )
+        })
+        .collect();
+
+    let stats = load_batch(pool, rows)
+        .await
+        .expect("load 1001 observations");
+
+    assert_eq!(stats.observations_loaded, 1_001);
+    assert_eq!(stats.batches, 2);
+}

--- a/crates/bins/au-kpis-api/tests/sigterm.rs
+++ b/crates/bins/au-kpis-api/tests/sigterm.rs
@@ -3,6 +3,7 @@ use std::{
     net::TcpStream,
     path::PathBuf,
     process::{Child, Command, Stdio},
+    sync::LazyLock,
     thread,
     time::{Duration, Instant},
 };
@@ -13,8 +14,12 @@ use au_kpis_testing::{
     timescale::{TimescaleHarness, start_timescale},
 };
 
+static API_PROCESS_TEST_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
+
 #[tokio::test(flavor = "multi_thread")]
 async fn api_binary_honors_sigterm() {
+    let _guard = API_PROCESS_TEST_LOCK.lock().await;
     let mut harness = ApiProcess::start("au_kpis_api_sigterm", None).await;
     let addr = harness.addr.clone();
 
@@ -29,6 +34,7 @@ async fn api_binary_honors_sigterm() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn api_binary_serves_health_route() {
+    let _guard = API_PROCESS_TEST_LOCK.lock().await;
     let _harness = ApiProcess::start("au_kpis_api_health", None).await;
     let response = http_get(&(_harness.addr), "/v1/health");
 
@@ -44,6 +50,7 @@ async fn api_binary_serves_health_route() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn api_binary_honors_configured_shutdown_grace_period() {
+    let _guard = API_PROCESS_TEST_LOCK.lock().await;
     let mut harness = ApiProcess::start("au_kpis_api_sigterm_drain", Some(1)).await;
     let mut stream = TcpStream::connect(&harness.addr).expect("open in-flight request connection");
     stream


### PR DESCRIPTION
## Context

Implements the `au-kpis-loader` crate for issue #27. The loader now accepts adapter-emitted `SeriesDescriptor + Observation` items, validates the series key relationship, upserts first-seen series metadata, stages observations through PostgreSQL `COPY FROM STDIN`, and writes revisioned observations with conflict-safe upserts.

Closes #27

## Pass requirements

- [x] COPY-based batch upsert (1000 rows / 10 MB per transaction)
- [x] Series row upserted-on-first-observation
- [x] Revision tracking correct: `observations_latest` view returns max revision
- [x] Integration test: 10k observations load in <500 ms
- [x] Partial failure per batch tolerated (bad batches → `parse_errors`)
- [x] `#[tracing::instrument]` on hot path

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p au-kpis-loader --test load_batch`
- [x] `cargo nextest run -p au-kpis-loader`
- [x] `cargo nextest run --workspace` (220 passed)
- [x] `cargo deny check`
- [ ] `cargo audit` (blocked by existing advisories: RUSTSEC-2023-0071 via sqlx-mysql/rsa and RUSTSEC-2025-0111 via testcontainers/tokio-tar)

## Spec impact

No Spec changes required. Implementation follows `Spec.md § Ingestion pipeline -> Loader (batch upsert)` and `Spec.md § Testing strategy`.
