### PR TITLE
feat(api): observations endpoint (#31)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -318,12 +318,19 @@ name = "au-kpis-api-http"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "au-kpis-cache",
  "au-kpis-config",
+ "au-kpis-db",
+ "au-kpis-domain",
  "au-kpis-error",
  "au-kpis-telemetry",
+ "au-kpis-testing",
  "axum 0.7.9",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
  "http",
  "jsonschema",
  "serde",
@@ -335,6 +342,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
+ "url",
  "utoipa",
 ]
 

--- a/crates/au-kpis-api-http/Cargo.toml
+++ b/crates/au-kpis-api-http/Cargo.toml
@@ -8,26 +8,34 @@ repository.workspace = true
 description = "axum routes + handlers (library)."
 
 [dependencies]
+async-stream = "0.3" # stream JSON/CSV chunks from sqlx without buffering result pages
 au-kpis-cache = { workspace = true }
 au-kpis-config = { workspace = true }
+au-kpis-domain = { workspace = true }
 au-kpis-telemetry = { workspace = true }
 axum = { version = "0.7", features = ["macros"] }
+base64 = "0.22" # opaque cursor encoding; std has no base64 codec
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+futures = "0.3" # TryStreamExt over sqlx row streams
 http = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { version = "0.8", default-features = false, features = ["postgres", "runtime-tokio", "tls-rustls"] }
+sqlx = { version = "0.8", default-features = false, features = ["postgres", "runtime-tokio", "tls-rustls", "chrono", "json"] }
 thiserror = "2"
 tokio = { version = "1", features = ["signal"] }
 tokio-util = "0.7"
 tower = { version = "0.5", features = ["timeout"] }
 tower-http = { version = "0.6", features = ["compression-full", "cors", "request-id", "timeout", "trace"] }
 tracing = "0.1"
-utoipa = { version = "5", features = ["axum_extras"] }
+url = "2" # robust query-string decoding for dimensions[region]=AUS filters
+utoipa = { version = "5", features = ["axum_extras", "chrono"] }
 
 [dev-dependencies]
 anyhow = "1"
 async-trait = "0.1"
+au-kpis-db = { workspace = true }
 au-kpis-error = { workspace = true }
+au-kpis-testing = { workspace = true }
 jsonschema = "0.29"
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.5", features = ["util"] }

--- a/crates/au-kpis-api-http/src/docs.rs
+++ b/crates/au-kpis-api-http/src/docs.rs
@@ -4,6 +4,10 @@ use utoipa::OpenApi;
 
 use crate::{
     error::ProblemDetails,
+    observations::{
+        __path_list_observations, ObservationsMetadata, ObservationsResponse, ObservationsRow,
+        PaginationMetadata,
+    },
     routes::{__path_health, __path_openapi, HealthResponse},
 };
 
@@ -15,7 +19,15 @@ use crate::{
         version = "0.1.0",
         description = "Unified API for Australian public economic data."
     ),
-    paths(health, openapi),
-    components(schemas(HealthResponse, ProblemDetails))
+    paths(health, openapi, list_observations),
+    components(schemas(
+        HealthResponse,
+        ObservationsMetadata,
+        ObservationsResponse,
+        ObservationsRow,
+        PaginationMetadata,
+        ProblemDetails
+    )),
+    tags((name = "observations", description = "Time-series observations"))
 )]
 pub struct ApiDoc;

