### PR TITLE
feat(scheduler): discovery leader binary (#30)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,22 @@ dependencies = [
 [[package]]
 name = "au-kpis-scheduler"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "au-kpis-config",
+ "au-kpis-db",
+ "au-kpis-domain",
+ "au-kpis-queue",
+ "au-kpis-telemetry",
+ "au-kpis-testing",
+ "axum 0.7.9",
+ "clap",
+ "sqlx",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "au-kpis-schema"

--- a/crates/bins/au-kpis-scheduler/Cargo.toml
+++ b/crates/bins/au-kpis-scheduler/Cargo.toml
@@ -8,3 +8,37 @@ repository.workspace = true
 description = "Discovery cron binary."
 
 [dependencies]
+anyhow = "1"
+au-kpis-config = { workspace = true }
+au-kpis-db = { workspace = true }
+au-kpis-domain = { workspace = true }
+au-kpis-queue = { workspace = true }
+au-kpis-telemetry = { workspace = true }
+# Reuse the API/ingestion HTTP stack for the Prometheus metrics endpoint.
+axum = "0.7"
+# CLI parsing is binary-local; no workspace helper handles scheduler flags.
+clap = { version = "4", features = ["derive", "env"] }
+# Needed for session-scoped Postgres advisory locks.
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio",
+    "tls-rustls",
+    "postgres",
+] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "signal", "time"] }
+tokio-util = "0.7"
+tracing = "0.1"
+
+[dev-dependencies]
+assert_cmd = "2"
+au-kpis-config = { workspace = true }
+au-kpis-db = { workspace = true }
+au-kpis-testing = { workspace = true }
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio",
+    "tls-rustls",
+    "postgres",
+] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }
+
+[lints]
+workspace = true

--- a/crates/bins/au-kpis-scheduler/src/main.rs
+++ b/crates/bins/au-kpis-scheduler/src/main.rs
@@ -1,2 +1,473 @@
 //! Discovery cron binary.
