### PR TITLE
feat(api): dataflow catalog endpoints (#32)

### DIFF
--- a/crates/au-kpis-api-http/src/dataflows.rs
+++ b/crates/au-kpis-api-http/src/dataflows.rs
@@ -1,0 +1,484 @@
+//! `/v1/dataflows` catalog endpoints.
+
+use std::time::Duration;
+
+use au_kpis_domain::{
+    Code, Codelist, Dataflow, Dimension, Frequency, License,
+    ids::{CodeId, CodelistId, DataflowId, DimensionId, MeasureId, SourceId},
+};
+use axum::{
+    Json,
+    extract::{Path, State},
+    http::{HeaderValue, Uri, header},
+    response::{IntoResponse, Response},
+};
+use serde::{Deserialize, Serialize};
+use sqlx::{PgPool, Row};
+use utoipa::ToSchema;
+
+use crate::{ApiError, AppState};
+
+const CATALOG_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
+const CATALOG_CACHE_CONTROL: &str = "public, max-age=3600, stale-while-revalidate=86400";
+
+/// Query parameters for `GET /v1/dataflows`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct DataflowsQuery {
+    /// Optional source id filter, e.g. `abs`.
+    pub source: Option<SourceId>,
+    /// Optional publication frequency filter.
+    pub frequency: Option<Frequency>,
+}
+
+/// Response envelope for `GET /v1/dataflows`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct DataflowsResponse {
+    /// Matching dataflows, ordered by source then dataflow id.
+    pub dataflows: Vec<Dataflow>,
+}
+
+/// Response envelope for `GET /v1/dataflows/{id}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct DataflowDetailResponse {
+    /// Dataflow metadata.
+    pub dataflow: Dataflow,
+    /// Ordered dimension metadata for the dataflow.
+    pub dimensions: Vec<Dimension>,
+}
+
+/// Response envelope for `GET /v1/dataflows/{id}/codelists/{dim}`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct DataflowCodelistResponse {
+    /// Requested dataflow id.
+    pub dataflow_id: DataflowId,
+    /// Requested dimension id.
+    pub dimension_id: DimensionId,
+    /// Codelist attached to the requested dimension.
+    pub codelist: Codelist,
+}
+
+/// `GET /v1/dataflows`.
+#[utoipa::path(
+    get,
+    path = "/v1/dataflows",
+    operation_id = "listDataflows",
+    params(
+        ("source" = Option<String>, Query, description = "Optional source id filter, e.g. abs."),
+        ("frequency" = Option<String>, Query, description = "Optional publication frequency filter.")
+    ),
+    responses(
+        (status = 200, description = "Dataflow catalog page.", body = DataflowsResponse, content_type = "application/json", headers(
+            ("Cache-Control" = String, description = "Public CDN cache policy.")
+        )),
+        (status = 400, description = "Invalid query.", body = crate::ProblemDetails, content_type = "application/problem+json"),
+        (status = 500, description = "Internal error.", body = crate::ProblemDetails, content_type = "application/problem+json")
+    ),
+    tag = "dataflows"
+)]
+pub async fn list_dataflows(State(state): State<AppState>, uri: Uri) -> Result<Response, ApiError> {
+    let query = parse_dataflows_query(uri.query())?;
+    let cache_key = list_cache_key(&query);
+    if let Some(cached) = state
+        .cache
+        .get_json::<DataflowsResponse>(&cache_key)
+        .await?
+    {
+        return Ok(catalog_response(cached));
+    }
+
+    let response = DataflowsResponse {
+        dataflows: load_dataflows(&state.db, &query).await?,
+    };
+    state
+        .cache
+        .set_json(&cache_key, &response, CATALOG_CACHE_TTL)
+        .await?;
+    Ok(catalog_response(response))
+}
+
+/// `GET /v1/dataflows/{id}`.
+#[utoipa::path(
+    get,
+    path = "/v1/dataflows/{id}",
+    operation_id = "getDataflow",
+    params(
+        ("id" = String, Path, description = "Dataflow id.")
+    ),
+    responses(
+        (status = 200, description = "Dataflow metadata and dimensions.", body = DataflowDetailResponse, content_type = "application/json", headers(
+            ("Cache-Control" = String, description = "Public CDN cache policy.")
+        )),
+        (status = 404, description = "Dataflow not found.", body = crate::ProblemDetails, content_type = "application/problem+json"),
+        (status = 500, description = "Internal error.", body = crate::ProblemDetails, content_type = "application/problem+json")
+    ),
+    tag = "dataflows"
+)]
+pub async fn get_dataflow(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<Response, ApiError> {
+    let id =
+        DataflowId::new(id).map_err(|err| ApiError::Validation(format!("invalid id: {err}")))?;
+    let cache_key = format!("api:dataflows:get:{id}");
+    if let Some(cached) = state
+        .cache
+        .get_json::<DataflowDetailResponse>(&cache_key)
+        .await?
+    {
+        return Ok(catalog_response(cached));
+    }
+
+    let dataflow = load_dataflow(&state.db, &id).await?;
+    let dimensions = load_dimensions(&state.db, &id).await?;
+    let response = DataflowDetailResponse {
+        dataflow,
+        dimensions,
+    };
+    state
+        .cache
+        .set_json(&cache_key, &response, CATALOG_CACHE_TTL)
+        .await?;
+    Ok(catalog_response(response))
+}
+
+/// `GET /v1/dataflows/{id}/codelists/{dim}`.
+#[utoipa::path(
+    get,
+    path = "/v1/dataflows/{id}/codelists/{dim}",
+    operation_id = "getDataflowCodelist",
+    params(
+        ("id" = String, Path, description = "Dataflow id."),
+        ("dim" = String, Path, description = "Dimension id.")
+    ),
+    responses(
+        (status = 200, description = "Codelist for the requested dimension.", body = DataflowCodelistResponse, content_type = "application/json", headers(
+            ("Cache-Control" = String, description = "Public CDN cache policy.")
+        )),
+        (status = 404, description = "Dataflow or dimension not found.", body = crate::ProblemDetails, content_type = "application/problem+json"),
+        (status = 500, description = "Internal error.", body = crate::ProblemDetails, content_type = "application/problem+json")
+    ),
+    tag = "dataflows"
+)]
+pub async fn get_dataflow_codelist(
+    State(state): State<AppState>,
+    Path((id, dim)): Path<(String, String)>,
+) -> Result<Response, ApiError> {
+    let dataflow_id =
+        DataflowId::new(id).map_err(|err| ApiError::Validation(format!("invalid id: {err}")))?;
+    let dimension_id = DimensionId::new(dim)
+        .map_err(|err| ApiError::Validation(format!("invalid dimension: {err}")))?;
+    let cache_key = format!("api:dataflows:codelist:{dataflow_id}:{dimension_id}");
+    if let Some(cached) = state
+        .cache
+        .get_json::<DataflowCodelistResponse>(&cache_key)
+        .await?
+    {
+        return Ok(catalog_response(cached));
+    }
+
+    let codelist = load_codelist(&state.db, &dataflow_id, &dimension_id).await?;
+    let response = DataflowCodelistResponse {
+        dataflow_id,
+        dimension_id,
+        codelist,
+    };
+    state
+        .cache
+        .set_json(&cache_key, &response, CATALOG_CACHE_TTL)
+        .await?;
+    Ok(catalog_response(response))
+}
+
+fn catalog_response<T>(body: T) -> Response
+where
+    T: Serialize,
+{
+    let mut response = Json(body).into_response();
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(CATALOG_CACHE_CONTROL),
+    );
+    response
+}
+
+fn parse_dataflows_query(raw: Option<&str>) -> Result<DataflowsQuery, ApiError> {
+    let mut source = None;
+    let mut frequency = None;
+
+    for (key, value) in url::form_urlencoded::parse(raw.unwrap_or_default().as_bytes()) {
+        match key.as_ref() {
+            "source" => {
+                source = Some(
+                    SourceId::new(value.into_owned())
+                        .map_err(|err| ApiError::Validation(format!("invalid source: {err}")))?,
+                );
+            }
+            "frequency" => {
+                frequency = Some(parse_frequency(&value)?);
+            }
+            _ => {}
+        }
+    }
+
+    Ok(DataflowsQuery { source, frequency })
+}
+
+fn parse_frequency(value: &str) -> Result<Frequency, ApiError> {
+    match value {
+        "daily" => Ok(Frequency::Daily),
+        "weekly" => Ok(Frequency::Weekly),
+        "monthly" => Ok(Frequency::Monthly),
+        "quarterly" => Ok(Frequency::Quarterly),
+        "annual" => Ok(Frequency::Annual),
+        "irregular" => Ok(Frequency::Irregular),
+        _ => Err(ApiError::Validation(format!(
+            "unsupported frequency `{value}`"
+        ))),
+    }
+}
+
+fn list_cache_key(query: &DataflowsQuery) -> String {
+    let source = query.source.as_ref().map_or("-", SourceId::as_str);
+    let frequency = query
+        .frequency
+        .as_ref()
+        .map_or("-", |frequency| frequency_as_str(*frequency));
+    format!("api:dataflows:list:source={source}:frequency={frequency}")
+}
+
+fn frequency_as_str(frequency: Frequency) -> &'static str {
+    match frequency {
+        Frequency::Daily => "daily",
+        Frequency::Weekly => "weekly",
+        Frequency::Monthly => "monthly",
+        Frequency::Quarterly => "quarterly",
+        Frequency::Annual => "annual",
+        Frequency::Irregular => "irregular",
+    }
+}
+
+async fn load_dataflows(pool: &PgPool, query: &DataflowsQuery) -> Result<Vec<Dataflow>, ApiError> {
+    let rows = sqlx::query(
+        "SELECT id, source_id, name, description, dimensions, measures,
+                frequency, license, attribution, source_url
+         FROM dataflows
+         WHERE ($1::text IS NULL OR source_id = $1)
+           AND ($2::text IS NULL OR frequency = $2)
+         ORDER BY source_id, id",
+    )
+    .bind(query.source.as_ref().map(SourceId::as_str))
+    .bind(query.frequency.map(frequency_as_str))
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(dataflow_from_row).collect()
+}
+
+async fn load_dataflow(pool: &PgPool, id: &DataflowId) -> Result<Dataflow, ApiError> {
+    let row = sqlx::query(
+        "SELECT id, source_id, name, description, dimensions, measures,
+                frequency, license, attribution, source_url
+         FROM dataflows
+         WHERE id = $1",
+    )
+    .bind(id.as_str())
+    .fetch_optional(pool)
+    .await?;
+
+    row.map(dataflow_from_row)
+        .transpose()?
+        .ok_or_else(|| ApiError::NotFound(format!("dataflow `{id}`")))
+}
+
+async fn load_dimensions(
+    pool: &PgPool,
+    dataflow_id: &DataflowId,
+) -> Result<Vec<Dimension>, ApiError> {
+    let rows = sqlx::query(
+        "SELECT id, name, description, codelist_id, position
+         FROM dimensions
+         WHERE dataflow_id = $1
+         ORDER BY position",
+    )
+    .bind(dataflow_id.as_str())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(dimension_from_row).collect()
+}
+
+async fn load_codelist(
+    pool: &PgPool,
+    dataflow_id: &DataflowId,
+    dimension_id: &DimensionId,
+) -> Result<Codelist, ApiError> {
+    let row = sqlx::query(
+        "SELECT c.id, c.name, c.description
+         FROM dimensions d
+         JOIN codelists c ON c.id = d.codelist_id
+         WHERE d.dataflow_id = $1 AND d.id = $2",
+    )
+    .bind(dataflow_id.as_str())
+    .bind(dimension_id.as_str())
+    .fetch_optional(pool)
+    .await?;
+
+    let row = row.ok_or_else(|| {
+        ApiError::NotFound(format!(
+            "codelist for dataflow `{dataflow_id}` dimension `{dimension_id}`"
+        ))
+    })?;
+    let codelist_id = codelist_id_from_str(row.try_get("id")?)?;
+    let codes = load_codes(pool, &codelist_id).await?;
+
+    Ok(Codelist {
+        id: codelist_id,
+        name: row.try_get("name")?,
+        description: row.try_get("description")?,
+        codes,
+    })
+}
+
+async fn load_codes(pool: &PgPool, codelist_id: &CodelistId) -> Result<Vec<Code>, ApiError> {
+    let rows = sqlx::query(
+        "SELECT id, codelist_id, name, description, parent_id
+         FROM codes
+         WHERE codelist_id = $1
+         ORDER BY parent_id NULLS FIRST, id",
+    )
+    .bind(codelist_id.as_str())
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(code_from_row).collect()
+}
+
+fn dataflow_from_row(row: sqlx::postgres::PgRow) -> Result<Dataflow, ApiError> {
+    let frequency: String = row.try_get("frequency")?;
+    let license: String = row.try_get("license")?;
+
+    Ok(Dataflow {
+        id: dataflow_id_from_str(row.try_get("id")?)?,
+        source_id: source_id_from_str(row.try_get("source_id")?)?,
+        name: row.try_get("name")?,
+        description: row.try_get("description")?,
+        dimensions: row
+            .try_get::<Vec<String>, _>("dimensions")?
+            .into_iter()
+            .map(dimension_id_from_str)
+            .collect::<Result<Vec<_>, _>>()?,
+        measures: row
+            .try_get::<Vec<String>, _>("measures")?
+            .into_iter()
+            .map(measure_id_from_str)
+            .collect::<Result<Vec<_>, _>>()?,
+        frequency: parse_db_frequency(&frequency)?,
+        license: parse_license(&license),
+        attribution: row.try_get("attribution")?,
+        source_url: row.try_get("source_url")?,
+    })
+}
+
+fn dimension_from_row(row: sqlx::postgres::PgRow) -> Result<Dimension, ApiError> {
+    let position = row.try_get::<i16, _>("position")?;
+    let position = u16::try_from(position).map_err(|err| {
+        tracing::error!(%err, "database returned invalid dimension position");
+        ApiError::Internal
+    })?;
+
+    Ok(Dimension {
+        id: dimension_id_from_str(row.try_get("id")?)?,
+        name: row.try_get("name")?,
+        description: row.try_get("description")?,
+        codelist_id: codelist_id_from_str(row.try_get("codelist_id")?)?,
+        position,
+    })
+}
+
+fn code_from_row(row: sqlx::postgres::PgRow) -> Result<Code, ApiError> {
+    Ok(Code {
+        id: code_id_from_str(row.try_get("id")?)?,
+        codelist_id: codelist_id_from_str(row.try_get("codelist_id")?)?,
+        name: row.try_get("name")?,
+        description: row.try_get("description")?,
+        parent_id: row
+            .try_get::<Option<String>, _>("parent_id")?
+            .map(code_id_from_str)
+            .transpose()?,
+    })
+}
+
+fn parse_license(value: &str) -> License {
+    match value {
+        "CC-BY-4.0" => License::CcBy40,
+        "CC-BY-ND-4.0" => License::CcByNd40,
+        "CC-BY-SA-4.0" => License::CcBySa40,
+        "public-domain" => License::PublicDomain,
+        other => License::Other(other.to_string()),
+    }
+}
+
+fn parse_db_frequency(value: &str) -> Result<Frequency, ApiError> {
+    parse_frequency(value).map_err(|err| {
+        tracing::error!(frequency = value, %err, "database returned invalid dataflow frequency");
+        ApiError::Internal
+    })
+}
+
+fn source_id_from_str(value: String) -> Result<SourceId, ApiError> {
+    SourceId::new(value).map_err(invalid_db_id)
+}
+
+fn dataflow_id_from_str(value: String) -> Result<DataflowId, ApiError> {
+    DataflowId::new(value).map_err(invalid_db_id)
+}
+
+fn dimension_id_from_str(value: String) -> Result<DimensionId, ApiError> {
+    DimensionId::new(value).map_err(invalid_db_id)
+}
+
+fn codelist_id_from_str(value: String) -> Result<CodelistId, ApiError> {
+    CodelistId::new(value).map_err(invalid_db_id)
+}
+
+fn code_id_from_str(value: String) -> Result<CodeId, ApiError> {
+    CodeId::new(value).map_err(invalid_db_id)
+}
+
+fn measure_id_from_str(value: String) -> Result<MeasureId, ApiError> {
+    MeasureId::new(value).map_err(invalid_db_id)
+}
+
+fn invalid_db_id(err: au_kpis_domain::ids::IdError) -> ApiError {
+    tracing::error!(%err, "database returned invalid identifier");
+    ApiError::Internal
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_filters_and_rejects_unsupported_frequency() {
+        let query = parse_dataflows_query(Some("source=abs&frequency=quarterly")).unwrap();
+
+        assert_eq!(query.source.as_ref().map(SourceId::as_str), Some("abs"));
+        assert_eq!(query.frequency, Some(Frequency::Quarterly));
+
+        let err = parse_dataflows_query(Some("frequency=hourly")).unwrap_err();
+        assert!(err.to_string().contains("frequency"));
+    }
+
+    #[test]
+    fn list_cache_key_is_stable_for_filters() {
+        let query = DataflowsQuery {
+            source: Some(SourceId::new("abs").unwrap()),
+            frequency: Some(Frequency::Quarterly),
+        };
+
+        assert_eq!(
+            list_cache_key(&query),
+            "api:dataflows:list:source=abs:frequency=quarterly"
+        );
+    }
+}