--- a/crates/au-kpis-api-http/src/lib.rs
+++ b/crates/au-kpis-api-http/src/lib.rs
@@ -24,11 +24,16 @@ use tower_http::{
 
 pub mod docs;
 pub mod error;
+pub mod observations;
 pub mod routes;
 pub mod state;
 
 pub use docs::ApiDoc;
 pub use error::{ApiError, ProblemDetails};
+pub use observations::{
+    ObservationsMetadata, ObservationsResponse, ObservationsRow, PaginationMetadata,
+    list_observations,
+};
 pub use routes::{HealthResponse, health, openapi};
 pub use state::AppState;
 
@@ -64,6 +69,7 @@ pub fn router(state: AppState) -> Result<Router, RouterBuildError> {
     router_with(
         Router::<AppState>::new()
             .route("/v1/health", get(health))
+            .route("/v1/observations", get(observations::list_observations))
             .route("/v1/openapi.json", get(openapi)),
         state,
     )

--- a/crates/au-kpis-api-http/src/observations.rs
+++ b/crates/au-kpis-api-http/src/observations.rs
@@ -1,0 +1,813 @@
+//! `/v1/observations` query handling and streaming renderers.
+
+use std::{collections::BTreeMap, fmt};
+
+use au_kpis_domain::{
+    ObservationStatus, TimePrecision,
+    ids::{ArtifactId, DataflowId, SeriesKey, Sha256Digest},
+};
+use axum::{
+    body::{Body, Bytes},
+    extract::State,
+    http::{HeaderMap, HeaderValue, StatusCode, Uri, header},
+    response::{IntoResponse, Response},
+};
+use base64::{Engine as _, prelude::BASE64_URL_SAFE_NO_PAD};
+use chrono::{DateTime, NaiveDate, Utc};
+use futures::{Stream, TryStreamExt};
+use serde::{Deserialize, Serialize};
+use sqlx::{PgPool, Postgres, QueryBuilder, Row, postgres::PgRow};
+use utoipa::ToSchema;
+
+use crate::{AppState, error::ApiError};
+
+const DEFAULT_LIMIT: usize = 1_000;
+const MAX_LIMIT: usize = 10_000;
+const CACHE_CONTROL_VALUE: &str = "public, max-age=60, stale-while-revalidate=300";
+
+/// Attribution and licensing metadata that applies to an observations page.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct ObservationsMetadata {
+    /// Requested dataflow identifier.
+    pub dataflow: DataflowId,
+    /// Required source acknowledgement to display with derived charts.
+    pub attribution: String,
+    /// Data license identifier, e.g. `CC-BY-4.0`.
+    pub license: String,
+    /// Canonical citation URL for the upstream source.
+    pub source_url: String,
+}
+
+/// Cursor metadata for the current observations page.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct PaginationMetadata {
+    /// Opaque cursor for the next page, or null when the page is complete.
+    pub next_cursor: Option<String>,
+}
+
+/// One observation row returned by `/v1/observations`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct ObservationsRow {
+    /// Deterministic series key.
+    pub series_key: SeriesKey,
+    /// Observation timestamp.
+    pub time: DateTime<Utc>,
+    /// Temporal precision of the timestamp.
+    pub time_precision: TimePrecision,
+    /// Numeric value; null when status is `missing`.
+    pub value: Option<f64>,
+    /// Observation status.
+    pub status: ObservationStatus,
+    /// Revision number, where zero is the original publication.
+    pub revision_no: u32,
+    /// Free-form source attributes for this observation.
+    pub attributes: BTreeMap<String, String>,
+    /// Ingestion timestamp for this revision.
+    pub ingested_at: DateTime<Utc>,
+    /// Content-addressed source artifact identifier.
+    pub source_artifact_id: ArtifactId,
+    /// Series dimension values keyed by dimension id.
+    pub dimensions: BTreeMap<String, String>,
+    /// Measure identifier for the series.
+    pub measure_id: String,
+    /// Unit for the series values.
+    pub unit: String,
+}
+
+/// JSON response envelope for `/v1/observations`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct ObservationsResponse {
+    /// Dataflow attribution and license metadata.
+    pub metadata: ObservationsMetadata,
+    /// Observation rows in ascending `(time, series_key)` order.
+    pub observations: Vec<ObservationsRow>,
+    /// Cursor for continuing the query.
+    pub pagination: PaginationMetadata,
+}
+
+/// `GET /v1/observations`.
+#[utoipa::path(
+    get,
+    operation_id = "listObservations",
+    path = "/v1/observations",
+    params(
+        ("dataflow" = String, Query, description = "Required dataflow id, e.g. abs.cpi."),
+        ("dimensions[]" = Option<Vec<String>>, Query, description = "Dimension filters as repeated key=value values. The handler also accepts dimensions[region]=AUS."),
+        ("since" = Option<String>, Query, description = "Inclusive lower time bound as YYYY-MM-DD or RFC3339."),
+        ("until" = Option<String>, Query, description = "Inclusive upper time bound as YYYY-MM-DD or RFC3339."),
+        ("frequency" = Option<String>, Query, description = "Optional dataflow frequency filter."),
+        ("format" = Option<String>, Query, description = "Response format: json or csv."),
+        ("cursor" = Option<String>, Query, description = "Opaque cursor from the previous page."),
+        ("limit" = Option<u32>, Query, description = "Page size, maximum 10000.")
+    ),
+    responses(
+        (
+            status = 200,
+            description = "Observation page.",
+            content(
+                (ObservationsResponse = "application/json"),
+                (String = "text/csv")
+            ),
+            headers(
+                ("ETag" = String, description = "Weak entity tag for this page."),
+                ("Cache-Control" = String, description = "Public CDN cache policy.")
+            )
+        ),
+        (
+            status = 304,
+            description = "The client's cached page is still fresh.",
+            headers(
+                ("ETag" = String, description = "Weak entity tag for this page."),
+                ("Cache-Control" = String, description = "Public CDN cache policy.")
+            )
+        ),
+        (
+            status = 400,
+            description = "Invalid query string.",
+            content_type = "application/problem+json",
+            body = crate::error::ProblemDetails
+        ),
+        (
+            status = 404,
+            description = "Dataflow not found.",
+            content_type = "application/problem+json",
+            body = crate::error::ProblemDetails
+        ),
+        (
+            status = 408,
+            description = "Request timed out.",
+            content_type = "application/problem+json",
+            body = crate::error::ProblemDetails
+        ),
+        (
+            status = 500,
+            description = "Internal server error.",
+            content_type = "application/problem+json",
+            body = crate::error::ProblemDetails
+        )
+    ),
+    tag = "observations"
+)]
+pub async fn list_observations(
+    State(state): State<AppState>,
+    headers: HeaderMap,
+    uri: Uri,
+) -> Result<Response, ApiError> {
+    let query = parse_observations_query(uri.query())?;
+    let metadata = load_observations_metadata(&state.db, &query.dataflow).await?;
+    let etag = compute_etag(&state.db, &query).await?;
+    let cache_control = HeaderValue::from_static(CACHE_CONTROL_VALUE);
+    let etag_header = HeaderValue::from_str(&etag).map_err(|err| {
+        tracing::error!(error = %err, "generated invalid ETag header");
+        ApiError::Internal
+    })?;
+
+    if if_none_match_fresh(&headers, &etag) {
+        let mut response = StatusCode::NOT_MODIFIED.into_response();
+        response
+            .headers_mut()
+            .insert(header::CACHE_CONTROL, cache_control);
+        response.headers_mut().insert(header::ETAG, etag_header);
+        return Ok(response);
+    }
+
+    let content_type = match query.format {
+        ResponseFormat::Json => HeaderValue::from_static("application/json"),
+        ResponseFormat::Csv => HeaderValue::from_static("text/csv; charset=utf-8"),
+    };
+    let stream = match query.format {
+        ResponseFormat::Json => {
+            Body::from_stream(json_observations_stream(state.db.clone(), query, metadata))
+        }
+        ResponseFormat::Csv => {
+            Body::from_stream(csv_observations_stream(state.db.clone(), query, metadata))
+        }
+    };
+
+    let mut response = Response::new(stream);
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, cache_control);
+    response.headers_mut().insert(header::ETAG, etag_header);
+    response
+        .headers_mut()
+        .insert(header::CONTENT_TYPE, content_type);
+    Ok(response)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedObservationsQuery {
+    dataflow: DataflowId,
+    dimensions: BTreeMap<String, String>,
+    since: Option<DateTime<Utc>>,
+    until: Option<DateTime<Utc>>,
+    frequency: Option<String>,
+    format: ResponseFormat,
+    cursor: Option<ObservationCursor>,
+    limit: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ResponseFormat {
+    Json,
+    Csv,
+}
+
+impl fmt::Display for ResponseFormat {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ResponseFormat::Json => f.write_str("json"),
+            ResponseFormat::Csv => f.write_str("csv"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+struct ObservationCursor {
+    time: DateTime<Utc>,
+    series_key: SeriesKey,
+}
+
+#[derive(Debug)]
+struct CacheFingerprint {
+    row_count: i64,
+    max_ingested_at: Option<DateTime<Utc>>,
+    max_time: Option<DateTime<Utc>>,
+    max_revision_no: Option<i32>,
+}
+
+fn parse_observations_query(raw: Option<&str>) -> Result<ParsedObservationsQuery, ApiError> {
+    let mut dataflow = None;
+    let mut dimensions = BTreeMap::new();
+    let mut since = None;
+    let mut until = None;
+    let mut frequency = None;
+    let mut format = ResponseFormat::Json;
+    let mut cursor = None;
+    let mut limit = DEFAULT_LIMIT;
+
+    for (key, value) in url::form_urlencoded::parse(raw.unwrap_or_default().as_bytes()) {
+        let key = key.into_owned();
+        let value = value.into_owned();
+        match key.as_str() {
+            "dataflow" => {
+                dataflow = Some(
+                    DataflowId::new(value)
+                        .map_err(|err| ApiError::Validation(format!("invalid dataflow: {err}")))?,
+                );
+            }
+            "since" => since = Some(parse_time_bound("since", &value)?),
+            "until" => until = Some(parse_time_bound("until", &value)?),
+            "frequency" => frequency = Some(parse_frequency(&value)?),
+            "format" => format = parse_format(&value)?,
+            "cursor" => cursor = Some(decode_cursor(&value)?),
+            "limit" => limit = parse_limit(&value)?,
+            "dimensions" | "dimensions[]" => {
+                let (dimension, code) = value
+                    .split_once('=')
+                    .or_else(|| value.split_once(':'))
+                    .ok_or_else(|| {
+                        ApiError::Validation("dimensions[] values must use dimension=value".into())
+                    })?;
+                insert_dimension_filter(&mut dimensions, dimension, code)?;
+            }
+            _ if key.starts_with("dimensions[") && key.ends_with(']') => {
+                let dimension = &key["dimensions[".len()..key.len() - 1];
+                insert_dimension_filter(&mut dimensions, dimension, &value)?;
+            }
+            _ => {}
+        }
+    }
+
+    let dataflow = dataflow
+        .ok_or_else(|| ApiError::Validation("dataflow query parameter is required".into()))?;
+    if let (Some(since), Some(until)) = (since, until) {
+        if since > until {
+            return Err(ApiError::Validation(
+                "since must be less than or equal to until".into(),
+            ));
+        }
+    }
+
+    Ok(ParsedObservationsQuery {
+        dataflow,
+        dimensions,
+        since,
+        until,
+        frequency,
+        format,
+        cursor,
+        limit,
+    })
+}
+
+fn insert_dimension_filter(
+    dimensions: &mut BTreeMap<String, String>,
+    dimension: &str,
+    code: &str,
+) -> Result<(), ApiError> {
+    if dimension.is_empty() || code.is_empty() {
+        return Err(ApiError::Validation(
+            "dimension filters require non-empty dimension and code".into(),
+        ));
+    }
+    dimensions.insert(dimension.to_string(), code.to_string());
+    Ok(())
+}
+
+fn parse_time_bound(name: &str, value: &str) -> Result<DateTime<Utc>, ApiError> {
+    if let Ok(date) = NaiveDate::parse_from_str(value, "%Y-%m-%d") {
+        return date
+            .and_hms_opt(0, 0, 0)
+            .map(|time| DateTime::from_naive_utc_and_offset(time, Utc))
+            .ok_or_else(|| ApiError::Validation(format!("{name} is outside supported range")));
+    }
+
+    DateTime::parse_from_rfc3339(value)
+        .map(|time| time.with_timezone(&Utc))
+        .map_err(|err| ApiError::Validation(format!("invalid {name}: {err}")))
+}
+
+fn parse_frequency(value: &str) -> Result<String, ApiError> {
+    match value {
+        "daily" | "weekly" | "monthly" | "quarterly" | "annual" | "irregular" => {
+            Ok(value.to_string())
+        }
+        _ => Err(ApiError::Validation(format!(
+            "unsupported frequency `{value}`"
+        ))),
+    }
+}
+
+fn parse_format(value: &str) -> Result<ResponseFormat, ApiError> {
+    match value {
+        "json" => Ok(ResponseFormat::Json),
+        "csv" => Ok(ResponseFormat::Csv),
+        "parquet" => Err(ApiError::Validation(
+            "format=parquet is planned for phase 3".into(),
+        )),
+        _ => Err(ApiError::Validation(format!(
+            "unsupported format `{value}`"
+        ))),
+    }
+}
+
+fn parse_limit(value: &str) -> Result<usize, ApiError> {
+    let limit = value
+        .parse::<usize>()
+        .map_err(|err| ApiError::Validation(format!("invalid limit: {err}")))?;
+    if limit == 0 || limit > MAX_LIMIT {
+        return Err(ApiError::Validation(format!(
+            "limit must be between 1 and {MAX_LIMIT}"
+        )));
+    }
+    Ok(limit)
+}
+
+fn encode_cursor(cursor: &ObservationCursor) -> Result<String, ApiError> {
+    let json = serde_json::to_vec(cursor).map_err(|err| {
+        tracing::error!(error = %err, "cursor serialization failed");
+        ApiError::Internal
+    })?;
+    Ok(BASE64_URL_SAFE_NO_PAD.encode(json))
+}
+
+fn decode_cursor(cursor: &str) -> Result<ObservationCursor, ApiError> {
+    let bytes = BASE64_URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|err| ApiError::Validation(format!("invalid cursor encoding: {err}")))?;
+    serde_json::from_slice(&bytes)
+        .map_err(|err| ApiError::Validation(format!("invalid cursor payload: {err}")))
+}
+
+async fn load_observations_metadata(
+    pool: &PgPool,
+    dataflow: &DataflowId,
+) -> Result<ObservationsMetadata, ApiError> {
+    let row = sqlx::query(
+        "SELECT license, attribution, source_url
+         FROM dataflows
+         WHERE id = $1",
+    )
+    .bind(dataflow.as_str())
+    .fetch_optional(pool)
+    .await?;
+
+    let row = row.ok_or_else(|| ApiError::NotFound(format!("dataflow `{dataflow}`")))?;
+    Ok(ObservationsMetadata {
+        dataflow: dataflow.clone(),
+        license: row.try_get("license")?,
+        attribution: row.try_get("attribution")?,
+        source_url: row.try_get("source_url")?,
+    })
+}
+
+async fn compute_etag(pool: &PgPool, query: &ParsedObservationsQuery) -> Result<String, ApiError> {
+    let mut builder = QueryBuilder::<Postgres>::new(
+        "SELECT count(*)::bigint AS row_count,
+                max(o.ingested_at) AS max_ingested_at,
+                max(o.time) AS max_time,
+                max(o.revision_no) AS max_revision_no
+         FROM observations_latest o
+         JOIN series s ON s.series_key = o.series_key
+         JOIN dataflows d ON d.id = s.dataflow_id",
+    );
+    push_observation_filters(&mut builder, query);
+    let row = builder.build().fetch_one(pool).await?;
+    let fingerprint = CacheFingerprint {
+        row_count: row.try_get("row_count")?,
+        max_ingested_at: row.try_get("max_ingested_at")?,
+        max_time: row.try_get("max_time")?,
+        max_revision_no: row.try_get("max_revision_no")?,
+    };
+    Ok(format!(
+        "W/\"{}\"",
+        Sha256Digest::hash(etag_seed(query, &fingerprint).as_bytes())
+    ))
+}
+
+fn etag_seed(query: &ParsedObservationsQuery, fingerprint: &CacheFingerprint) -> String {
+    format!(
+        "dataflow={};dimensions={:?};since={:?};until={:?};frequency={:?};format={};cursor={:?};limit={};row_count={};max_ingested_at={:?};max_time={:?};max_revision_no={:?}",
+        query.dataflow,
+        query.dimensions,
+        query.since,
+        query.until,
+        query.frequency,
+        query.format,
+        query.cursor,
+        query.limit,
+        fingerprint.row_count,
+        fingerprint.max_ingested_at,
+        fingerprint.max_time,
+        fingerprint.max_revision_no
+    )
+}
+
+fn if_none_match_fresh(headers: &HeaderMap, etag: &str) -> bool {
+    headers
+        .get(header::IF_NONE_MATCH)
+        .and_then(|value| value.to_str().ok())
+        .is_some_and(|value| {
+            value
+                .split(',')
+                .map(str::trim)
+                .any(|candidate| candidate == "*" || candidate == etag)
+        })
+}
+
+fn json_observations_stream(
+    pool: PgPool,
+    query: ParsedObservationsQuery,
+    metadata: ObservationsMetadata,
+) -> impl Stream<Item = Result<Bytes, ApiError>> + Send + 'static {
+    async_stream::try_stream! {
+        let metadata = serialize_json_chunk(&metadata)?;
+        yield Bytes::from(format!("{{\"metadata\":{metadata},\"observations\":["));
+
+        let limit = query.limit;
+        let stream = fetch_observation_rows(pool, query);
+        futures::pin_mut!(stream);
+        let mut emitted = 0_usize;
+        let mut first = true;
+        let mut last_cursor = None;
+        let mut next_cursor = None;
+        while let Some(row) = stream.try_next().await? {
+            if emitted == limit {
+                next_cursor = last_cursor;
+                break;
+            }
+
+            if !first {
+                yield Bytes::from_static(b",");
+            }
+            first = false;
+            last_cursor = Some(encode_cursor(&ObservationCursor {
+                time: row.time,
+                series_key: row.series_key,
+            })?);
+            emitted += 1;
+            yield Bytes::from(serialize_json_chunk(&row)?);
+        }
+
+        let pagination = serialize_json_chunk(&PaginationMetadata { next_cursor })?;
+        yield Bytes::from(format!("],\"pagination\":{pagination}}}"));
+    }
+}
+
+fn csv_observations_stream(
+    pool: PgPool,
+    query: ParsedObservationsQuery,
+    metadata: ObservationsMetadata,
+) -> impl Stream<Item = Result<Bytes, ApiError>> + Send + 'static {
+    async_stream::try_stream! {
+        yield Bytes::from(format!(
+            "# dataflow={},license={},attribution={},source_url={}\n",
+            csv_escape(metadata.dataflow.as_str()),
+            csv_escape(&metadata.license),
+            csv_escape(&metadata.attribution),
+            csv_escape(&metadata.source_url),
+        ));
+        yield Bytes::from_static(
+            b"series_key,time,time_precision,value,status,revision_no,dimensions,attributes,ingested_at,source_artifact_id,measure_id,unit\n",
+        );
+
+        let limit = query.limit;
+        let stream = fetch_observation_rows(pool, query);
+        futures::pin_mut!(stream);
+        let mut emitted = 0_usize;
+        let mut last_cursor = None;
+        let mut next_cursor = None;
+        while let Some(row) = stream.try_next().await? {
+            if emitted == limit {
+                next_cursor = last_cursor;
+                break;
+            }
+            last_cursor = Some(encode_cursor(&ObservationCursor {
+                time: row.time,
+                series_key: row.series_key,
+            })?);
+            emitted += 1;
+            yield Bytes::from(row_to_csv(&row)?);
+        }
+        if let Some(next_cursor) = next_cursor {
+            yield Bytes::from(format!("# next_cursor={}\n", csv_escape(&next_cursor)));
+        }
+    }
+}
+
+fn fetch_observation_rows(
+    pool: PgPool,
+    query: ParsedObservationsQuery,
+) -> impl Stream<Item = Result<ObservationsRow, ApiError>> + Send + 'static {
+    async_stream::try_stream! {
+        let mut builder = QueryBuilder::<Postgres>::new(
+            "SELECT o.series_key,
+                    o.time,
+                    o.revision_no,
+                    o.time_precision,
+                    o.value,
+                    o.status,
+                    o.attributes,
+                    o.ingested_at,
+                    o.source_artifact_id,
+                    s.dimensions,
+                    s.measure_id,
+                    s.unit
+             FROM observations_latest o
+             JOIN series s ON s.series_key = o.series_key
+             JOIN dataflows d ON d.id = s.dataflow_id",
+        );
+        push_observation_filters(&mut builder, &query);
+        builder.push(" ORDER BY o.time ASC, o.series_key ASC LIMIT ");
+        builder.push_bind((query.limit + 1) as i64);
+
+        let mut rows = builder.build().fetch(&pool);
+        while let Some(row) = rows.try_next().await? {
+            yield row_to_observation(row)?;
+        }
+    }
+}
+
+fn push_observation_filters(
+    builder: &mut QueryBuilder<'_, Postgres>,
+    query: &ParsedObservationsQuery,
+) {
+    builder.push(" WHERE s.dataflow_id = ");
+    builder.push_bind(query.dataflow.as_str().to_string());
+
+    if !query.dimensions.is_empty() {
+        builder.push(" AND s.dimensions @> ");
+        builder.push_bind(serde_json::json!(query.dimensions));
+        builder.push("::jsonb");
+    }
+
+    if let Some(since) = query.since {
+        builder.push(" AND o.time >= ");
+        builder.push_bind(since);
+    }
+
+    if let Some(until) = query.until {
+        builder.push(" AND o.time <= ");
+        builder.push_bind(until);
+    }
+
+    if let Some(frequency) = &query.frequency {
+        builder.push(" AND d.frequency = ");
+        builder.push_bind(frequency.clone());
+    }
+
+    if let Some(cursor) = query.cursor {
+        builder.push(" AND (o.time, o.series_key) > (");
+        builder.push_bind(cursor.time);
+        builder.push(", ");
+        builder.push_bind(cursor.series_key.digest().as_bytes().to_vec());
+        builder.push(")");
+    }
+}
+
+fn row_to_observation(row: PgRow) -> Result<ObservationsRow, ApiError> {
+    let revision_no = row.try_get::<i32, _>("revision_no")?;
+    let attributes = json_map(row.try_get("attributes")?)?;
+    let dimensions = json_map(row.try_get("dimensions")?)?;
+
+    Ok(ObservationsRow {
+        series_key: series_key_from_bytes(row.try_get("series_key")?)?,
+        time: row.try_get("time")?,
+        time_precision: parse_time_precision(row.try_get("time_precision")?)?,
+        value: row.try_get("value")?,
+        status: parse_observation_status(row.try_get("status")?)?,
+        revision_no: u32::try_from(revision_no).map_err(|err| {
+            tracing::error!(error = %err, revision_no, "database returned invalid revision_no");
+            ApiError::Internal
+        })?,
+        attributes,
+        ingested_at: row.try_get("ingested_at")?,
+        source_artifact_id: artifact_id_from_bytes(row.try_get("source_artifact_id")?)?,
+        dimensions,
+        measure_id: row.try_get("measure_id")?,
+        unit: row.try_get("unit")?,
+    })
+}
+
+fn json_map(value: serde_json::Value) -> Result<BTreeMap<String, String>, ApiError> {
+    serde_json::from_value(value).map_err(|err| {
+        tracing::error!(error = %err, "database JSON map was not string-valued");
+        ApiError::Internal
+    })
+}
+
+fn parse_time_precision(value: &str) -> Result<TimePrecision, ApiError> {
+    match value {
+        "day" => Ok(TimePrecision::Day),
+        "week" => Ok(TimePrecision::Week),
+        "month" => Ok(TimePrecision::Month),
+        "quarter" => Ok(TimePrecision::Quarter),
+        "year" => Ok(TimePrecision::Year),
+        _ => {
+            tracing::error!(
+                time_precision = value,
+                "database returned invalid time precision"
+            );
+            Err(ApiError::Internal)
+        }
+    }
+}
+
+fn parse_observation_status(value: &str) -> Result<ObservationStatus, ApiError> {
+    match value {
+        "normal" => Ok(ObservationStatus::Normal),
+        "estimated" => Ok(ObservationStatus::Estimated),
+        "forecast" => Ok(ObservationStatus::Forecast),
+        "imputed" => Ok(ObservationStatus::Imputed),
+        "missing" => Ok(ObservationStatus::Missing),
+        "provisional" => Ok(ObservationStatus::Provisional),
+        "revised" => Ok(ObservationStatus::Revised),
+        "break" => Ok(ObservationStatus::Break),
+        _ => {
+            tracing::error!(
+                status = value,
+                "database returned invalid observation status"
+            );
+            Err(ApiError::Internal)
+        }
+    }
+}
+
+fn series_key_from_bytes(bytes: Vec<u8>) -> Result<SeriesKey, ApiError> {
+    digest_from_bytes(bytes).map(SeriesKey::from_digest)
+}
+
+fn artifact_id_from_bytes(bytes: Vec<u8>) -> Result<ArtifactId, ApiError> {
+    digest_from_bytes(bytes).map(ArtifactId::from_digest)
+}
+
+fn digest_from_bytes(bytes: Vec<u8>) -> Result<Sha256Digest, ApiError> {
+    let length = bytes.len();
+    let bytes = bytes.try_into().map_err(|_| {
+        tracing::error!(length, "database returned invalid SHA-256 digest length");
+        ApiError::Internal
+    })?;
+    Ok(Sha256Digest::from_bytes(bytes))
+}
+
+fn serialize_json_chunk<T: Serialize>(value: &T) -> Result<String, ApiError> {
+    serde_json::to_string(value).map_err(|err| {
+        tracing::error!(error = %err, "response serialization failed");
+        ApiError::Internal
+    })
+}
+
+fn row_to_csv(row: &ObservationsRow) -> Result<String, ApiError> {
+    let dimensions = serialize_json_chunk(&row.dimensions)?;
+    let attributes = serialize_json_chunk(&row.attributes)?;
+    let value = row
+        .value
+        .map_or_else(String::new, |value| value.to_string());
+    let fields = [
+        row.series_key.to_string(),
+        row.time.to_rfc3339(),
+        serde_json::to_string(&row.time_precision)
+            .map_err(|err| {
+                tracing::error!(error = %err, "time precision serialization failed");
+                ApiError::Internal
+            })?
+            .trim_matches('"')
+            .to_string(),
+        value,
+        serde_json::to_string(&row.status)
+            .map_err(|err| {
+                tracing::error!(error = %err, "status serialization failed");
+                ApiError::Internal
+            })?
+            .trim_matches('"')
+            .to_string(),
+        row.revision_no.to_string(),
+        dimensions,
+        attributes,
+        row.ingested_at.to_rfc3339(),
+        row.source_artifact_id.to_string(),
+        row.measure_id.clone(),
+        row.unit.clone(),
+    ];
+    Ok(format!(
+        "{}\n",
+        fields
+            .into_iter()
+            .map(|field| csv_escape(&field))
+            .collect::<Vec<_>>()
+            .join(",")
+    ))
+}
+
+fn csv_escape(value: &str) -> String {
+    if value.contains([',', '"', '\n', '\r']) {
+        format!("\"{}\"", value.replace('"', "\"\""))
+    } else {
+        value.to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use au_kpis_domain::ids::{DataflowId, SeriesKey};
+    use chrono::{TimeZone, Utc};
+
+    #[test]
+    fn parses_dimensions_dates_cursor_and_limit_from_query_string() {
+        let dataflow = DataflowId::new("abs.cpi").unwrap();
+        let series_key = SeriesKey::derive(&dataflow, [("region", "AUS")]);
+        let cursor = encode_cursor(&ObservationCursor {
+            time: Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap(),
+            series_key,
+        })
+        .unwrap();
+
+        let query = parse_observations_query(Some(&format!(
+            "dataflow=abs.cpi&dimensions%5Bregion%5D=AUS&since=2024-01-01&until=2024-06-30&frequency=quarterly&format=csv&cursor={cursor}&limit=500"
+        )))
+        .unwrap();
+
+        assert_eq!(query.dataflow.as_str(), "abs.cpi");
+        assert_eq!(
+            query.dimensions.get("region").map(String::as_str),
+            Some("AUS")
+        );
+        assert_eq!(
+            query.since,
+            Some(Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap())
+        );
+        assert_eq!(
+            query.until,
+            Some(Utc.with_ymd_and_hms(2024, 6, 30, 0, 0, 0).unwrap())
+        );
+        assert_eq!(query.frequency.as_deref(), Some("quarterly"));
+        assert_eq!(query.format, ResponseFormat::Csv);
+        assert_eq!(query.limit, 500);
+        assert_eq!(query.cursor.unwrap().series_key, series_key);
+    }
+
+    #[test]
+    fn rejects_missing_dataflow_and_excessive_limits_before_db_access() {
+        let missing = parse_observations_query(Some("limit=10")).unwrap_err();
+        assert!(missing.to_string().contains("dataflow"));
+
+        let too_large = parse_observations_query(Some("dataflow=abs.cpi&limit=10001")).unwrap_err();
+        assert!(too_large.to_string().contains("limit"));
+    }
+
+    #[test]
+    fn cursor_roundtrips_as_opaque_base64_payload() {
+        let dataflow = DataflowId::new("abs.cpi").unwrap();
+        let cursor = ObservationCursor {
+            time: Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap(),
+            series_key: SeriesKey::derive(&dataflow, [("region", "AUS")]),
+        };
+
+        let encoded = encode_cursor(&cursor).unwrap();
+
+        assert!(!encoded.contains("2024-03-01"));
+        assert_eq!(decode_cursor(&encoded).unwrap(), cursor);
+    }
+}

--- a/crates/au-kpis-api-http/tests/observations.rs
+++ b/crates/au-kpis-api-http/tests/observations.rs
@@ -1,0 +1,371 @@
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+use au_kpis_api_http::{AppState, router};
+use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
+use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_domain::ids::{ArtifactId, DataflowId, SeriesKey};
+use au_kpis_telemetry::Telemetry;
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header},
+};
+use chrono::{TimeZone, Utc};
+use serde_json::json;
+use sqlx::PgPool;
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+#[derive(Debug, Default)]
+struct NoopCacheBackend;
+
+#[async_trait::async_trait]
+impl CacheBackend for NoopCacheBackend {
+    async fn get(&self, _key: &str) -> Result<Option<String>, CacheError> {
+        Ok(None)
+    }
+
+    async fn set(&self, _key: &str, _value: String, _ttl: Duration) -> Result<(), CacheError> {
+        Ok(())
+    }
+
+    async fn delete(&self, _key: &str) -> Result<bool, CacheError> {
+        Ok(false)
+    }
+
+    async fn take_token_bucket(
+        &self,
+        _key: &str,
+        _config: TokenBucketConfig,
+        _requested: u32,
+        _now_ms: u64,
+    ) -> Result<RateLimitDecision, CacheError> {
+        Ok(RateLimitDecision {
+            allowed: true,
+            remaining: 0,
+            retry_after: Duration::ZERO,
+        })
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn observations_endpoint_streams_latest_json_csv_and_cache_headers() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let db = TestDb::start("au_kpis_api_observations").await;
+    seed_observations(db.pool()).await;
+    let app = router(test_state(db.pool().clone())).expect("router");
+
+    let first = app
+        .clone()
+        .oneshot(request(
+            "/v1/observations?dataflow=abs.cpi&dimensions[region]=AUS&since=2024-01-01&until=2024-12-31&limit=1",
+        ))
+        .await
+        .expect("json response");
+
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_eq!(
+        first.headers().get(header::CACHE_CONTROL).unwrap(),
+        "public, max-age=60, stale-while-revalidate=300"
+    );
+    let etag = first.headers().get(header::ETAG).unwrap().clone();
+    let body = to_bytes(first.into_body(), usize::MAX)
+        .await
+        .expect("json body");
+    let parsed: serde_json::Value = serde_json::from_slice(&body).expect("valid json");
+    assert_eq!(parsed["metadata"]["license"], "CC-BY-4.0");
+    assert_eq!(
+        parsed["metadata"]["attribution"],
+        "Source: Australian Bureau of Statistics"
+    );
+    assert_eq!(parsed["observations"].as_array().unwrap().len(), 1);
+    assert_eq!(parsed["observations"][0]["value"], 135.0);
+    let cursor = parsed["pagination"]["next_cursor"]
+        .as_str()
+        .expect("next cursor")
+        .to_string();
+
+    let second = app
+        .clone()
+        .oneshot(request(&format!(
+            "/v1/observations?dataflow=abs.cpi&dimensions[region]=AUS&cursor={cursor}&limit=10"
+        )))
+        .await
+        .expect("second page response");
+    let body = to_bytes(second.into_body(), usize::MAX)
+        .await
+        .expect("second body");
+    let parsed: serde_json::Value = serde_json::from_slice(&body).expect("valid json");
+    assert_eq!(parsed["observations"].as_array().unwrap().len(), 1);
+    assert_eq!(parsed["observations"][0]["value"], 136.2);
+    assert!(parsed["pagination"]["next_cursor"].is_null());
+
+    let cached = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/v1/observations?dataflow=abs.cpi&dimensions[region]=AUS&since=2024-01-01&until=2024-12-31&limit=1")
+                .header(header::IF_NONE_MATCH, etag)
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("cached response");
+    assert_eq!(cached.status(), StatusCode::NOT_MODIFIED);
+
+    let csv = app
+        .oneshot(request(
+            "/v1/observations?dataflow=abs.cpi&dimensions[region]=AUS&format=csv&limit=1",
+        ))
+        .await
+        .expect("csv response");
+    assert_eq!(csv.status(), StatusCode::OK);
+    assert_eq!(
+        csv.headers().get(header::CONTENT_TYPE).unwrap(),
+        "text/csv; charset=utf-8"
+    );
+    let body = String::from_utf8(
+        to_bytes(csv.into_body(), usize::MAX)
+            .await
+            .expect("csv body")
+            .to_vec(),
+    )
+    .expect("csv utf-8");
+    assert!(body.starts_with("# dataflow=abs.cpi,license=CC-BY-4.0"));
+    assert!(body.contains("series_key,time,time_precision,value,status,revision_no"));
+    assert!(body.contains(",135,normal,1,"));
+    assert!(body.contains("# next_cursor="));
+}
+
+fn request(uri: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .body(Body::empty())
+        .expect("request")
+}
+
+fn test_state(db: PgPool) -> AppState {
+    AppState::new(
+        db,
+        Arc::new(CacheClient::from_backend(NoopCacheBackend)),
+        Arc::new(AppConfig {
+            http: HttpConfig {
+                bind: "127.0.0.1:0".into(),
+                cors_allowed_origins: Vec::new(),
+                shutdown_grace_period_secs: 30,
+            },
+            database: DatabaseConfig {
+                url: "postgres://postgres:postgres@localhost/au_kpis".into(),
+            },
+            cache: au_kpis_config::CacheConfig {
+                url: "redis://127.0.0.1:6379".into(),
+            },
+            telemetry: TelemetryConfig {
+                service_name: "au-kpis-test".into(),
+                log_format: LogFormat::Json,
+                log_level: "info".into(),
+                otlp_endpoint: None,
+            },
+        }),
+        Arc::new(Telemetry::disabled()),
+        CancellationToken::new(),
+    )
+}
+
+#[derive(Debug)]
+struct TestDb {
+    pool: PgPool,
+    _timescale: au_kpis_testing::timescale::TimescaleHarness,
+}
+
+impl TestDb {
+    async fn start(database: &str) -> Self {
+        let timescale = au_kpis_testing::timescale::start_timescale(database)
+            .await
+            .expect("start timescale test container");
+        let cfg = DatabaseConfig {
+            url: timescale.url().to_string(),
+        };
+
+        let mut last_err = None;
+        for _ in 0..10 {
+            match au_kpis_db::connect(&cfg).await {
+                Ok(pool) => {
+                    au_kpis_db::migrate(&pool).await.expect("apply migrations");
+                    return Self {
+                        pool,
+                        _timescale: timescale,
+                    };
+                }
+                Err(err) => {
+                    last_err = Some(err);
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            }
+        }
+        panic!("timescaledb did not accept connections: {last_err:?}");
+    }
+
+    fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+async fn seed_observations(pool: &PgPool) {
+    sqlx::query(
+        "INSERT INTO sources (id, name, homepage, description)
+         VALUES ('abs', 'Australian Bureau of Statistics', 'https://www.abs.gov.au', NULL)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert source");
+
+    sqlx::query(
+        "INSERT INTO measures (id, name, description, unit, scale)
+         VALUES ('index', 'CPI index', NULL, 'index', NULL)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert measure");
+
+    sqlx::query(
+        "INSERT INTO dataflows (
+             id, source_id, name, description, dimensions, measures,
+             frequency, license, attribution, source_url
+         )
+         VALUES (
+             'abs.cpi', 'abs', 'Consumer Price Index', NULL,
+             ARRAY['region'], ARRAY['index'], 'quarterly', 'CC-BY-4.0',
+             'Source: Australian Bureau of Statistics',
+             'https://www.abs.gov.au/statistics/economy/price-indexes-and-inflation/consumer-price-index-australia'
+         )",
+    )
+    .execute(pool)
+    .await
+    .expect("insert dataflow");
+
+    let artifact = ArtifactId::of_content(b"api observations fixture");
+    sqlx::query(
+        "INSERT INTO artifacts (
+             id, source_id, source_url, content_type, response_headers,
+             size_bytes, storage_key, fetched_at
+         )
+         VALUES ($1, 'abs', 'https://example.test/cpi.json', 'application/json',
+                 '{}'::jsonb, 128, $2, $3)",
+    )
+    .bind(artifact.digest().as_bytes().as_slice())
+    .bind(format!("artifacts/{artifact}"))
+    .bind(Utc.with_ymd_and_hms(2024, 4, 24, 0, 0, 0).unwrap())
+    .execute(pool)
+    .await
+    .expect("insert artifact");
+
+    let aus_key = insert_series(pool, "AUS").await;
+    let nsw_key = insert_series(pool, "NSW").await;
+    insert_observation(
+        pool,
+        ObservationSeed::new(aus_key, artifact, (2024, 3, 1), 0, 134.2),
+    )
+    .await;
+    insert_observation(
+        pool,
+        ObservationSeed::new(aus_key, artifact, (2024, 3, 1), 1, 135.0),
+    )
+    .await;
+    insert_observation(
+        pool,
+        ObservationSeed::new(aus_key, artifact, (2024, 6, 1), 0, 136.2),
+    )
+    .await;
+    insert_observation(
+        pool,
+        ObservationSeed::new(nsw_key, artifact, (2024, 3, 1), 0, 137.1),
+    )
+    .await;
+}
+
+async fn insert_series(pool: &PgPool, region: &str) -> SeriesKey {
+    let dataflow = DataflowId::new("abs.cpi").unwrap();
+    let dimensions: BTreeMap<String, String> = [("region".to_string(), region.to_string())]
+        .into_iter()
+        .collect();
+    let key = SeriesKey::derive(
+        &dataflow,
+        dimensions
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    );
+    sqlx::query(
+        "INSERT INTO series (
+             series_key, dataflow_id, measure_id, dimensions, unit,
+             first_observed, last_observed, active
+         )
+         VALUES ($1, 'abs.cpi', 'index', $2, 'index', $3, $4, true)",
+    )
+    .bind(key.digest().as_bytes().as_slice())
+    .bind(json!(dimensions))
+    .bind(Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap())
+    .bind(Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap())
+    .execute(pool)
+    .await
+    .expect("insert series");
+    key
+}
+
+#[derive(Debug, Clone, Copy)]
+struct ObservationSeed {
+    series_key: SeriesKey,
+    artifact: ArtifactId,
+    date: (i32, u32, u32),
+    revision_no: i32,
+    value: f64,
+}
+
+impl ObservationSeed {
+    fn new(
+        series_key: SeriesKey,
+        artifact: ArtifactId,
+        date: (i32, u32, u32),
+        revision_no: i32,
+        value: f64,
+    ) -> Self {
+        Self {
+            series_key,
+            artifact,
+            date,
+            revision_no,
+            value,
+        }
+    }
+}
+
+async fn insert_observation(pool: &PgPool, seed: ObservationSeed) {
+    sqlx::query(
+        "INSERT INTO observations (
+             series_key, time, revision_no, time_precision, value, status,
+             attributes, ingested_at, source_artifact_id
+         )
+         VALUES ($1, $2, $3, 'quarter', $4, 'normal',
+                 '{}'::jsonb, $5, $6)",
+    )
+    .bind(seed.series_key.digest().as_bytes().as_slice())
+    .bind(
+        Utc.with_ymd_and_hms(seed.date.0, seed.date.1, seed.date.2, 0, 0, 0)
+            .unwrap(),
+    )
+    .bind(seed.revision_no)
+    .bind(seed.value)
+    .bind(Utc.with_ymd_and_hms(2024, 4, 24, 0, 0, 0).unwrap())
+    .bind(seed.artifact.digest().as_bytes().as_slice())
+    .execute(pool)
+    .await
+    .expect("insert observation");
+}
+
+fn docker_available() -> bool {
+    std::env::var_os("DOCKER_HOST").is_some()
+        || std::path::Path::new("/var/run/docker.sock").exists()
+}

--- a/crates/au-kpis-api-http/tests/routes.rs
+++ b/crates/au-kpis-api-http/tests/routes.rs
@@ -151,6 +151,10 @@ async fn openapi_route_serves_generated_spec() {
         "openapi"
     );
     assert_eq!(
+        parsed["paths"]["/v1/observations"]["get"]["operationId"],
+        "listObservations"
+    );
+    assert_eq!(
         parsed["paths"]["/v1/health"]["get"]["responses"]["408"]["content"]["application/problem+json"]
             ["schema"]["$ref"],
         "#/components/schemas/ProblemDetails"
@@ -170,6 +174,37 @@ async fn openapi_route_serves_generated_spec() {
     assert!(
         output.is_ok(),
         "expected live /v1/openapi.json payload to validate, got {output:?}"
+    );
+}
+
+#[tokio::test]
+async fn observations_route_validates_required_dataflow_before_db_access() {
+    let response = router(test_state())
+        .expect("router")
+        .oneshot(
+            Request::builder()
+                .uri("/v1/observations?limit=10")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/problem+json"
+    );
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let parsed: ProblemDetails = serde_json::from_slice(&body).expect("problem details json");
+    assert!(
+        parsed
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("dataflow"))
     );
 }
 

--- a/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
+++ b/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
@@ -5,6 +5,17 @@ expression: emitted_spec()
 {
   "components": {
     "schemas": {
+      "ArtifactId": {
+        "description": "Lowercase hex-encoded SHA-256 digest (64 chars).",
+        "format": "sha256-hex",
+        "maxLength": 64,
+        "minLength": 64,
+        "type": "string"
+      },
+      "DataflowId": {
+        "description": "Identifier for a dataflow (e.g. `abs.cpi`).",
+        "type": "string"
+      },
       "HealthResponse": {
         "description": "Health endpoint response.",
         "properties": {
@@ -16,6 +27,174 @@ expression: emitted_spec()
         "required": [
           "status"
         ],
+        "type": "object"
+      },
+      "ObservationStatus": {
+        "description": "Observation status flags sourced from SDMX. Subset in use across Australian\npublishers; extend as new codes appear in upstream feeds.",
+        "enum": [
+          "normal",
+          "estimated",
+          "forecast",
+          "imputed",
+          "missing",
+          "provisional",
+          "revised",
+          "break"
+        ],
+        "type": "string"
+      },
+      "ObservationsMetadata": {
+        "description": "Attribution and licensing metadata that applies to an observations page.",
+        "properties": {
+          "attribution": {
+            "description": "Required source acknowledgement to display with derived charts.",
+            "type": "string"
+          },
+          "dataflow": {
+            "$ref": "#/components/schemas/DataflowId",
+            "description": "Requested dataflow identifier."
+          },
+          "license": {
+            "description": "Data license identifier, e.g. `CC-BY-4.0`.",
+            "type": "string"
+          },
+          "source_url": {
+            "description": "Canonical citation URL for the upstream source.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "dataflow",
+          "attribution",
+          "license",
+          "source_url"
+        ],
+        "type": "object"
+      },
+      "ObservationsResponse": {
+        "description": "JSON response envelope for `/v1/observations`.",
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/ObservationsMetadata",
+            "description": "Dataflow attribution and license metadata."
+          },
+          "observations": {
+            "description": "Observation rows in ascending `(time, series_key)` order.",
+            "items": {
+              "$ref": "#/components/schemas/ObservationsRow"
+            },
+            "type": "array"
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMetadata",
+            "description": "Cursor for continuing the query."
+          }
+        },
+        "required": [
+          "metadata",
+          "observations",
+          "pagination"
+        ],
+        "type": "object"
+      },
+      "ObservationsRow": {
+        "description": "One observation row returned by `/v1/observations`.",
+        "properties": {
+          "attributes": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Free-form source attributes for this observation.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "dimensions": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Series dimension values keyed by dimension id.",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "ingested_at": {
+            "description": "Ingestion timestamp for this revision.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "measure_id": {
+            "description": "Measure identifier for the series.",
+            "type": "string"
+          },
+          "revision_no": {
+            "description": "Revision number, where zero is the original publication.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "series_key": {
+            "$ref": "#/components/schemas/SeriesKey",
+            "description": "Deterministic series key."
+          },
+          "source_artifact_id": {
+            "$ref": "#/components/schemas/ArtifactId",
+            "description": "Content-addressed source artifact identifier."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ObservationStatus",
+            "description": "Observation status."
+          },
+          "time": {
+            "description": "Observation timestamp.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "time_precision": {
+            "$ref": "#/components/schemas/TimePrecision",
+            "description": "Temporal precision of the timestamp."
+          },
+          "unit": {
+            "description": "Unit for the series values.",
+            "type": "string"
+          },
+          "value": {
+            "description": "Numeric value; null when status is `missing`.",
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "series_key",
+          "time",
+          "time_precision",
+          "status",
+          "revision_no",
+          "attributes",
+          "ingested_at",
+          "source_artifact_id",
+          "dimensions",
+          "measure_id",
+          "unit"
+        ],
+        "type": "object"
+      },
+      "PaginationMetadata": {
+        "description": "Cursor metadata for the current observations page.",
+        "properties": {
+          "next_cursor": {
+            "description": "Opaque cursor for the next page, or null when the page is complete.",
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        },
         "type": "object"
       },
       "ProblemDetails": {
@@ -56,6 +235,24 @@ expression: emitted_spec()
           "status"
         ],
         "type": "object"
+      },
+      "SeriesKey": {
+        "description": "Lowercase hex-encoded SHA-256 digest (64 chars).",
+        "format": "sha256-hex",
+        "maxLength": 64,
+        "minLength": 64,
+        "type": "string"
+      },
+      "TimePrecision": {
+        "description": "Temporal granularity of an observation's timestamp. Matches the SDMX\n`@FREQ` facet on a coarse scale.",
+        "enum": [
+          "day",
+          "week",
+          "month",
+          "quarter",
+          "year"
+        ],
+        "type": "string"
       }
     }
   },
@@ -99,6 +296,182 @@ expression: emitted_spec()
         "tags": []
       }
     },