-fn main() {}
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::{
+    env,
+    ffi::OsString,
+    future::IntoFuture,
+    sync::{
+        Arc,
+        atomic::{AtomicU64, Ordering},
+    },
+    time::{Duration, SystemTime},
+};
+
+use anyhow::Context;
+use au_kpis_config::load_ingestion;
+use au_kpis_db::{PgPool, connect as connect_db, migrate};
+use au_kpis_domain::SourceId;
+use au_kpis_queue::{ApalisPgQueue, CronSchedule, Job, Queue};
+use au_kpis_telemetry::{Telemetry, init as init_telemetry};
+use axum::{Router, http::header, response::IntoResponse, routing::get};
+use clap::{Parser, Subcommand};
+use sqlx::{Pool, Postgres, pool::PoolConnection};
+use tokio::{net::TcpListener, signal};
+use tokio_util::sync::CancellationToken;
+
+const SCHEDULER_LEADER_LOCK_ID: i64 = 30_000_030;
+const DEFAULT_TICK_MS: u64 = 1_000;
+const DEFAULT_ABS_INTERVAL_MS: u64 = 60 * 60 * 1_000;
+const ABS_DISCOVERY_CRON: &str = "0 * * * *";
+
+/// Command-line arguments for `au-kpis-scheduler`.
+#[derive(Debug, Parser)]
+#[command(author, version, about)]
+struct Cli {
+    /// Scheduler id recorded in logs and metrics.
+    #[arg(long, env = "AU_KPIS_SCHEDULER_ID")]
+    worker_id: Option<String>,
+
+    /// Leader-election retry and schedule scan interval.
+    #[arg(long, env = "AU_KPIS_SCHEDULER_TICK_MS", default_value_t = DEFAULT_TICK_MS)]
+    tick_ms: u64,
+
+    /// Test/ops override for the ABS discovery cadence.
+    #[arg(
+        long,
+        env = "AU_KPIS_SCHEDULER_ABS_INTERVAL_MS",
+        default_value_t = DEFAULT_ABS_INTERVAL_MS
+    )]
+    abs_interval_ms: u64,
+
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+/// Scheduler subcommands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Subcommand)]
+enum Command {
+    /// Start the long-running scheduler loop.
+    Run,
+}
+
+#[derive(Debug, Clone)]
+struct DiscoverySchedule {
+    id: &'static str,
+    cron_expression: &'static str,
+    emit_every: Duration,
+    job: Job,
+}
+
+#[derive(Debug, Default)]
+struct SchedulerMetrics {
+    leader_active: AtomicU64,
+    leader_acquired_total: AtomicU64,
+    discovery_jobs_emitted_total: AtomicU64,
+    scheduler_ticks_total: AtomicU64,
+}
+
+impl SchedulerMetrics {
+    fn render_prometheus(&self) -> String {
+        format!(
+            "# HELP au_kpis_scheduler_leader_active Whether this scheduler process currently owns the leader lock.\n\
+             # TYPE au_kpis_scheduler_leader_active gauge\n\
+             au_kpis_scheduler_leader_active {}\n\
+             # HELP au_kpis_scheduler_leader_acquired_total Leader lock acquisitions by this process.\n\
+             # TYPE au_kpis_scheduler_leader_acquired_total counter\n\
+             au_kpis_scheduler_leader_acquired_total {}\n\
+             # HELP au_kpis_scheduler_discovery_jobs_emitted_total Discovery jobs emitted by this process.\n\
+             # TYPE au_kpis_scheduler_discovery_jobs_emitted_total counter\n\
+             au_kpis_scheduler_discovery_jobs_emitted_total {}\n\
+             # HELP au_kpis_scheduler_ticks_total Scheduler loop ticks.\n\
+             # TYPE au_kpis_scheduler_ticks_total counter\n\
+             au_kpis_scheduler_ticks_total {}\n",
+            self.leader_active.load(Ordering::Relaxed),
+            self.leader_acquired_total.load(Ordering::Relaxed),
+            self.discovery_jobs_emitted_total.load(Ordering::Relaxed),
+            self.scheduler_ticks_total.load(Ordering::Relaxed)
+        )
+    }
+}
+
+#[derive(Debug)]
+struct Runtime {
+    db: PgPool,
+    metrics: Arc<SchedulerMetrics>,
+    shutdown: CancellationToken,
+    tick: Duration,
+    schedules: Vec<DiscoverySchedule>,
+    worker_id: String,
+}
+
+#[derive(Debug)]
+struct LeaderGuard {
+    conn: PoolConnection<Postgres>,
+    metrics: Arc<SchedulerMetrics>,
+}
+
+impl LeaderGuard {
+    async fn try_acquire(
+        pool: &Pool<Postgres>,
+        metrics: Arc<SchedulerMetrics>,
+    ) -> anyhow::Result<Option<Self>> {
+        let mut conn = pool.acquire().await.context("acquire leader connection")?;
+        let acquired: bool = sqlx::query_scalar("SELECT pg_try_advisory_lock($1)")
+            .bind(SCHEDULER_LEADER_LOCK_ID)
+            .fetch_one(&mut *conn)
+            .await
+            .context("try scheduler leader lock")?;
+
+        if !acquired {
+            return Ok(None);
+        }
+
+        conn.close_on_drop();
+        metrics.leader_active.store(1, Ordering::Relaxed);
+        metrics
+            .leader_acquired_total
+            .fetch_add(1, Ordering::Relaxed);
+        Ok(Some(Self { conn, metrics }))
+    }
+
+    async fn release(mut self) -> anyhow::Result<()> {
+        sqlx::query("SELECT pg_advisory_unlock($1)")
+            .bind(SCHEDULER_LEADER_LOCK_ID)
+            .execute(&mut *self.conn)
+            .await
+            .context("unlock scheduler leader lock")?;
+        self.metrics.leader_active.store(0, Ordering::Relaxed);
+        Ok(())
+    }
+}
+
+impl Drop for LeaderGuard {
+    fn drop(&mut self) {
+        self.metrics.leader_active.store(0, Ordering::Relaxed);
+    }
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    resolve_command(&cli)?;
+
+    let config = Arc::new(load_ingestion(None).context("load config")?);
+    let _telemetry = init_or_disabled(&config.telemetry)?;
+    let db = connect_db(&config.database)
+        .await
+        .context("connect postgres database")?;
+    migrate(&db).await.context("apply database migrations")?;
+
+    let shutdown = CancellationToken::new();
+    let metrics = Arc::new(SchedulerMetrics::default());
+    let runtime = Runtime {
+        db,
+        metrics,
+        shutdown: shutdown.clone(),
+        tick: Duration::from_millis(cli.tick_ms),
+        schedules: default_discovery_schedules(Duration::from_millis(cli.abs_interval_ms)),
+        worker_id: cli.worker_id.unwrap_or_else(default_worker_id),
+    };
+
+    let listener = TcpListener::bind(&config.http.bind)
+        .await
+        .with_context(|| format!("bind metrics listener on {}", config.http.bind))?;
+    write_startup_notify(&listener)
+        .await
+        .context("write startup notification")?;
+    let metrics_server = tokio::spawn(serve_metrics(
+        listener,
+        Arc::clone(&runtime.metrics),
+        shutdown.clone(),
+    ));
+    let shutdown_listener = shutdown_signal(shutdown.clone());
+    tokio::pin!(shutdown_listener);
+    let scheduler = run_scheduler(runtime);
+    tokio::pin!(scheduler);
+
+    let drain_window = Duration::from_secs(config.http.shutdown_grace_period_secs);
+    tokio::select! {
+        result = &mut scheduler => {
+            shutdown.cancel();
+            result?;
+        }
+        result = &mut shutdown_listener => {
+            result.context("listen for shutdown signal")?;
+            match tokio::time::timeout(drain_window, &mut scheduler).await {
+                Ok(result) => result?,
+                Err(_) => tracing::warn!(
+                    drain_window_secs = drain_window.as_secs(),
+                    "scheduler drain window elapsed; forcing exit"
+                ),
+            }
+        }
+    }
+
+    match tokio::time::timeout(drain_window, metrics_server).await {
+        Ok(result) => result.context("join metrics server")??,
+        Err(_) => tracing::warn!(
+            drain_window_secs = drain_window.as_secs(),
+            "metrics server drain window elapsed; forcing exit"
+        ),
+    }
+
+    Ok(())
+}
+
+async fn run_scheduler(runtime: Runtime) -> anyhow::Result<()> {
+    let queue = ApalisPgQueue::new(runtime.db.clone());
+    register_schedules(&queue, &runtime.schedules).await?;
+
+    loop {
+        runtime
+            .metrics
+            .scheduler_ticks_total
+            .fetch_add(1, Ordering::Relaxed);
+        if runtime.shutdown.is_cancelled() {
+            return Ok(());
+        }
+
+        if let Some(leader) =
+            LeaderGuard::try_acquire(&runtime.db, Arc::clone(&runtime.metrics)).await?
+        {
+            tracing::info!(scheduler = runtime.worker_id, "scheduler leader acquired");
+            run_leader_loop(&runtime, &queue).await?;
+            leader.release().await?;
+            return Ok(());
+        }
+
+        tokio::select! {
+            () = runtime.shutdown.cancelled() => return Ok(()),
+            () = tokio::time::sleep(runtime.tick) => {}
+        }
+    }
+}
+
+async fn run_leader_loop(runtime: &Runtime, queue: &ApalisPgQueue) -> anyhow::Result<()> {
+    let mut due = runtime
+        .schedules
+        .iter()
+        .map(|schedule| ScheduleState {
+            schedule,
+            next_due: tokio::time::Instant::now(),
+        })
+        .collect::<Vec<_>>();
+
+    loop {
+        runtime
+            .metrics
+            .scheduler_ticks_total
+            .fetch_add(1, Ordering::Relaxed);
+        let now = tokio::time::Instant::now();
+        for state in &mut due {
+            if now >= state.next_due {
+                queue
+                    .push(state.schedule.job.clone().with_trace_parent(trace_parent()))
+                    .await
+                    .with_context(|| format!("emit {} discovery job", state.schedule.id))?;
+                runtime
+                    .metrics
+                    .discovery_jobs_emitted_total
+                    .fetch_add(1, Ordering::Relaxed);
+                state.next_due = now + state.schedule.emit_every;
+            }
+        }
+
+        tokio::select! {
+            () = runtime.shutdown.cancelled() => return Ok(()),
+            () = tokio::time::sleep(runtime.tick) => {}
+        }
+    }
+}
+
+#[derive(Debug)]
+struct ScheduleState<'a> {
+    schedule: &'a DiscoverySchedule,
+    next_due: tokio::time::Instant,
+}
+
+async fn register_schedules(
+    queue: &ApalisPgQueue,
+    schedules: &[DiscoverySchedule],
+) -> anyhow::Result<()> {
+    for schedule in schedules {
+        queue
+            .schedule(CronSchedule::new(
+                schedule.id,
+                schedule.cron_expression,
+                schedule.job.clone(),
+            )?)
+            .await
+            .with_context(|| format!("register {} cron schedule", schedule.id))?;
+    }
+    Ok(())
+}
+
+fn default_discovery_schedules(abs_interval: Duration) -> Vec<DiscoverySchedule> {
+    vec![DiscoverySchedule {
+        id: "abs-discovery",
+        cron_expression: ABS_DISCOVERY_CRON,
+        emit_every: abs_interval,
+        job: Job::discover(SourceId::new("abs").expect("static source id is valid")),
+    }]
+}
+
+async fn serve_metrics(
+    listener: TcpListener,
+    metrics: Arc<SchedulerMetrics>,
+    shutdown: CancellationToken,
+) -> anyhow::Result<()> {
+    let app = Router::new().route(
+        "/metrics",
+        get({
+            let metrics = Arc::clone(&metrics);
+            move || async move {
+                (
+                    [(header::CONTENT_TYPE, "text/plain; version=0.0.4")],
+                    metrics.render_prometheus(),
+                )
+                    .into_response()
+            }
+        }),
+    );
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown.cancelled_owned())
+        .into_future()
+        .await
+        .context("serve scheduler metrics")
+}
+
+fn resolve_command(cli: &Cli) -> anyhow::Result<()> {
+    match cli.command {
+        Some(Command::Run) => Ok(()),
+        None => anyhow::bail!("choose `run` to start the scheduler"),
+    }
+}
+
+fn init_or_disabled(config: &au_kpis_config::TelemetryConfig) -> anyhow::Result<Telemetry> {
+    match init_telemetry(config) {
+        Ok(telemetry) => Ok(telemetry),
+        Err(err) if err.to_string() == "global telemetry subscriber already installed" => {
+            Ok(Telemetry::disabled())
+        }
+        Err(err) => Err(err).context("initialize telemetry"),
+    }
+}
+
+async fn shutdown_signal(token: CancellationToken) -> anyhow::Result<()> {
+    let ctrl_c = async { signal::ctrl_c().await.context("install Ctrl-C handler") };
+
+    #[cfg(unix)]
+    let terminate = async {
+        let mut stream = signal::unix::signal(signal::unix::SignalKind::terminate())
+            .context("install SIGTERM handler")?;
+        stream.recv().await.context("SIGTERM stream closed")
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<anyhow::Result<()>>();
+
+    tokio::select! {
+        result = ctrl_c => result?,
+        result = terminate => result?,
+    }
+
+    token.cancel();
+    Ok(())
+}
+
+async fn write_startup_notify(listener: &TcpListener) -> anyhow::Result<()> {
+    write_startup_notify_path(listener, env::var_os("AU_KPIS_STARTUP_NOTIFY_FILE")).await
+}
+
+async fn write_startup_notify_path(
+    listener: &TcpListener,
+    path: Option<OsString>,
+) -> anyhow::Result<()> {
+    let Some(path) = path else {
+        return Ok(());
+    };
+
+    let addr = listener
+        .local_addr()
+        .context("read bound listener address")?;
+    tokio::fs::write(path, addr.to_string())
+        .await
+        .context("persist bound listener address")?;
+    Ok(())
+}
+
+fn default_worker_id() -> String {
+    format!("au-kpis-scheduler-{}", std::process::id())
+}
+
+fn trace_parent() -> String {
+    static COUNTER: AtomicU64 = AtomicU64::new(1);
+    let nanos = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let parent = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("00-{nanos:032x}-{parent:016x}-01")
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::Ordering;
+    use std::time::Duration;
+
+    use au_kpis_queue::JobKind;
+
+    use super::*;
+
+    #[test]
+    fn default_schedule_registers_abs_discovery_cadence() {
+        let schedules = default_discovery_schedules(Duration::from_secs(3600));
+
+        assert_eq!(schedules.len(), 1);
+        assert_eq!(schedules[0].id, "abs-discovery");
+        assert_eq!(schedules[0].cron_expression, "0 * * * *");
+        assert_eq!(schedules[0].emit_every, Duration::from_secs(3600));
+        assert!(matches!(
+            schedules[0].job.kind(),
+            JobKind::Discover { source_id } if source_id.as_str() == "abs"
+        ));
+    }
+
+    #[test]
+    fn metrics_render_prometheus_leader_and_emission_state() {
+        let metrics = SchedulerMetrics::default();
+        metrics.leader_active.store(1, Ordering::Relaxed);
+        metrics
+            .discovery_jobs_emitted_total
+            .store(3, Ordering::Relaxed);
+
+        let body = metrics.render_prometheus();
+
+        assert!(body.contains("# TYPE au_kpis_scheduler_leader_active gauge"));
+        assert!(body.contains("au_kpis_scheduler_leader_active 1"));
+        assert!(body.contains("au_kpis_scheduler_discovery_jobs_emitted_total 3"));
+    }
+
+    #[test]
+    fn trace_parent_uses_w3c_shape() {
+        let trace = trace_parent();
+
+        assert_eq!(trace.len(), 55);
+        assert!(trace.starts_with("00-"));
+        assert!(trace.ends_with("-01"));
+    }
+}

--- a/crates/bins/au-kpis-scheduler/tests/scheduler.rs
+++ b/crates/bins/au-kpis-scheduler/tests/scheduler.rs
@@ -1,0 +1,350 @@
+use std::{
+    io::{Read, Write},
+    net::TcpStream,
+    path::PathBuf,
+    process::{Child, Command, Stdio},
+    sync::LazyLock,
+    thread,
+    time::{Duration, Instant},
+};
+
+use assert_cmd::cargo::cargo_bin;
+use au_kpis_testing::timescale::{TimescaleHarness, start_timescale};
+
+static SCHEDULER_PROCESS_TEST_LOCK: LazyLock<tokio::sync::Mutex<()>> =
+    LazyLock::new(|| tokio::sync::Mutex::new(()));
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn two_schedulers_singleton_and_failover_emits_discovery_jobs() {
+    let _guard = SCHEDULER_PROCESS_TEST_LOCK.lock().await;
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let db = SchedulerDb::start("au_kpis_scheduler_failover").await;
+    let mut first = SchedulerProcess::start(db.url(), "scheduler-a").await;
+    let mut second = SchedulerProcess::start(db.url(), "scheduler-b").await;
+
+    let leader = wait_for_single_leader(&mut first, &mut second);
+    wait_for_discovery_job_count(db.pool(), 1).await;
+    let before_failover = discovery_job_count(db.pool()).await;
+
+    match leader {
+        Leader::First => {
+            first.send_sigterm();
+            first.wait_for_exit(Duration::from_secs(5));
+            wait_until_leader(&mut second);
+        }
+        Leader::Second => {
+            second.send_sigterm();
+            second.wait_for_exit(Duration::from_secs(5));
+            wait_until_leader(&mut first);
+        }
+    }
+
+    wait_for_discovery_job_count(db.pool(), before_failover + 1).await;
+}
+
+struct SchedulerDb {
+    pool: sqlx::PgPool,
+    url: String,
+    _timescale: TimescaleHarness,
+}
+
+impl SchedulerDb {
+    async fn start(database: &str) -> Self {
+        let timescale = start_timescale(database)
+            .await
+            .expect("start timescale test container");
+        let pool = connect_with_retry(timescale.url()).await;
+        Self {
+            pool,
+            url: timescale.url().to_string(),
+            _timescale: timescale,
+        }
+    }
+
+    fn pool(&self) -> &sqlx::PgPool {
+        &self.pool
+    }
+
+    fn url(&self) -> &str {
+        &self.url
+    }
+}
+
+struct SchedulerProcess {
+    addr: String,
+    startup_file: PathBuf,
+    child: Child,
+}
+
+impl SchedulerProcess {
+    async fn start(database_url: &str, worker_id: &str) -> Self {
+        let startup_file = unique_startup_file(worker_id);
+        let mut command = Command::new(cargo_bin("au-kpis-scheduler"));
+        command
+            .args([
+                "--worker-id",
+                worker_id,
+                "--tick-ms",
+                "50",
+                "--abs-interval-ms",
+                "200",
+                "run",
+            ])
+            .env("AU_KPIS_HTTP__BIND", "127.0.0.1:0")
+            .env("AU_KPIS_DATABASE__URL", database_url)
+            .env("AU_KPIS_STARTUP_NOTIFY_FILE", &startup_file)
+            .env(
+                "LLVM_PROFILE_FILE",
+                ignored_child_coverage_profile(worker_id),
+            )
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped());
+
+        let mut child = command.spawn().expect("spawn au-kpis-scheduler");
+        let addr = wait_for_startup_file(&startup_file, &mut child);
+        Self {
+            addr,
+            startup_file,
+            child,
+        }
+    }
+
+    fn is_leader(&mut self) -> bool {
+        self.assert_running();
+        http_get(&self.addr, "/metrics").contains("au_kpis_scheduler_leader_active 1")
+    }
+
+    fn send_sigterm(&self) {
+        let kill = Command::new("kill")
+            .args(["-TERM", &self.child.id().to_string()])
+            .status()
+            .expect("send SIGTERM");
+        assert!(kill.success(), "SIGTERM failed: {kill:?}");
+    }
+
+    fn assert_running(&mut self) {
+        if let Some(status) = self.child.try_wait().expect("poll child") {
+            panic!("au-kpis-scheduler exited unexpectedly: {status}");
+        }
+    }
+
+    fn wait_for_exit(&mut self, within: Duration) {
+        let deadline = Instant::now() + within;
+        loop {
+            if let Some(status) = self.child.try_wait().expect("poll child") {
+                assert!(
+                    status.success(),
+                    "au-kpis-scheduler exited unsuccessfully: {status}"
+                );
+                return;
+            }
+            assert!(
+                Instant::now() < deadline,
+                "au-kpis-scheduler did not exit within {}s of SIGTERM",
+                within.as_secs()
+            );
+            thread::sleep(Duration::from_millis(50));
+        }
+    }
+}
+
+impl Drop for SchedulerProcess {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.startup_file);
+        if self.child.try_wait().ok().flatten().is_none() {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Leader {
+    First,
+    Second,
+}
+
+fn wait_for_single_leader(first: &mut SchedulerProcess, second: &mut SchedulerProcess) -> Leader {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let first_leads = first.is_leader();
+        let second_leads = second.is_leader();
+        match (first_leads, second_leads) {
+            (true, false) => return Leader::First,
+            (false, true) => return Leader::Second,
+            (true, true) => panic!("both schedulers reported leader_active=1"),
+            (false, false) => {}
+        }
+        assert!(
+            Instant::now() < deadline,
+            "no singleton scheduler leader became active"
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+fn wait_until_leader(process: &mut SchedulerProcess) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if process.is_leader() {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "standby scheduler did not acquire leadership"
+        );
+        thread::sleep(Duration::from_millis(100));
+    }
+}
+
+async fn connect_with_retry(database_url: &str) -> sqlx::PgPool {
+    let cfg = au_kpis_config::DatabaseConfig {
+        url: database_url.to_string(),
+    };
+    let mut last_err = None;
+    for _ in 0..10 {
+        match au_kpis_db::connect(&cfg).await {
+            Ok(pool) => {
+                au_kpis_db::migrate(&pool).await.expect("apply migrations");
+                return pool;
+            }
+            Err(err) => {
+                last_err = Some(err);
+                tokio::time::sleep(Duration::from_millis(500)).await;
+            }
+        }
+    }
+    panic!("timescaledb did not accept connections: {last_err:?}");
+}
+
+async fn wait_for_discovery_job_count(pool: &sqlx::PgPool, minimum: i64) {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        let count = discovery_job_count(pool).await;
+        if count >= minimum {
+            return;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "scheduler emitted {count} discovery jobs, expected at least {minimum}"
+        );
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+}
+
+async fn discovery_job_count(pool: &sqlx::PgPool) -> i64 {
+    sqlx::query_scalar("SELECT count(*) FROM queue_jobs WHERE stage = 'discover'")
+        .fetch_one(pool)
+        .await
+        .expect("count discovery jobs")
+}
+
+fn docker_available() -> bool {
+    std::env::var_os("DOCKER_HOST").is_some()
+        || std::path::Path::new("/var/run/docker.sock").exists()
+}
+
+fn unique_startup_file(worker_id: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "au-kpis-scheduler-startup-{worker_id}-{}-{}.txt",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system time")
+            .as_nanos()
+    ));
+    path
+}
+
+fn ignored_child_coverage_profile(worker_id: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "au-kpis-scheduler-child-coverage-{worker_id}-{}-%p-%m.profraw",
+        std::process::id()
+    ));
+    path
+}
+
+fn wait_for_startup_file(path: &PathBuf, child: &mut Child) -> String {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(10) {
+        if let Ok(addr) = std::fs::read_to_string(path) {
+            let addr = addr.trim().to_string();
+            if !addr.is_empty() {
+                let _ = std::fs::remove_file(path);
+                return addr;
+            }
+        }
+        if child
+            .try_wait()
+            .expect("poll child during startup")
+            .is_some()
+        {
+            break;
+        }
+        thread::sleep(Duration::from_millis(100));
+    }
+
+    panic!("au-kpis-scheduler never reported its bound address");
+}
+
+fn http_get(addr: &str, path: &str) -> String {
+    let mut stream = TcpStream::connect(addr).expect("connect to scheduler metrics server");
+    stream
+        .set_read_timeout(Some(Duration::from_secs(5)))
+        .expect("set metrics read timeout");
+    write!(
+        stream,
+        "GET {path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n"
+    )
+    .expect("write HTTP request");
+
+    read_http_response(&mut stream)
+}
+
+fn read_http_response(stream: &mut TcpStream) -> String {
+    let mut bytes = Vec::new();
+    let mut content_length = None;
+    loop {
+        let mut chunk = [0_u8; 1024];
+        let read = stream.read(&mut chunk).expect("read HTTP response");
+        assert!(read > 0, "metrics server closed before response completed");
+        bytes.extend_from_slice(&chunk[..read]);
+
+        if content_length.is_none() {
+            if let Some((headers, _)) = split_headers_body(&bytes) {
+                content_length = parse_content_length(headers);
+            }
+        }
+        if let Some(len) = content_length {
+            if let Some((_, body)) = split_headers_body(&bytes) {
+                if body.len() >= len {
+                    return String::from_utf8(bytes).expect("metrics response is UTF-8");
+                }
+            }
+        }
+    }
+}
+
+fn split_headers_body(bytes: &[u8]) -> Option<(&[u8], &[u8])> {
+    bytes
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .map(|index| bytes.split_at(index + 4))
+}
+
+fn parse_content_length(headers: &[u8]) -> Option<usize> {
+    std::str::from_utf8(headers)
+        .expect("HTTP headers are UTF-8")
+        .lines()
+        .find_map(|line| {
+            let (name, value) = line.split_once(':')?;
+            name.eq_ignore_ascii_case("content-length")
+                .then(|| value.trim().parse().expect("valid content-length"))
+        })
+}


### PR DESCRIPTION
## Summary

- Implements `au-kpis-scheduler run` with shared config, telemetry, migrations, `/metrics`, and graceful shutdown.
- Adds Postgres advisory-lock leader election so only one scheduler emits discovery work.
- Registers the ABS discovery cron schedule and emits traced discovery jobs on the active leader.
- Adds unit coverage plus a Docker-backed two-scheduler failover integration test.

## Linked issue

Closes #30

## Pass requirements

- [x] Singleton via PG advisory lock leader election
- [x] Emits discovery jobs per adapter cron schedule
- [x] Integration test: two schedulers, one leads, failover works on leader loss
- [x] Metrics exposed at `/metrics`

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo test -p au-kpis-scheduler --bin au-kpis-scheduler`
- [x] `cargo test -p au-kpis-scheduler --test scheduler -- --nocapture`
- [x] `cargo test -p au-kpis-scheduler -- --nocapture`
- [x] `cargo clippy -p au-kpis-scheduler --all-targets -- -D warnings`

Note: this local machine has no Docker socket, so the testcontainers failover test skips locally and will run in GitHub CI.

## Spec impact

No Spec changes required.