--- a/crates/au-kpis-api-http/src/docs.rs
+++ b/crates/au-kpis-api-http/src/docs.rs
@@ -3,6 +3,10 @@
 use utoipa::OpenApi;
 
 use crate::{
+    dataflows::{
+        __path_get_dataflow, __path_get_dataflow_codelist, __path_list_dataflows,
+        DataflowCodelistResponse, DataflowDetailResponse, DataflowsQuery, DataflowsResponse,
+    },
     error::ProblemDetails,
     observations::{
         __path_list_observations, ObservationsMetadata, ObservationsResponse, ObservationsRow,
@@ -19,8 +23,23 @@ use crate::{
         version = "0.1.0",
         description = "Unified API for Australian public economic data."
     ),
-    paths(health, openapi, list_observations),
+    paths(
+        health,
+        openapi,
+        list_dataflows,
+        get_dataflow,
+        get_dataflow_codelist,
+        list_observations
+    ),
     components(schemas(
+        au_kpis_domain::Code,
+        au_kpis_domain::Codelist,
+        au_kpis_domain::Dataflow,
+        au_kpis_domain::Dimension,
+        DataflowCodelistResponse,
+        DataflowDetailResponse,
+        DataflowsQuery,
+        DataflowsResponse,
         HealthResponse,
         ObservationsMetadata,
         ObservationsResponse,
@@ -28,6 +47,9 @@ use crate::{
         PaginationMetadata,
         ProblemDetails
     )),
-    tags((name = "observations", description = "Time-series observations"))
+    tags(
+        (name = "dataflows", description = "Dataflow catalog and codelists"),
+        (name = "observations", description = "Time-series observations")
+    )
 )]
 pub struct ApiDoc;

--- a/crates/au-kpis-api-http/src/lib.rs
+++ b/crates/au-kpis-api-http/src/lib.rs
@@ -22,12 +22,17 @@ use tower_http::{
     trace::TraceLayer,
 };
 
+pub mod dataflows;
 pub mod docs;
 pub mod error;
 pub mod observations;
 pub mod routes;
 pub mod state;
 
+pub use dataflows::{
+    DataflowCodelistResponse, DataflowDetailResponse, DataflowsQuery, DataflowsResponse,
+    get_dataflow, get_dataflow_codelist, list_dataflows,
+};
 pub use docs::ApiDoc;
 pub use error::{ApiError, ProblemDetails};
 pub use observations::{
@@ -69,6 +74,12 @@ pub fn router(state: AppState) -> Result<Router, RouterBuildError> {
     router_with(
         Router::<AppState>::new()
             .route("/v1/health", get(health))
+            .route("/v1/dataflows", get(dataflows::list_dataflows))
+            .route("/v1/dataflows/:id", get(dataflows::get_dataflow))
+            .route(
+                "/v1/dataflows/:id/codelists/:dim",
+                get(dataflows::get_dataflow_codelist),
+            )
             .route("/v1/observations", get(observations::list_observations))
             .route("/v1/openapi.json", get(openapi)),
         state,

--- a/crates/au-kpis-api-http/tests/dataflows.rs
+++ b/crates/au-kpis-api-http/tests/dataflows.rs
@@ -1,0 +1,482 @@
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use au_kpis_api_http::{AppState, router};
+use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
+use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_telemetry::Telemetry;
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header},
+};
+use serde_json::json;
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+const LONG_TTL: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Debug, Clone, Default)]
+struct RecordingCacheBackend {
+    inner: Arc<RecordingCacheState>,
+}
+
+#[derive(Debug, Default)]
+struct RecordingCacheState {
+    values: Mutex<BTreeMap<String, String>>,
+    sets: Mutex<Vec<CacheSet>>,
+}
+
+#[derive(Debug, Clone)]
+struct CacheSet {
+    key: String,
+    ttl: Duration,
+}
+
+#[async_trait::async_trait]
+impl CacheBackend for RecordingCacheBackend {
+    async fn get(&self, key: &str) -> Result<Option<String>, CacheError> {
+        Ok(self
+            .inner
+            .values
+            .lock()
+            .expect("cache values lock")
+            .get(key)
+            .cloned())
+    }
+
+    async fn set(&self, key: &str, value: String, ttl: Duration) -> Result<(), CacheError> {
+        self.inner
+            .values
+            .lock()
+            .expect("cache values lock")
+            .insert(key.to_string(), value);
+        self.inner
+            .sets
+            .lock()
+            .expect("cache sets lock")
+            .push(CacheSet {
+                key: key.to_string(),
+                ttl,
+            });
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<bool, CacheError> {
+        Ok(self
+            .inner
+            .values
+            .lock()
+            .expect("cache values lock")
+            .remove(key)
+            .is_some())
+    }
+
+    async fn take_token_bucket(
+        &self,
+        _key: &str,
+        _config: TokenBucketConfig,
+        _requested: u32,
+        _now_ms: u64,
+    ) -> Result<RateLimitDecision, CacheError> {
+        Ok(RateLimitDecision {
+            allowed: true,
+            remaining: 0,
+            retry_after: Duration::ZERO,
+        })
+    }
+}
+
+#[tokio::test]
+async fn dataflow_catalog_routes_serve_cached_payloads_without_database() {
+    let cache = RecordingCacheBackend::default();
+    cache
+        .inner
+        .values
+        .lock()
+        .expect("cache values lock")
+        .extend([
+            (
+                "api:dataflows:list:source=abs:frequency=quarterly".to_string(),
+                json!({
+                    "dataflows": [cached_dataflow_json()]
+                })
+                .to_string(),
+            ),
+            (
+                "api:dataflows:get:abs.cpi".to_string(),
+                json!({
+                    "dataflow": cached_dataflow_json(),
+                    "dimensions": [{
+                        "id": "region",
+                        "name": "Region",
+                        "description": null,
+                        "codelist_id": "CL_REGION_AU",
+                        "position": 0
+                    }]
+                })
+                .to_string(),
+            ),
+            (
+                "api:dataflows:codelist:abs.cpi:region".to_string(),
+                json!({
+                    "dataflow_id": "abs.cpi",
+                    "dimension_id": "region",
+                    "codelist": {
+                        "id": "CL_REGION_AU",
+                        "name": "Australian regions",
+                        "description": null,
+                        "codes": [{
+                            "id": "AUS",
+                            "codelist_id": "CL_REGION_AU",
+                            "name": "Australia",
+                            "description": null,
+                            "parent_id": null
+                        }]
+                    }
+                })
+                .to_string(),
+            ),
+        ]);
+
+    let app = router(test_state(
+        lazy_pool(),
+        Arc::new(CacheClient::from_backend(cache)),
+    ))
+    .expect("router");
+
+    for uri in [
+        "/v1/dataflows?source=abs&frequency=quarterly",
+        "/v1/dataflows/abs.cpi",
+        "/v1/dataflows/abs.cpi/codelists/region",
+    ] {
+        let response = app.clone().oneshot(request(uri)).await.expect("response");
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(
+            response.headers().get(header::CACHE_CONTROL).unwrap(),
+            "public, max-age=3600, stale-while-revalidate=86400"
+        );
+        let body = to_bytes(response.into_body(), usize::MAX)
+            .await
+            .expect("body");
+        let parsed: serde_json::Value = serde_json::from_slice(&body).expect("json body");
+        assert!(
+            parsed.to_string().contains("abs.cpi"),
+            "expected cached payload for {uri}, got {parsed}"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dataflow_catalog_endpoints_filter_render_codelists_and_use_long_ttl_cache() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let db = TestDb::start("au_kpis_api_dataflows").await;
+    seed_catalog(db.pool()).await;
+
+    let cache = RecordingCacheBackend::default();
+    let app = router(test_state(
+        db.pool().clone(),
+        Arc::new(CacheClient::from_backend(cache.clone())),
+    ))
+    .expect("router");
+
+    let list = app
+        .clone()
+        .oneshot(request("/v1/dataflows?source=abs&frequency=quarterly"))
+        .await
+        .expect("list response");
+    assert_eq!(list.status(), StatusCode::OK);
+    assert_eq!(
+        list.headers().get(header::CACHE_CONTROL).unwrap(),
+        "public, max-age=3600, stale-while-revalidate=86400"
+    );
+    let body = to_bytes(list.into_body(), usize::MAX)
+        .await
+        .expect("list body");
+    let parsed: serde_json::Value = serde_json::from_slice(&body).expect("list json");
+    assert_eq!(parsed["dataflows"].as_array().unwrap().len(), 1);
+    assert_eq!(parsed["dataflows"][0]["id"], "abs.cpi");
+    assert_eq!(parsed["dataflows"][0]["frequency"], "quarterly");
+
+    let detail = app
+        .clone()
+        .oneshot(request("/v1/dataflows/abs.cpi"))
+        .await
+        .expect("detail response");
+    assert_eq!(detail.status(), StatusCode::OK);
+    let body = to_bytes(detail.into_body(), usize::MAX)
+        .await
+        .expect("detail body");
+    let parsed: serde_json::Value = serde_json::from_slice(&body).expect("detail json");
+    assert_eq!(parsed["dataflow"]["id"], "abs.cpi");
+    assert_eq!(parsed["dataflow"]["license"], "CC-BY-4.0");
+    assert_eq!(parsed["dimensions"][0]["id"], "region");
+    assert_eq!(parsed["dimensions"][0]["codelist_id"], "CL_REGION_AU");
+
+    let codelist = app
+        .clone()
+        .oneshot(request("/v1/dataflows/abs.cpi/codelists/region"))
+        .await
+        .expect("codelist response");
+    assert_eq!(codelist.status(), StatusCode::OK);
+    let body = to_bytes(codelist.into_body(), usize::MAX)
+        .await
+        .expect("codelist body");
+    let parsed: serde_json::Value = serde_json::from_slice(&body).expect("codelist json");
+    assert_eq!(parsed["dataflow_id"], "abs.cpi");
+    assert_eq!(parsed["dimension_id"], "region");
+    assert_eq!(parsed["codelist"]["id"], "CL_REGION_AU");
+    assert_eq!(parsed["codelist"]["codes"][0]["id"], "AUS");
+    assert_eq!(parsed["codelist"]["codes"][1]["id"], "NSW");
+
+    let sets = cache.inner.sets.lock().expect("cache sets lock").clone();
+    assert!(
+        sets.iter()
+            .any(|set| set.key.starts_with("api:dataflows:list:") && set.ttl >= LONG_TTL),
+        "list response should be cached with a long TTL, got {sets:?}"
+    );
+    assert!(
+        sets.iter()
+            .any(|set| set.key == "api:dataflows:get:abs.cpi" && set.ttl >= LONG_TTL),
+        "detail response should be cached with a long TTL, got {sets:?}"
+    );
+    assert!(
+        sets.iter()
+            .any(|set| set.key == "api:dataflows:codelist:abs.cpi:region" && set.ttl >= LONG_TTL),
+        "codelist response should be cached with a long TTL, got {sets:?}"
+    );
+
+    sqlx::query("DELETE FROM dataflows WHERE id = 'abs.cpi'")
+        .execute(db.pool())
+        .await
+        .expect("delete dataflow after cache warm");
+    let cached = app
+        .oneshot(request("/v1/dataflows?source=abs&frequency=quarterly"))
+        .await
+        .expect("cached list response");
+    assert_eq!(cached.status(), StatusCode::OK);
+    let body = to_bytes(cached.into_body(), usize::MAX)
+        .await
+        .expect("cached body");
+    let parsed: serde_json::Value = serde_json::from_slice(&body).expect("cached json");
+    assert_eq!(parsed["dataflows"][0]["id"], "abs.cpi");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn dataflow_catalog_endpoints_return_problem_json_for_missing_resources() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let db = TestDb::start("au_kpis_api_dataflows_missing").await;
+    seed_catalog(db.pool()).await;
+    let app = router(test_state(
+        db.pool().clone(),
+        Arc::new(CacheClient::from_backend(RecordingCacheBackend::default())),
+    ))
+    .expect("router");
+
+    let missing_dataflow = app
+        .clone()
+        .oneshot(request("/v1/dataflows/missing.flow"))
+        .await
+        .expect("missing dataflow response");
+    assert_eq!(missing_dataflow.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        missing_dataflow
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .unwrap(),
+        "application/problem+json"
+    );
+
+    let missing_dimension = app
+        .oneshot(request("/v1/dataflows/abs.cpi/codelists/missing"))
+        .await
+        .expect("missing dimension response");
+    assert_eq!(missing_dimension.status(), StatusCode::NOT_FOUND);
+    assert_eq!(
+        missing_dimension
+            .headers()
+            .get(header::CONTENT_TYPE)
+            .unwrap(),
+        "application/problem+json"
+    );
+}
+
+fn request(uri: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .body(Body::empty())
+        .expect("request")
+}
+
+fn test_state(db: PgPool, cache: Arc<CacheClient>) -> AppState {
+    AppState::new(
+        db,
+        cache,
+        Arc::new(AppConfig {
+            http: HttpConfig {
+                bind: "127.0.0.1:0".into(),
+                cors_allowed_origins: Vec::new(),
+                shutdown_grace_period_secs: 30,
+            },
+            database: DatabaseConfig {
+                url: "postgres://postgres:postgres@localhost/au_kpis".into(),
+            },
+            cache: au_kpis_config::CacheConfig {
+                url: "redis://127.0.0.1:6379".into(),
+            },
+            telemetry: TelemetryConfig {
+                service_name: "au-kpis-test".into(),
+                log_format: LogFormat::Json,
+                log_level: "info".into(),
+                otlp_endpoint: None,
+            },
+        }),
+        Arc::new(Telemetry::disabled()),
+        CancellationToken::new(),
+    )
+}
+
+fn lazy_pool() -> PgPool {
+    PgPoolOptions::new()
+        .max_connections(1)
+        .connect_lazy("postgres://postgres:postgres@127.0.0.1/au_kpis_unreachable")
+        .expect("lazy postgres pool")
+}
+
+fn cached_dataflow_json() -> serde_json::Value {
+    json!({
+        "id": "abs.cpi",
+        "source_id": "abs",
+        "name": "Consumer Price Index",
+        "description": null,
+        "dimensions": ["region"],
+        "measures": ["index"],
+        "frequency": "quarterly",
+        "license": "CC-BY-4.0",
+        "attribution": "Source: Australian Bureau of Statistics",
+        "source_url": "https://www.abs.gov.au/statistics/economy/price-indexes-and-inflation/consumer-price-index-australia"
+    })
+}
+
+#[derive(Debug)]
+struct TestDb {
+    pool: PgPool,
+    _timescale: au_kpis_testing::timescale::TimescaleHarness,
+}
+
+impl TestDb {
+    async fn start(database: &str) -> Self {
+        let timescale = au_kpis_testing::timescale::start_timescale(database)
+            .await
+            .expect("start timescale test container");
+        let cfg = DatabaseConfig {
+            url: timescale.url().to_string(),
+        };
+
+        let mut last_err = None;
+        for _ in 0..10 {
+            match au_kpis_db::connect(&cfg).await {
+                Ok(pool) => {
+                    au_kpis_db::migrate(&pool).await.expect("apply migrations");
+                    return Self {
+                        pool,
+                        _timescale: timescale,
+                    };
+                }
+                Err(err) => {
+                    last_err = Some(err);
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            }
+        }
+        panic!("timescaledb did not accept connections: {last_err:?}");
+    }
+
+    fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+async fn seed_catalog(pool: &PgPool) {
+    sqlx::query(
+        "INSERT INTO sources (id, name, homepage, description)
+         VALUES
+         ('abs', 'Australian Bureau of Statistics', 'https://www.abs.gov.au', NULL),
+         ('rba', 'Reserve Bank of Australia', 'https://www.rba.gov.au', NULL)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert sources");
+
+    sqlx::query(
+        "INSERT INTO codelists (id, name, description)
+         VALUES
+         ('CL_REGION_AU', 'Australian regions', 'ABS statistical regions'),
+         ('CL_MEASURE_CPI', 'CPI measures', NULL)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert codelists");
+
+    sqlx::query(
+        "INSERT INTO codes (codelist_id, id, name, description, parent_id)
+         VALUES
+         ('CL_REGION_AU', 'AUS', 'Australia', NULL, NULL),
+         ('CL_REGION_AU', 'NSW', 'New South Wales', NULL, 'AUS'),
+         ('CL_MEASURE_CPI', 'all_groups', 'All groups CPI', NULL, NULL)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert codes");
+
+    sqlx::query(
+        "INSERT INTO dataflows (
+             id, source_id, name, description, dimensions, measures,
+             frequency, license, attribution, source_url
+         )
+         VALUES
+         (
+             'abs.cpi', 'abs', 'Consumer Price Index',
+             'Quarterly CPI across Australian regions.',
+             ARRAY['region', 'measure'], ARRAY['index'], 'quarterly', 'CC-BY-4.0',
+             'Source: Australian Bureau of Statistics',
+             'https://www.abs.gov.au/statistics/economy/price-indexes-and-inflation/consumer-price-index-australia'
+         ),
+         (
+             'rba.cash_rate', 'rba', 'Cash Rate Target', NULL,
+             ARRAY['measure'], ARRAY['rate'], 'daily', 'CC-BY-4.0',
+             'Source: Reserve Bank of Australia',
+             'https://www.rba.gov.au/statistics/cash-rate/'
+         )",
+    )
+    .execute(pool)
+    .await
+    .expect("insert dataflows");
+
+    sqlx::query(
+        "INSERT INTO dimensions (dataflow_id, id, name, description, codelist_id, position)
+         VALUES
+         ('abs.cpi', 'region', 'Region', 'Geographic region', 'CL_REGION_AU', 0),
+         ('abs.cpi', 'measure', 'Measure', NULL, 'CL_MEASURE_CPI', 1),
+         ('rba.cash_rate', 'measure', 'Measure', NULL, 'CL_MEASURE_CPI', 0)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert dimensions");
+}
+
+fn docker_available() -> bool {
+    std::env::var_os("DOCKER_HOST").is_some()
+        || std::path::Path::new("/var/run/docker.sock").exists()
+}

--- a/crates/au-kpis-api-http/tests/routes.rs
+++ b/crates/au-kpis-api-http/tests/routes.rs
@@ -155,6 +155,18 @@ async fn openapi_route_serves_generated_spec() {
         "listObservations"
     );
     assert_eq!(
+        parsed["paths"]["/v1/dataflows"]["get"]["operationId"],
+        "listDataflows"
+    );
+    assert_eq!(
+        parsed["paths"]["/v1/dataflows/{id}"]["get"]["operationId"],
+        "getDataflow"
+    );
+    assert_eq!(
+        parsed["paths"]["/v1/dataflows/{id}/codelists/{dim}"]["get"]["operationId"],
+        "getDataflowCodelist"
+    );
+    assert_eq!(
         parsed["paths"]["/v1/health"]["get"]["responses"]["408"]["content"]["application/problem+json"]
             ["schema"]["$ref"],
         "#/components/schemas/ProblemDetails"
@@ -205,6 +217,37 @@ async fn observations_route_validates_required_dataflow_before_db_access() {
             .detail
             .as_deref()
             .is_some_and(|detail| detail.contains("dataflow"))
+    );
+}
+
+#[tokio::test]
+async fn dataflows_route_validates_frequency_before_db_access() {
+    let response = router(test_state())
+        .expect("router")
+        .oneshot(
+            Request::builder()
+                .uri("/v1/dataflows?frequency=hourly")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/problem+json"
+    );
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let parsed: ProblemDetails = serde_json::from_slice(&body).expect("problem details json");
+    assert!(
+        parsed
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("frequency"))
     );
 }
 

--- a/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
+++ b/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
@@ -12,8 +12,280 @@ expression: emitted_spec()
         "minLength": 64,
         "type": "string"
       },
+      "Code": {
+        "description": "A single code within a codelist (e.g. `VIC` → \"Victoria\").",
+        "properties": {
+          "codelist_id": {
+            "$ref": "#/components/schemas/CodelistId",
+            "description": "The codelist this code belongs to. Denormalised here so a `Code`\nemitted from the API is self-contained."
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "$ref": "#/components/schemas/CodeId"
+          },
+          "name": {
+            "type": "string"
+          },
+          "parent_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CodeId",
+                "description": "Optional parent code id for hierarchical codelists (e.g. regions with\nstate → LGA containment)."
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "codelist_id",
+          "name"
+        ],
+        "type": "object"
+      },
+      "CodeId": {
+        "description": "Identifier for a code within a codelist (e.g. `VIC`).",
+        "type": "string"
+      },
+      "Codelist": {
+        "description": "A reusable vocabulary of codes attached to dimensions.",
+        "properties": {
+          "codes": {
+            "items": {
+              "$ref": "#/components/schemas/Code"
+            },
+            "type": "array"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "$ref": "#/components/schemas/CodelistId"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "codes"
+        ],
+        "type": "object"
+      },
+      "CodelistId": {
+        "description": "Identifier for a codelist (e.g. `CL_STATE_AU`).",
+        "type": "string"
+      },
+      "Dataflow": {
+        "description": "A dataflow — a named collection of series sharing dimensions and measures.",
+        "properties": {
+          "attribution": {
+            "description": "Required attribution string shown to end-users alongside derived charts.",
+            "type": "string"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "dimensions": {
+            "description": "Ordered list of dimension ids that key series within this dataflow.",
+            "items": {
+              "$ref": "#/components/schemas/DimensionId"
+            },
+            "type": "array"
+          },
+          "frequency": {
+            "$ref": "#/components/schemas/Frequency"
+          },
+          "id": {
+            "$ref": "#/components/schemas/DataflowId"
+          },
+          "license": {
+            "$ref": "#/components/schemas/License"
+          },
+          "measures": {
+            "description": "Measures published by this dataflow (index, rate, count, ...).",
+            "items": {
+              "$ref": "#/components/schemas/MeasureId"
+            },
+            "type": "array"
+          },
+          "name": {
+            "type": "string"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/SourceId"
+          },
+          "source_url": {
+            "description": "Canonical citation URL.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "source_id",
+          "name",
+          "dimensions",
+          "measures",
+          "frequency",
+          "license",
+          "attribution",
+          "source_url"
+        ],
+        "type": "object"
+      },
+      "DataflowCodelistResponse": {
+        "description": "Response envelope for `GET /v1/dataflows/{id}/codelists/{dim}`.",
+        "properties": {
+          "codelist": {
+            "$ref": "#/components/schemas/Codelist",
+            "description": "Codelist attached to the requested dimension."
+          },
+          "dataflow_id": {
+            "$ref": "#/components/schemas/DataflowId",
+            "description": "Requested dataflow id."
+          },
+          "dimension_id": {
+            "$ref": "#/components/schemas/DimensionId",
+            "description": "Requested dimension id."
+          }
+        },
+        "required": [
+          "dataflow_id",
+          "dimension_id",
+          "codelist"
+        ],
+        "type": "object"
+      },
+      "DataflowDetailResponse": {
+        "description": "Response envelope for `GET /v1/dataflows/{id}`.",
+        "properties": {
+          "dataflow": {
+            "$ref": "#/components/schemas/Dataflow",
+            "description": "Dataflow metadata."
+          },
+          "dimensions": {
+            "description": "Ordered dimension metadata for the dataflow.",
+            "items": {
+              "$ref": "#/components/schemas/Dimension"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "dataflow",
+          "dimensions"
+        ],
+        "type": "object"
+      },
       "DataflowId": {
         "description": "Identifier for a dataflow (e.g. `abs.cpi`).",
+        "type": "string"
+      },
+      "DataflowsQuery": {
+        "description": "Query parameters for `GET /v1/dataflows`.",
+        "properties": {
+          "frequency": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Frequency",
+                "description": "Optional publication frequency filter."
+              }
+            ]
+          },
+          "source": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceId",
+                "description": "Optional source id filter, e.g. `abs`."
+              }
+            ]
+          }
+        },
+        "type": "object"
+      },
+      "DataflowsResponse": {
+        "description": "Response envelope for `GET /v1/dataflows`.",
+        "properties": {
+          "dataflows": {
+            "description": "Matching dataflows, ordered by source then dataflow id.",
+            "items": {
+              "$ref": "#/components/schemas/Dataflow"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "dataflows"
+        ],
+        "type": "object"
+      },
+      "Dimension": {
+        "description": "A single dimension within a dataflow. Binds a dimension id to a codelist\nthat enumerates the permitted values.",
+        "properties": {
+          "codelist_id": {
+            "$ref": "#/components/schemas/CodelistId"
+          },
+          "description": {
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "$ref": "#/components/schemas/DimensionId"
+          },
+          "name": {
+            "type": "string"
+          },
+          "position": {
+            "description": "Position of this dimension in the dataflow's canonical dimension order.\nAdapters must emit dimensions in this order so series-key derivation is\nstable across codebases (see `Spec.md § Data model`).",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "codelist_id",
+          "position"
+        ],
+        "type": "object"
+      },
+      "DimensionId": {
+        "description": "Identifier for a dimension within a dataflow (e.g. `region`).",
+        "type": "string"
+      },
+      "Frequency": {
+        "description": "Cadence at which a dataflow publishes new observations. Informational —\nused by the scheduler to pick discovery intervals and by the SLO alerting\nrule `dataflow-no-new-observations`.",
+        "enum": [
+          "daily",
+          "weekly",
+          "monthly",
+          "quarterly",
+          "annual",
+          "irregular"
+        ],
         "type": "string"
       },
       "HealthResponse": {
@@ -28,6 +300,52 @@ expression: emitted_spec()
           "status"
         ],
         "type": "object"
+      },
+      "License": {
+        "description": "Canonical license identifier. Ingestion refuses to load a dataflow whose\n`license` field is absent (see `Spec.md § Data licensing and attribution`).",
+        "oneOf": [
+          {
+            "enum": [
+              "CC-BY-4.0"
+            ],
+            "type": "string"
+          },
+          {
+            "enum": [
+              "CC-BY-ND-4.0"
+            ],
+            "type": "string"
+          },
+          {
+            "enum": [
+              "CC-BY-SA-4.0"
+            ],
+            "type": "string"
+          },
+          {
+            "enum": [
+              "public-domain"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Escape hatch for licenses not yet enumerated. Carries the SPDX-style id.",
+            "properties": {
+              "other": {
+                "description": "Escape hatch for licenses not yet enumerated. Carries the SPDX-style id.",
+                "type": "string"
+              }
+            },
+            "required": [
+              "other"
+            ],
+            "type": "object"
+          }
+        ]
+      },
+      "MeasureId": {
+        "description": "Identifier for a measure (e.g. `unemployment_rate`).",
+        "type": "string"
       },
       "ObservationStatus": {
         "description": "Observation status flags sourced from SDMX. Subset in use across Australian\npublishers; extend as new codes appear in upstream feeds.",
@@ -243,6 +561,10 @@ expression: emitted_spec()
         "minLength": 64,
         "type": "string"
       },
+      "SourceId": {
+        "description": "Identifier for an upstream data source (e.g. `abs`, `rba`, `apra`).",
+        "type": "string"
+      },
       "TimePrecision": {
         "description": "Temporal granularity of an observation's timestamp. Matches the SDMX\n`@FREQ` facet on a coarse scale.",
         "enum": [
@@ -267,6 +589,204 @@ expression: emitted_spec()
   },
   "openapi": "3.1.0",
   "paths": {
+    "/v1/dataflows": {
+      "get": {
+        "operationId": "listDataflows",
+        "parameters": [
+          {
+            "description": "Optional source id filter, e.g. abs.",
+            "in": "query",
+            "name": "source",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional publication frequency filter.",
+            "in": "query",
+            "name": "frequency",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataflowsResponse"
+                }
+              }
+            },
+            "description": "Dataflow catalog page.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Public CDN cache policy.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Invalid query."
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Internal error."
+          }
+        },
+        "summary": "`GET /v1/dataflows`.",
+        "tags": [
+          "dataflows"
+        ]
+      }
+    },
+    "/v1/dataflows/{id}": {
+      "get": {
+        "operationId": "getDataflow",
+        "parameters": [
+          {
+            "description": "Dataflow id.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataflowDetailResponse"
+                }
+              }
+            },
+            "description": "Dataflow metadata and dimensions.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Public CDN cache policy.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Dataflow not found."
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Internal error."
+          }
+        },
+        "summary": "`GET /v1/dataflows/{id}`.",
+        "tags": [
+          "dataflows"
+        ]
+      }
+    },
+    "/v1/dataflows/{id}/codelists/{dim}": {
+      "get": {
+        "operationId": "getDataflowCodelist",
+        "parameters": [
+          {
+            "description": "Dataflow id.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Dimension id.",
+            "in": "path",
+            "name": "dim",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataflowCodelistResponse"
+                }
+              }
+            },
+            "description": "Codelist for the requested dimension.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Public CDN cache policy.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Dataflow or dimension not found."
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Internal error."
+          }
+        },
+        "summary": "`GET /v1/dataflows/{id}/codelists/{dim}`.",
+        "tags": [
+          "dataflows"
+        ]
+      }
+    },
     "/v1/health": {
       "get": {
         "operationId": "health",
@@ -513,6 +1033,10 @@ expression: emitted_spec()
     }
   },
   "tags": [
+    {
+      "description": "Dataflow catalog and codelists",
+      "name": "dataflows"
+    },
     {
       "description": "Time-series observations",
       "name": "observations"

--- a/openapi.json
+++ b/openapi.json
@@ -10,6 +10,198 @@
     "version": "0.1.0"
   },
   "paths": {
+    "/v1/dataflows": {
+      "get": {
+        "tags": ["dataflows"],
+        "summary": "`GET /v1/dataflows`.",
+        "operationId": "listDataflows",
+        "parameters": [
+          {
+            "name": "source",
+            "in": "query",
+            "description": "Optional source id filter, e.g. abs.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "frequency",
+            "in": "query",
+            "description": "Optional publication frequency filter.",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dataflow catalog page.",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Public CDN cache policy."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataflowsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/dataflows/{id}": {
+      "get": {
+        "tags": ["dataflows"],
+        "summary": "`GET /v1/dataflows/{id}`.",
+        "operationId": "getDataflow",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Dataflow id.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Dataflow metadata and dimensions.",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Public CDN cache policy."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataflowDetailResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dataflow not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/dataflows/{id}/codelists/{dim}": {
+      "get": {
+        "tags": ["dataflows"],
+        "summary": "`GET /v1/dataflows/{id}/codelists/{dim}`.",
+        "operationId": "getDataflowCodelist",
+        "parameters": [
+          {
+            "name": "id",
+            "in": "path",
+            "description": "Dataflow id.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "dim",
+            "in": "path",
+            "description": "Dimension id.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Codelist for the requested dimension.",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Public CDN cache policy."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DataflowCodelistResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Dataflow or dimension not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/health": {
       "get": {
         "tags": [],
@@ -262,9 +454,240 @@
         "maxLength": 64,
         "minLength": 64
       },
+      "Code": {
+        "type": "object",
+        "description": "A single code within a codelist (e.g. `VIC` → \"Victoria\").",
+        "required": ["id", "codelist_id", "name"],
+        "properties": {
+          "codelist_id": {
+            "$ref": "#/components/schemas/CodelistId",
+            "description": "The codelist this code belongs to. Denormalised here so a `Code`\nemitted from the API is self-contained."
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "id": {
+            "$ref": "#/components/schemas/CodeId"
+          },
+          "name": {
+            "type": "string"
+          },
+          "parent_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/CodeId",
+                "description": "Optional parent code id for hierarchical codelists (e.g. regions with\nstate → LGA containment)."
+              }
+            ]
+          }
+        }
+      },
+      "CodeId": {
+        "type": "string",
+        "description": "Identifier for a code within a codelist (e.g. `VIC`)."
+      },
+      "Codelist": {
+        "type": "object",
+        "description": "A reusable vocabulary of codes attached to dimensions.",
+        "required": ["id", "name", "codes"],
+        "properties": {
+          "codes": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Code"
+            }
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "id": {
+            "$ref": "#/components/schemas/CodelistId"
+          },
+          "name": {
+            "type": "string"
+          }
+        }
+      },
+      "CodelistId": {
+        "type": "string",
+        "description": "Identifier for a codelist (e.g. `CL_STATE_AU`)."
+      },
+      "Dataflow": {
+        "type": "object",
+        "description": "A dataflow — a named collection of series sharing dimensions and measures.",
+        "required": [
+          "id",
+          "source_id",
+          "name",
+          "dimensions",
+          "measures",
+          "frequency",
+          "license",
+          "attribution",
+          "source_url"
+        ],
+        "properties": {
+          "attribution": {
+            "type": "string",
+            "description": "Required attribution string shown to end-users alongside derived charts."
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "dimensions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DimensionId"
+            },
+            "description": "Ordered list of dimension ids that key series within this dataflow."
+          },
+          "frequency": {
+            "$ref": "#/components/schemas/Frequency"
+          },
+          "id": {
+            "$ref": "#/components/schemas/DataflowId"
+          },
+          "license": {
+            "$ref": "#/components/schemas/License"
+          },
+          "measures": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/MeasureId"
+            },
+            "description": "Measures published by this dataflow (index, rate, count, ...)."
+          },
+          "name": {
+            "type": "string"
+          },
+          "source_id": {
+            "$ref": "#/components/schemas/SourceId"
+          },
+          "source_url": {
+            "type": "string",
+            "description": "Canonical citation URL."
+          }
+        }
+      },
+      "DataflowCodelistResponse": {
+        "type": "object",
+        "description": "Response envelope for `GET /v1/dataflows/{id}/codelists/{dim}`.",
+        "required": ["dataflow_id", "dimension_id", "codelist"],
+        "properties": {
+          "codelist": {
+            "$ref": "#/components/schemas/Codelist",
+            "description": "Codelist attached to the requested dimension."
+          },
+          "dataflow_id": {
+            "$ref": "#/components/schemas/DataflowId",
+            "description": "Requested dataflow id."
+          },
+          "dimension_id": {
+            "$ref": "#/components/schemas/DimensionId",
+            "description": "Requested dimension id."
+          }
+        }
+      },
+      "DataflowDetailResponse": {
+        "type": "object",
+        "description": "Response envelope for `GET /v1/dataflows/{id}`.",
+        "required": ["dataflow", "dimensions"],
+        "properties": {
+          "dataflow": {
+            "$ref": "#/components/schemas/Dataflow",
+            "description": "Dataflow metadata."
+          },
+          "dimensions": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Dimension"
+            },
+            "description": "Ordered dimension metadata for the dataflow."
+          }
+        }
+      },
       "DataflowId": {
         "type": "string",
         "description": "Identifier for a dataflow (e.g. `abs.cpi`)."
+      },
+      "DataflowsQuery": {
+        "type": "object",
+        "description": "Query parameters for `GET /v1/dataflows`.",
+        "properties": {
+          "frequency": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Frequency",
+                "description": "Optional publication frequency filter."
+              }
+            ]
+          },
+          "source": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceId",
+                "description": "Optional source id filter, e.g. `abs`."
+              }
+            ]
+          }
+        }
+      },
+      "DataflowsResponse": {
+        "type": "object",
+        "description": "Response envelope for `GET /v1/dataflows`.",
+        "required": ["dataflows"],
+        "properties": {
+          "dataflows": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Dataflow"
+            },
+            "description": "Matching dataflows, ordered by source then dataflow id."
+          }
+        }
+      },
+      "Dimension": {
+        "type": "object",
+        "description": "A single dimension within a dataflow. Binds a dimension id to a codelist\nthat enumerates the permitted values.",
+        "required": ["id", "name", "codelist_id", "position"],
+        "properties": {
+          "codelist_id": {
+            "$ref": "#/components/schemas/CodelistId"
+          },
+          "description": {
+            "type": ["string", "null"]
+          },
+          "id": {
+            "$ref": "#/components/schemas/DimensionId"
+          },
+          "name": {
+            "type": "string"
+          },
+          "position": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Position of this dimension in the dataflow's canonical dimension order.\nAdapters must emit dimensions in this order so series-key derivation is\nstable across codebases (see `Spec.md § Data model`).",
+            "minimum": 0
+          }
+        }
+      },
+      "DimensionId": {
+        "type": "string",
+        "description": "Identifier for a dimension within a dataflow (e.g. `region`)."
+      },
+      "Frequency": {
+        "type": "string",
+        "description": "Cadence at which a dataflow publishes new observations. Informational —\nused by the scheduler to pick discovery intervals and by the SLO alerting\nrule `dataflow-no-new-observations`.",
+        "enum": ["daily", "weekly", "monthly", "quarterly", "annual", "irregular"]
       },
       "HealthResponse": {
         "type": "object",
@@ -276,6 +699,42 @@
             "description": "Current service health."
           }
         }