+    "/v1/observations": {
+      "get": {
+        "operationId": "listObservations",
+        "parameters": [
+          {
+            "description": "Required dataflow id, e.g. abs.cpi.",
+            "in": "query",
+            "name": "dataflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Dimension filters as repeated key=value values. The handler also accepts dimensions[region]=AUS.",
+            "in": "query",
+            "name": "dimensions[]",
+            "required": false,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          },
+          {
+            "description": "Inclusive lower time bound as YYYY-MM-DD or RFC3339.",
+            "in": "query",
+            "name": "since",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Inclusive upper time bound as YYYY-MM-DD or RFC3339.",
+            "in": "query",
+            "name": "until",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional dataflow frequency filter.",
+            "in": "query",
+            "name": "frequency",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Response format: json or csv.",
+            "in": "query",
+            "name": "format",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Opaque cursor from the previous page.",
+            "in": "query",
+            "name": "cursor",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Page size, maximum 10000.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObservationsResponse"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "description": "Observation page.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Public CDN cache policy.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Weak entity tag for this page.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "The client's cached page is still fresh.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Public CDN cache policy.",
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "ETag": {
+                "description": "Weak entity tag for this page.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Invalid query string."
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Dataflow not found."
+          },
+          "408": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Request timed out."
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Internal server error."
+          }
+        },
+        "summary": "`GET /v1/observations`.",
+        "tags": [
+          "observations"
+        ]
+      }
+    },
     "/v1/openapi.json": {
       "get": {
         "operationId": "openapi",
@@ -138,5 +511,11 @@ expression: emitted_spec()
         "tags": []
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "description": "Time-series observations",
+      "name": "observations"
+    }
+  ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -39,6 +39,180 @@
         }
       }
     },
+    "/v1/observations": {
+      "get": {
+        "tags": ["observations"],
+        "summary": "`GET /v1/observations`.",
+        "operationId": "listObservations",
+        "parameters": [
+          {
+            "name": "dataflow",
+            "in": "query",
+            "description": "Required dataflow id, e.g. abs.cpi.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dimensions[]",
+            "in": "query",
+            "description": "Dimension filters as repeated key=value values. The handler also accepts dimensions[region]=AUS.",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "name": "since",
+            "in": "query",
+            "description": "Inclusive lower time bound as YYYY-MM-DD or RFC3339.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "until",
+            "in": "query",
+            "description": "Inclusive upper time bound as YYYY-MM-DD or RFC3339.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "frequency",
+            "in": "query",
+            "description": "Optional dataflow frequency filter.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "format",
+            "in": "query",
+            "description": "Response format: json or csv.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "description": "Opaque cursor from the previous page.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Page size, maximum 10000.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Observation page.",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Public CDN cache policy."
+              },
+              "ETag": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Weak entity tag for this page."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ObservationsResponse"
+                }
+              },
+              "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "304": {
+            "description": "The client's cached page is still fresh.",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Public CDN cache policy."
+              },
+              "ETag": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Weak entity tag for this page."
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query string.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dataflow not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "408": {
+            "description": "Request timed out.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/openapi.json": {
       "get": {
         "tags": [],
@@ -81,6 +255,17 @@
   },
   "components": {
     "schemas": {
+      "ArtifactId": {
+        "type": "string",
+        "format": "sha256-hex",
+        "description": "Lowercase hex-encoded SHA-256 digest (64 chars).",
+        "maxLength": 64,
+        "minLength": 64
+      },
+      "DataflowId": {
+        "type": "string",
+        "description": "Identifier for a dataflow (e.g. `abs.cpi`)."
+      },
       "HealthResponse": {
         "type": "object",
         "description": "Health endpoint response.",
@@ -89,6 +274,159 @@
           "status": {
             "type": "string",
             "description": "Current service health."
+          }
+        }
+      },
+      "ObservationStatus": {
+        "type": "string",
+        "description": "Observation status flags sourced from SDMX. Subset in use across Australian\npublishers; extend as new codes appear in upstream feeds.",
+        "enum": [
+          "normal",
+          "estimated",
+          "forecast",
+          "imputed",
+          "missing",
+          "provisional",
+          "revised",
+          "break"
+        ]
+      },
+      "ObservationsMetadata": {
+        "type": "object",
+        "description": "Attribution and licensing metadata that applies to an observations page.",
+        "required": ["dataflow", "attribution", "license", "source_url"],
+        "properties": {
+          "attribution": {
+            "type": "string",
+            "description": "Required source acknowledgement to display with derived charts."
+          },
+          "dataflow": {
+            "$ref": "#/components/schemas/DataflowId",
+            "description": "Requested dataflow identifier."
+          },
+          "license": {
+            "type": "string",
+            "description": "Data license identifier, e.g. `CC-BY-4.0`."
+          },
+          "source_url": {
+            "type": "string",
+            "description": "Canonical citation URL for the upstream source."
+          }
+        }
+      },
+      "ObservationsResponse": {
+        "type": "object",
+        "description": "JSON response envelope for `/v1/observations`.",
+        "required": ["metadata", "observations", "pagination"],
+        "properties": {
+          "metadata": {
+            "$ref": "#/components/schemas/ObservationsMetadata",
+            "description": "Dataflow attribution and license metadata."
+          },
+          "observations": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ObservationsRow"
+            },
+            "description": "Observation rows in ascending `(time, series_key)` order."
+          },
+          "pagination": {
+            "$ref": "#/components/schemas/PaginationMetadata",
+            "description": "Cursor for continuing the query."
+          }
+        }
+      },
+      "ObservationsRow": {
+        "type": "object",
+        "description": "One observation row returned by `/v1/observations`.",
+        "required": [
+          "series_key",
+          "time",
+          "time_precision",
+          "status",
+          "revision_no",
+          "attributes",
+          "ingested_at",
+          "source_artifact_id",
+          "dimensions",
+          "measure_id",
+          "unit"
+        ],
+        "properties": {
+          "attributes": {
+            "type": "object",
+            "description": "Free-form source attributes for this observation.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "dimensions": {
+            "type": "object",
+            "description": "Series dimension values keyed by dimension id.",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "ingested_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Ingestion timestamp for this revision."
+          },
+          "measure_id": {
+            "type": "string",
+            "description": "Measure identifier for the series."
+          },
+          "revision_no": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Revision number, where zero is the original publication.",
+            "minimum": 0
+          },
+          "series_key": {
+            "$ref": "#/components/schemas/SeriesKey",
+            "description": "Deterministic series key."
+          },
+          "source_artifact_id": {
+            "$ref": "#/components/schemas/ArtifactId",
+            "description": "Content-addressed source artifact identifier."
+          },
+          "status": {
+            "$ref": "#/components/schemas/ObservationStatus",
+            "description": "Observation status."
+          },
+          "time": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Observation timestamp."
+          },
+          "time_precision": {
+            "$ref": "#/components/schemas/TimePrecision",
+            "description": "Temporal precision of the timestamp."
+          },
+          "unit": {
+            "type": "string",
+            "description": "Unit for the series values."
+          },
+          "value": {
+            "type": ["number", "null"],
+            "format": "double",
+            "description": "Numeric value; null when status is `missing`."
+          }
+        }
+      },
+      "PaginationMetadata": {
+        "type": "object",
+        "description": "Cursor metadata for the current observations page.",
+        "properties": {
+          "next_cursor": {
+            "type": ["string", "null"],
+            "description": "Opaque cursor for the next page, or null when the page is complete."
           }
         }
       },