+      },
+      "License": {
+        "oneOf": [
+          {
+            "type": "string",
+            "enum": ["CC-BY-4.0"]
+          },
+          {
+            "type": "string",
+            "enum": ["CC-BY-ND-4.0"]
+          },
+          {
+            "type": "string",
+            "enum": ["CC-BY-SA-4.0"]
+          },
+          {
+            "type": "string",
+            "enum": ["public-domain"]
+          },
+          {
+            "type": "object",
+            "description": "Escape hatch for licenses not yet enumerated. Carries the SPDX-style id.",
+            "required": ["other"],
+            "properties": {
+              "other": {
+                "type": "string",
+                "description": "Escape hatch for licenses not yet enumerated. Carries the SPDX-style id."
+              }
+            }
+          }
+        ],
+        "description": "Canonical license identifier. Ingestion refuses to load a dataflow whose\n`license` field is absent (see `Spec.md § Data licensing and attribution`)."
+      },
+      "MeasureId": {
+        "type": "string",
+        "description": "Identifier for a measure (e.g. `unemployment_rate`)."
       },
       "ObservationStatus": {
         "type": "string",
@@ -466,6 +925,10 @@
         "maxLength": 64,
         "minLength": 64
       },
+      "SourceId": {
+        "type": "string",
+        "description": "Identifier for an upstream data source (e.g. `abs`, `rba`, `apra`)."
+      },
       "TimePrecision": {
         "type": "string",
         "description": "Temporal granularity of an observation's timestamp. Matches the SDMX\n`@FREQ` facet on a coarse scale.",
@@ -474,6 +937,10 @@
     }
   },
   "tags": [
+    {
+      "name": "dataflows",
+      "description": "Dataflow catalog and codelists"
+    },
     {
       "name": "observations",
       "description": "Time-series observations"


### PR DESCRIPTION
Closes #32

## Pass requirements

- [x] `GET /v1/dataflows` lists dataflows with `source` and `frequency` filters.
- [x] `GET /v1/dataflows/{id}` returns dataflow metadata and ordered dimensions.
- [x] `GET /v1/dataflows/{id}/codelists/{dim}` returns the dimension codelist and codes.
- [x] `schemathesis` passes.
- [x] Catalog responses are Redis-cached through `CacheClient` with a long TTL and public cache headers.

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test -p au-kpis-api-http -- --nocapture`
- `cargo test -p au-kpis-openapi -- --nocapture`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks protect --staged`
- OpenAPI normalized drift check against `openapi.json`
- `env -u RUST_LOG cargo nextest run --workspace` attempted locally; container-backed tests fail because this environment has no Docker socket at `/var/run/docker.sock`. The new `au-kpis-api-http::dataflows` integration tests compile locally and will run their database path in CI.

## Spec impact

No Spec changes required. This implements the catalog endpoints already listed in `Spec.md § API surface` and cache behavior from `Spec.md § API surface / Non-functional`.