@@ -120,7 +458,25 @@
             "description": "Problem type URI."
           }
         }
+      },
+      "SeriesKey": {
+        "type": "string",
+        "format": "sha256-hex",
+        "description": "Lowercase hex-encoded SHA-256 digest (64 chars).",
+        "maxLength": 64,
+        "minLength": 64
+      },
+      "TimePrecision": {
+        "type": "string",
+        "description": "Temporal granularity of an observation's timestamp. Matches the SDMX\n`@FREQ` facet on a coarse scale.",
+        "enum": ["day", "week", "month", "quarter", "year"]
       }
     }
-  }
+  },
+  "tags": [
+    {
+      "name": "observations",
+      "description": "Time-series observations"
+    }
+  ]
 }


### PR DESCRIPTION
Closes #31

## Pass requirements

- [x] Query params: dataflow, dimensions[], since, until, frequency, format, cursor, limit
- [x] JSON + CSV response formats (Parquet in M3)
- [x] Cursor-based pagination (base64-encoded `(time, series_key)`)
- [x] Cache headers (`ETag`, `Cache-Control`)
- [x] `schemathesis` passes against endpoint
- [x] Attribution + license metadata in response
- [x] Streams via `StreamBody`/streaming body (no full-result buffering)

## Test plan

- `cargo test -p au-kpis-api-http -- --nocapture`
- `cargo test -p au-kpis-openapi -- --nocapture`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks protect --staged`
- OpenAPI normalized drift check: `cargo run -p au-kpis-openapi` + `jq -S` comparison

Local note: full `cargo nextest run --workspace` cannot complete on this workstation because Docker-backed Timescale/Redis/MinIO tests cannot open `/var/run/docker.sock`. The new API integration test compiles and skips locally for the same reason, and should run in CI where Docker is available.

## Spec impact

No Spec changes required. Implements `Spec.md § API surface`, `Spec.md § Data licensing and attribution`, and the API/testing portions of Phase 2.
