### PR TITLE
feat(api): add series lookup endpoint (#33)

### DIFF
--- a/crates/au-kpis-api-http/src/docs.rs
+++ b/crates/au-kpis-api-http/src/docs.rs
@@ -13,6 +13,7 @@ use crate::{
         PaginationMetadata,
     },
     routes::{__path_health, __path_openapi, HealthResponse},
+    series::{__path_get_series, SeriesLookupResponse, SeriesRevisionMetadata},
 };
 
 /// Root OpenAPI document for the API handlers in this crate.
@@ -29,13 +30,16 @@ use crate::{
         list_dataflows,
         get_dataflow,
         get_dataflow_codelist,
-        list_observations
+        list_observations,
+        get_series
     ),
     components(schemas(
         au_kpis_domain::Code,
         au_kpis_domain::Codelist,
         au_kpis_domain::Dataflow,
         au_kpis_domain::Dimension,
+        au_kpis_domain::Observation,
+        au_kpis_domain::Series,
         DataflowCodelistResponse,
         DataflowDetailResponse,
         DataflowsQuery,
@@ -45,11 +49,14 @@ use crate::{
         ObservationsResponse,
         ObservationsRow,
         PaginationMetadata,
-        ProblemDetails
+        ProblemDetails,
+        SeriesLookupResponse,
+        SeriesRevisionMetadata
     )),
     tags(
         (name = "dataflows", description = "Dataflow catalog and codelists"),
-        (name = "observations", description = "Time-series observations")
+        (name = "observations", description = "Time-series observations"),
+        (name = "series", description = "Series metadata lookups")
     )
 )]
 pub struct ApiDoc;

--- a/crates/au-kpis-api-http/src/lib.rs
+++ b/crates/au-kpis-api-http/src/lib.rs
@@ -27,6 +27,7 @@ pub mod docs;
 pub mod error;
 pub mod observations;
 pub mod routes;
+pub mod series;
 pub mod state;
 
 pub use dataflows::{
@@ -40,6 +41,7 @@ pub use observations::{
     list_observations,
 };
 pub use routes::{HealthResponse, health, openapi};
+pub use series::{SeriesLookupResponse, SeriesRevisionMetadata, get_series};
 pub use state::AppState;
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
@@ -81,6 +83,7 @@ pub fn router(state: AppState) -> Result<Router, RouterBuildError> {
                 get(dataflows::get_dataflow_codelist),
             )
             .route("/v1/observations", get(observations::list_observations))
+            .route("/v1/series/:dataflow/:series_key", get(series::get_series))
             .route("/v1/openapi.json", get(openapi)),
         state,
     )

--- a/crates/au-kpis-api-http/src/series.rs
+++ b/crates/au-kpis-api-http/src/series.rs
@@ -1,0 +1,285 @@
+//! `/v1/series/{dataflow}/{series_key}` lookup endpoint.
+
+use std::{collections::BTreeMap, str::FromStr};
+
+use au_kpis_domain::{
+    Observation, ObservationStatus, Series, TimePrecision,
+    ids::{
+        ArtifactId, CodeId, DataflowId, DimensionId, MeasureId, SHA256_BYTES, SeriesKey,
+        Sha256Digest,
+    },
+};
+use axum::{
+    Json,
+    extract::{Path, State},
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{PgPool, Row, postgres::PgRow};
+use utoipa::ToSchema;
+
+use crate::{ApiError, AppState};
+
+/// Revision details for the latest observation returned with a series lookup.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct SeriesRevisionMetadata {
+    /// Latest revision number for the observation timestamp.
+    pub revision_no: u32,
+    /// Whether this observation supersedes the original publication.
+    pub is_revision: bool,
+    /// When this revision was ingested.
+    pub ingested_at: DateTime<Utc>,
+    /// Source artifact that produced this revision.
+    pub source_artifact_id: ArtifactId,
+}
+
+/// Response envelope for `GET /v1/series/{dataflow}/{series_key}`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct SeriesLookupResponse {
+    /// Series metadata.
+    pub series: Series,
+    /// Latest observation by timestamp, using `observations_latest` revision selection.
+    pub latest_observation: Option<Observation>,
+    /// Revision metadata for `latest_observation`.
+    pub revision: Option<SeriesRevisionMetadata>,
+}
+
+/// `GET /v1/series/{dataflow}/{series_key}`.
+#[utoipa::path(
+    get,
+    path = "/v1/series/{dataflow}/{series_key}",
+    operation_id = "getSeries",
+    params(
+        ("dataflow" = String, Path, description = "Dataflow id."),
+        ("series_key" = String, Path, description = "64-character series key hex digest.")
+    ),
+    responses(
+        (status = 200, description = "Series metadata and latest observation.", body = SeriesLookupResponse, content_type = "application/json"),
+        (status = 400, description = "Invalid path parameter.", body = crate::ProblemDetails, content_type = "application/problem+json"),
+        (status = 404, description = "Series not found.", body = crate::ProblemDetails, content_type = "application/problem+json"),
+        (status = 500, description = "Internal error.", body = crate::ProblemDetails, content_type = "application/problem+json")
+    ),
+    tag = "series"
+)]
+pub async fn get_series(
+    State(state): State<AppState>,
+    Path((dataflow, series_key)): Path<(String, String)>,
+) -> Result<Json<SeriesLookupResponse>, ApiError> {
+    let dataflow = DataflowId::new(dataflow)
+        .map_err(|err| ApiError::Validation(format!("invalid dataflow: {err}")))?;
+    let series_key = SeriesKey::from_str(&series_key)
+        .map_err(|err| ApiError::Validation(format!("invalid series_key: {err}")))?;
+    load_series_lookup(&state.db, &dataflow, &series_key)
+        .await
+        .map(Json)
+}
+
+async fn load_series_lookup(
+    pool: &PgPool,
+    dataflow: &DataflowId,
+    series_key: &SeriesKey,
+) -> Result<SeriesLookupResponse, ApiError> {
+    let row = sqlx::query(
+        "SELECT s.series_key,
+                s.dataflow_id,
+                s.measure_id,
+                s.dimensions,
+                s.unit,
+                s.first_observed,
+                s.last_observed,
+                s.active,
+                o.time AS observation_time,
+                o.time_precision,
+                o.value,
+                o.status,
+                o.revision_no,
+                o.attributes,
+                o.ingested_at,
+                o.source_artifact_id
+         FROM series s
+         LEFT JOIN LATERAL (
+             SELECT series_key, time, time_precision, value, status, revision_no,
+                    attributes, ingested_at, source_artifact_id
+             FROM observations_latest
+             WHERE series_key = s.series_key
+             ORDER BY time DESC
+             LIMIT 1
+         ) o ON TRUE
+         WHERE s.dataflow_id = $1 AND s.series_key = $2",
+    )
+    .bind(dataflow.as_str())
+    .bind(series_key.digest().as_bytes().to_vec())
+    .fetch_optional(pool)
+    .await?;
+
+    let row = row.ok_or_else(|| ApiError::NotFound(format!("series `{series_key}`")))?;
+    series_lookup_from_row(row)
+}
+
+fn series_lookup_from_row(row: PgRow) -> Result<SeriesLookupResponse, ApiError> {
+    let series = series_from_row(&row)?;
+    let latest_observation = observation_from_row(&row)?;
+    let revision = latest_observation
+        .as_ref()
+        .map(|observation| SeriesRevisionMetadata {
+            revision_no: observation.revision_no,
+            is_revision: observation.revision_no > 0,
+            ingested_at: observation.ingested_at,
+            source_artifact_id: observation.source_artifact_id,
+        });
+
+    Ok(SeriesLookupResponse {
+        series,
+        latest_observation,
+        revision,
+    })
+}
+
+fn series_from_row(row: &PgRow) -> Result<Series, ApiError> {
+    Ok(Series {
+        series_key: series_key_from_bytes(row.try_get("series_key")?)?,
+        dataflow_id: dataflow_id_from_str(row.try_get("dataflow_id")?)?,
+        measure_id: measure_id_from_str(row.try_get("measure_id")?)?,
+        dimensions: dimensions_from_json(row.try_get("dimensions")?)?,
+        unit: row.try_get("unit")?,
+        first_observed: row.try_get("first_observed")?,
+        last_observed: row.try_get("last_observed")?,
+        active: row.try_get("active")?,
+    })
+}
+
+fn observation_from_row(row: &PgRow) -> Result<Option<Observation>, ApiError> {
+    let Some(time) = row.try_get::<Option<DateTime<Utc>>, _>("observation_time")? else {
+        return Ok(None);
+    };
+    let revision_no = row
+        .try_get::<Option<i32>, _>("revision_no")?
+        .ok_or(ApiError::Internal)?;
+    let revision_no = u32::try_from(revision_no).map_err(|err| {
+        tracing::error!(%err, revision_no, "database returned invalid revision_no");
+        ApiError::Internal
+    })?;
+    let source_artifact_id = row
+        .try_get::<Option<Vec<u8>>, _>("source_artifact_id")?
+        .ok_or(ApiError::Internal)
+        .and_then(artifact_id_from_bytes)?;
+
+    Ok(Some(Observation {
+        series_key: series_key_from_bytes(row.try_get("series_key")?)?,
+        time,
+        time_precision: parse_time_precision(
+            row.try_get::<Option<String>, _>("time_precision")?
+                .as_deref()
+                .ok_or(ApiError::Internal)?,
+        )?,
+        value: row.try_get("value")?,
+        status: parse_observation_status(
+            row.try_get::<Option<String>, _>("status")?
+                .as_deref()
+                .ok_or(ApiError::Internal)?,
+        )?,
+        revision_no,
+        attributes: json_map(row.try_get("attributes")?)?,
+        ingested_at: row
+            .try_get::<Option<DateTime<Utc>>, _>("ingested_at")?
+            .ok_or(ApiError::Internal)?,
+        source_artifact_id,
+    }))
+}
+
+fn dimensions_from_json(
+    value: serde_json::Value,
+) -> Result<BTreeMap<DimensionId, CodeId>, ApiError> {
+    serde_json::from_value(value).map_err(|err| {
+        tracing::error!(error = %err, "database series dimensions were invalid");
+        ApiError::Internal
+    })
+}
+
+fn json_map(value: Option<serde_json::Value>) -> Result<BTreeMap<String, String>, ApiError> {
+    serde_json::from_value(value.ok_or(ApiError::Internal)?).map_err(|err| {
+        tracing::error!(error = %err, "database JSON map was not string-valued");
+        ApiError::Internal
+    })
+}
+
+fn parse_time_precision(value: &str) -> Result<TimePrecision, ApiError> {
+    match value {
+        "day" => Ok(TimePrecision::Day),
+        "week" => Ok(TimePrecision::Week),
+        "month" => Ok(TimePrecision::Month),
+        "quarter" => Ok(TimePrecision::Quarter),
+        "year" => Ok(TimePrecision::Year),
+        _ => {
+            tracing::error!(
+                time_precision = value,
+                "database returned invalid time precision"
+            );
+            Err(ApiError::Internal)
+        }
+    }
+}
+
+fn parse_observation_status(value: &str) -> Result<ObservationStatus, ApiError> {
+    match value {
+        "normal" => Ok(ObservationStatus::Normal),
+        "estimated" => Ok(ObservationStatus::Estimated),
+        "forecast" => Ok(ObservationStatus::Forecast),
+        "imputed" => Ok(ObservationStatus::Imputed),
+        "missing" => Ok(ObservationStatus::Missing),
+        "provisional" => Ok(ObservationStatus::Provisional),
+        "revised" => Ok(ObservationStatus::Revised),
+        "break" => Ok(ObservationStatus::Break),
+        _ => {
+            tracing::error!(
+                status = value,
+                "database returned invalid observation status"
+            );
+            Err(ApiError::Internal)
+        }
+    }
+}
+
+fn series_key_from_bytes(bytes: Vec<u8>) -> Result<SeriesKey, ApiError> {
+    digest_from_bytes(bytes).map(SeriesKey::from_digest)
+}
+
+fn artifact_id_from_bytes(bytes: Vec<u8>) -> Result<ArtifactId, ApiError> {
+    digest_from_bytes(bytes).map(ArtifactId::from_digest)
+}
+
+fn digest_from_bytes(bytes: Vec<u8>) -> Result<Sha256Digest, ApiError> {
+    let length = bytes.len();
+    let bytes: [u8; SHA256_BYTES] = bytes.try_into().map_err(|_| {
+        tracing::error!(length, "database returned invalid SHA-256 digest length");
+        ApiError::Internal
+    })?;
+    Ok(Sha256Digest::from_bytes(bytes))
+}
+
+fn dataflow_id_from_str(value: String) -> Result<DataflowId, ApiError> {
+    DataflowId::new(value).map_err(invalid_db_id)
+}
+
+fn measure_id_from_str(value: String) -> Result<MeasureId, ApiError> {
+    MeasureId::new(value).map_err(invalid_db_id)
+}
+
+fn invalid_db_id(err: au_kpis_domain::ids::IdError) -> ApiError {
+    tracing::error!(%err, "database returned invalid identifier");
+    ApiError::Internal
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_series_key_is_a_validation_error() {
+        let err = SeriesKey::from_str("not-a-key")
+            .map_err(|err| ApiError::Validation(format!("invalid series_key: {err}")))
+            .unwrap_err();
+
+        assert!(err.to_string().contains("series_key"));
+    }
+}

--- a/crates/au-kpis-api-http/tests/routes.rs
+++ b/crates/au-kpis-api-http/tests/routes.rs
@@ -167,6 +167,10 @@ async fn openapi_route_serves_generated_spec() {
         "getDataflowCodelist"
     );
     assert_eq!(
+        parsed["paths"]["/v1/series/{dataflow}/{series_key}"]["get"]["operationId"],
+        "getSeries"
+    );
+    assert_eq!(
         parsed["paths"]["/v1/health"]["get"]["responses"]["408"]["content"]["application/problem+json"]
             ["schema"]["$ref"],
         "#/components/schemas/ProblemDetails"
@@ -248,6 +252,37 @@ async fn dataflows_route_validates_frequency_before_db_access() {
             .detail
             .as_deref()
             .is_some_and(|detail| detail.contains("frequency"))
+    );
+}
+
+#[tokio::test]
+async fn series_route_validates_series_key_before_db_access() {
+    let response = router(test_state())
+        .expect("router")
+        .oneshot(
+            Request::builder()
+                .uri("/v1/series/abs.cpi/not-a-hex-key")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/problem+json"
+    );
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let parsed: ProblemDetails = serde_json::from_slice(&body).expect("problem details json");
+    assert!(
+        parsed
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("series_key"))
     );
 }
 

--- a/crates/au-kpis-api-http/tests/series.rs
+++ b/crates/au-kpis-api-http/tests/series.rs
@@ -1,0 +1,303 @@
+use std::{collections::BTreeMap, sync::Arc, time::Duration};
+
+use au_kpis_api_http::{AppState, router};
+use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
+use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_domain::ids::{ArtifactId, DataflowId, SeriesKey};
+use au_kpis_telemetry::Telemetry;
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header},
+};
+use chrono::{TimeZone, Utc};
+use serde_json::json;
+use sqlx::PgPool;
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+#[derive(Debug, Default)]
+struct NoopCacheBackend;
+
+#[async_trait::async_trait]
+impl CacheBackend for NoopCacheBackend {
+    async fn get(&self, _key: &str) -> Result<Option<String>, CacheError> {
+        Ok(None)
+    }
+
+    async fn set(&self, _key: &str, _value: String, _ttl: Duration) -> Result<(), CacheError> {
+        Ok(())
+    }
+
+    async fn delete(&self, _key: &str) -> Result<bool, CacheError> {
+        Ok(false)
+    }
+
+    async fn take_token_bucket(
+        &self,
+        _key: &str,
+        _config: TokenBucketConfig,
+        _requested: u32,
+        _now_ms: u64,
+    ) -> Result<RateLimitDecision, CacheError> {
+        Ok(RateLimitDecision {
+            allowed: true,
+            remaining: 0,
+            retry_after: Duration::ZERO,
+        })
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn series_endpoint_returns_metadata_latest_observation_and_revision_metadata() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let db = TestDb::start("au_kpis_api_series").await;
+    let series_key = seed_series(db.pool()).await;
+    let app = router(test_state(db.pool().clone())).expect("router");
+
+    let response = app
+        .clone()
+        .oneshot(request(&format!("/v1/series/abs.cpi/{series_key}")))
+        .await
+        .expect("series response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/json"
+    );
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("series body");
+    let parsed: serde_json::Value = serde_json::from_slice(&body).expect("series json");
+    assert_eq!(parsed["series"]["series_key"], series_key.to_string());
+    assert_eq!(parsed["series"]["dataflow_id"], "abs.cpi");
+    assert_eq!(parsed["series"]["dimensions"], json!({ "region": "AUS" }));
+    assert_eq!(parsed["latest_observation"]["value"], 136.9);
+    assert_eq!(parsed["latest_observation"]["revision_no"], 1);
+    assert_eq!(parsed["revision"]["revision_no"], 1);
+    assert_eq!(parsed["revision"]["is_revision"], true);
+    assert_eq!(
+        parsed["revision"]["source_artifact_id"],
+        ArtifactId::of_content(b"api series fixture").to_string()
+    );
+
+    let wrong_dataflow = app
+        .clone()
+        .oneshot(request(&format!("/v1/series/rba.cash_rate/{series_key}")))
+        .await
+        .expect("wrong dataflow response");
+    assert_eq!(wrong_dataflow.status(), StatusCode::NOT_FOUND);
+
+    let missing_key = SeriesKey::derive(
+        &DataflowId::new("abs.cpi").unwrap(),
+        [("region", "MISSING")],
+    );
+    let missing = app
+        .oneshot(request(&format!("/v1/series/abs.cpi/{missing_key}")))
+        .await
+        .expect("missing response");
+    assert_eq!(missing.status(), StatusCode::NOT_FOUND);
+}
+
+fn request(uri: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .body(Body::empty())
+        .expect("request")
+}
+
+fn test_state(db: PgPool) -> AppState {
+    AppState::new(
+        db,
+        Arc::new(CacheClient::from_backend(NoopCacheBackend)),
+        Arc::new(AppConfig {
+            http: HttpConfig {
+                bind: "127.0.0.1:0".into(),
+                cors_allowed_origins: Vec::new(),
+                shutdown_grace_period_secs: 30,
+            },
+            database: DatabaseConfig {
+                url: "postgres://postgres:postgres@localhost/au_kpis".into(),
+            },
+            cache: au_kpis_config::CacheConfig {
+                url: "redis://127.0.0.1:6379".into(),
+            },
+            telemetry: TelemetryConfig {
+                service_name: "au-kpis-test".into(),
+                log_format: LogFormat::Json,
+                log_level: "info".into(),
+                otlp_endpoint: None,
+            },
+        }),
+        Arc::new(Telemetry::disabled()),
+        CancellationToken::new(),
+    )
+}
+
+#[derive(Debug)]
+struct TestDb {
+    pool: PgPool,
+    _timescale: au_kpis_testing::timescale::TimescaleHarness,
+}
+
+impl TestDb {
+    async fn start(database: &str) -> Self {
+        let timescale = au_kpis_testing::timescale::start_timescale(database)
+            .await
+            .expect("start timescale test container");
+        let cfg = DatabaseConfig {
+            url: timescale.url().to_string(),
+        };
+
+        let mut last_err = None;
+        for _ in 0..10 {
+            match au_kpis_db::connect(&cfg).await {
+                Ok(pool) => {
+                    au_kpis_db::migrate(&pool).await.expect("apply migrations");
+                    return Self {
+                        pool,
+                        _timescale: timescale,
+                    };
+                }
+                Err(err) => {
+                    last_err = Some(err);
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            }
+        }
+        panic!("timescaledb did not accept connections: {last_err:?}");
+    }
+
+    fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+async fn seed_series(pool: &PgPool) -> SeriesKey {
+    sqlx::query(
+        "INSERT INTO sources (id, name, homepage, description)
+         VALUES
+         ('abs', 'Australian Bureau of Statistics', 'https://www.abs.gov.au', NULL),
+         ('rba', 'Reserve Bank of Australia', 'https://www.rba.gov.au', NULL)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert sources");
+
+    sqlx::query(
+        "INSERT INTO measures (id, name, description, unit, scale)
+         VALUES ('index', 'CPI index', NULL, 'index', NULL)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert measure");
+
+    sqlx::query(
+        "INSERT INTO dataflows (
+             id, source_id, name, description, dimensions, measures,
+             frequency, license, attribution, source_url
+         )
+         VALUES
+         (
+             'abs.cpi', 'abs', 'Consumer Price Index', NULL,
+             ARRAY['region'], ARRAY['index'], 'quarterly', 'CC-BY-4.0',
+             'Source: Australian Bureau of Statistics',
+             'https://www.abs.gov.au/statistics/economy/price-indexes-and-inflation/consumer-price-index-australia'
+         ),
+         (
+             'rba.cash_rate', 'rba', 'Cash Rate Target', NULL,
+             ARRAY['measure'], ARRAY['rate'], 'daily', 'CC-BY-4.0',
+             'Source: Reserve Bank of Australia',
+             'https://www.rba.gov.au/statistics/cash-rate/'
+         )",
+    )
+    .execute(pool)
+    .await
+    .expect("insert dataflows");
+
+    let dataflow = DataflowId::new("abs.cpi").unwrap();
+    let dimensions: BTreeMap<String, String> = [("region".to_string(), "AUS".to_string())]
+        .into_iter()
+        .collect();
+    let series_key = SeriesKey::derive(
+        &dataflow,
+        dimensions
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    );
+    sqlx::query(
+        "INSERT INTO series (
+             series_key, dataflow_id, measure_id, dimensions, unit,
+             first_observed, last_observed, active
+         )
+         VALUES ($1, 'abs.cpi', 'index', $2, 'index', $3, $4, true)",
+    )
+    .bind(series_key.digest().as_bytes().as_slice())
+    .bind(json!(dimensions))
+    .bind(Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap())
+    .bind(Utc.with_ymd_and_hms(2024, 6, 1, 0, 0, 0).unwrap())
+    .execute(pool)
+    .await
+    .expect("insert series");
+
+    let artifact = ArtifactId::of_content(b"api series fixture");
+    sqlx::query(
+        "INSERT INTO artifacts (
+             id, source_id, source_url, content_type, response_headers,
+             size_bytes, storage_key, fetched_at
+         )
+         VALUES ($1, 'abs', 'https://example.test/cpi.json', 'application/json',
+                 '{}'::jsonb, 128, $2, $3)",
+    )
+    .bind(artifact.digest().as_bytes().as_slice())
+    .bind(format!("artifacts/{artifact}"))
+    .bind(Utc.with_ymd_and_hms(2024, 7, 24, 0, 0, 0).unwrap())
+    .execute(pool)
+    .await
+    .expect("insert artifact");
+
+    insert_observation(pool, series_key, artifact, (2024, 3, 1), 0, 135.0).await;
+    insert_observation(pool, series_key, artifact, (2024, 6, 1), 0, 136.2).await;
+    insert_observation(pool, series_key, artifact, (2024, 6, 1), 1, 136.9).await;
+
+    series_key
+}
+
+async fn insert_observation(
+    pool: &PgPool,
+    series_key: SeriesKey,
+    artifact: ArtifactId,
+    date: (i32, u32, u32),
+    revision_no: i32,
+    value: f64,
+) {
+    sqlx::query(
+        "INSERT INTO observations (
+             series_key, time, revision_no, time_precision, value, status,
+             attributes, ingested_at, source_artifact_id
+         )
+         VALUES ($1, $2, $3, 'quarter', $4, 'normal',
+                 '{}'::jsonb, $5, $6)",
+    )
+    .bind(series_key.digest().as_bytes().as_slice())
+    .bind(
+        Utc.with_ymd_and_hms(date.0, date.1, date.2, 0, 0, 0)
+            .unwrap(),
+    )
+    .bind(revision_no)
+    .bind(value)
+    .bind(Utc.with_ymd_and_hms(2024, 7, 24, 0, 0, 0).unwrap())
+    .bind(artifact.digest().as_bytes().as_slice())
+    .execute(pool)
+    .await
+    .expect("insert observation");
+}
+
+fn docker_available() -> bool {
+    std::env::var_os("DOCKER_HOST").is_some()
+        || std::path::Path::new("/var/run/docker.sock").exists()
+}

--- a/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
+++ b/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
@@ -347,6 +347,66 @@ expression: emitted_spec()
         "description": "Identifier for a measure (e.g. `unemployment_rate`).",
         "type": "string"
       },
+      "Observation": {
+        "description": "One observation — a single row in the `observations` hypertable.",
+        "properties": {
+          "attributes": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "description": "Free-form attributes attached to this observation (e.g. SDMX `OBS_STATUS`\nor adapter-specific annotations).",
+            "propertyNames": {
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "ingested_at": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "revision_no": {
+            "description": "`0` for the original publication; `N` for the Nth revision.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "series_key": {
+            "$ref": "#/components/schemas/SeriesKey"
+          },
+          "source_artifact_id": {
+            "$ref": "#/components/schemas/ArtifactId"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ObservationStatus"
+          },
+          "time": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "time_precision": {
+            "$ref": "#/components/schemas/TimePrecision"
+          },
+          "value": {
+            "description": "`None` when `status = Missing`.",
+            "format": "double",
+            "type": [
+              "number",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "series_key",
+          "time",
+          "time_precision",
+          "status",
+          "revision_no",
+          "attributes",
+          "ingested_at",
+          "source_artifact_id"
+        ],
+        "type": "object"
+      },
       "ObservationStatus": {
         "description": "Observation status flags sourced from SDMX. Subset in use across Australian\npublishers; extend as new codes appear in upstream feeds.",
         "enum": [
@@ -554,12 +614,133 @@ expression: emitted_spec()
         ],
         "type": "object"
       },
+      "Series": {
+        "description": "One time series within a dataflow. `dimensions` is the sorted bag of\n`(key, value)` pairs that, together with `dataflow_id`, seeds `series_key`.",
+        "properties": {
+          "active": {
+            "description": "Whether the upstream source still publishes this series. Inactive\nseries are retained for historical queries but excluded from the\ndefault `/v1/series` listing.",
+            "type": "boolean"
+          },
+          "dataflow_id": {
+            "$ref": "#/components/schemas/DataflowId"
+          },
+          "dimensions": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CodeId"
+            },
+            "description": "Dimension values keyed by typed dimension ids and code ids. Stored\nsorted (via `BTreeMap`) so iteration order is stable across\nserialisation + re-hashing.",
+            "propertyNames": {
+              "description": "Identifier for a dimension within a dataflow (e.g. `region`).",
+              "type": "string"
+            },
+            "type": "object"
+          },
+          "first_observed": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "last_observed": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "measure_id": {
+            "$ref": "#/components/schemas/MeasureId"
+          },
+          "series_key": {
+            "$ref": "#/components/schemas/SeriesKey"
+          },
+          "unit": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "series_key",
+          "dataflow_id",
+          "measure_id",
+          "dimensions",
+          "unit",
+          "active"
+        ],
+        "type": "object"
+      },
       "SeriesKey": {
         "description": "Lowercase hex-encoded SHA-256 digest (64 chars).",
         "format": "sha256-hex",
         "maxLength": 64,
         "minLength": 64,
         "type": "string"
+      },
+      "SeriesLookupResponse": {
+        "description": "Response envelope for `GET /v1/series/{dataflow}/{series_key}`.",
+        "properties": {
+          "latest_observation": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Observation",
+                "description": "Latest observation by timestamp, using `observations_latest` revision selection."
+              }
+            ]
+          },
+          "revision": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SeriesRevisionMetadata",
+                "description": "Revision metadata for `latest_observation`."
+              }
+            ]
+          },
+          "series": {
+            "$ref": "#/components/schemas/Series",
+            "description": "Series metadata."
+          }
+        },
+        "required": [
+          "series"
+        ],
+        "type": "object"
+      },
+      "SeriesRevisionMetadata": {
+        "description": "Revision details for the latest observation returned with a series lookup.",
+        "properties": {
+          "ingested_at": {
+            "description": "When this revision was ingested.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "is_revision": {
+            "description": "Whether this observation supersedes the original publication.",
+            "type": "boolean"
+          },
+          "revision_no": {
+            "description": "Latest revision number for the observation timestamp.",
+            "format": "int32",
+            "minimum": 0,
+            "type": "integer"
+          },
+          "source_artifact_id": {
+            "$ref": "#/components/schemas/ArtifactId",
+            "description": "Source artifact that produced this revision."
+          }
+        },
+        "required": [
+          "revision_no",
+          "is_revision",
+          "ingested_at",
+          "source_artifact_id"
+        ],
+        "type": "object"
       },
       "SourceId": {
         "description": "Identifier for an upstream data source (e.g. `abs`, `rba`, `apra`).",
@@ -1030,6 +1211,77 @@ expression: emitted_spec()
         "summary": "`GET /v1/openapi.json`.",
         "tags": []
       }
+    },
+    "/v1/series/{dataflow}/{series_key}": {
+      "get": {
+        "operationId": "getSeries",
+        "parameters": [
+          {
+            "description": "Dataflow id.",
+            "in": "path",
+            "name": "dataflow",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "64-character series key hex digest.",
+            "in": "path",
+            "name": "series_key",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SeriesLookupResponse"
+                }
+              }
+            },
+            "description": "Series metadata and latest observation."
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Invalid path parameter."
+          },
+          "404": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Series not found."
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Internal error."
+          }
+        },
+        "summary": "`GET /v1/series/{dataflow}/{series_key}`.",
+        "tags": [
+          "series"
+        ]
+      }
     }
   },
   "tags": [
@@ -1040,6 +1292,10 @@ expression: emitted_spec()
     {
       "description": "Time-series observations",
       "name": "observations"
+    },
+    {
+      "description": "Series metadata lookups",
+      "name": "series"
     }
   ]
 }

--- a/openapi.json
+++ b/openapi.json
@@ -443,6 +443,75 @@
           }
         }
       }
+    },
+    "/v1/series/{dataflow}/{series_key}": {
+      "get": {
+        "tags": ["series"],
+        "summary": "`GET /v1/series/{dataflow}/{series_key}`.",
+        "operationId": "getSeries",
+        "parameters": [
+          {
+            "name": "dataflow",
+            "in": "path",
+            "description": "Dataflow id.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "series_key",
+            "in": "path",
+            "description": "64-character series key hex digest.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Series metadata and latest observation.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SeriesLookupResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid path parameter.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Series not found.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
     }
   },
   "components": {
@@ -736,6 +805,63 @@
         "type": "string",
         "description": "Identifier for a measure (e.g. `unemployment_rate`)."
       },
+      "Observation": {
+        "type": "object",
+        "description": "One observation — a single row in the `observations` hypertable.",
+        "required": [
+          "series_key",
+          "time",
+          "time_precision",
+          "status",
+          "revision_no",
+          "attributes",
+          "ingested_at",
+          "source_artifact_id"
+        ],
+        "properties": {
+          "attributes": {
+            "type": "object",
+            "description": "Free-form attributes attached to this observation (e.g. SDMX `OBS_STATUS`\nor adapter-specific annotations).",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "propertyNames": {
+              "type": "string"
+            }
+          },
+          "ingested_at": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "revision_no": {
+            "type": "integer",
+            "format": "int32",
+            "description": "`0` for the original publication; `N` for the Nth revision.",
+            "minimum": 0
+          },
+          "series_key": {
+            "$ref": "#/components/schemas/SeriesKey"
+          },
+          "source_artifact_id": {
+            "$ref": "#/components/schemas/ArtifactId"
+          },
+          "status": {
+            "$ref": "#/components/schemas/ObservationStatus"
+          },
+          "time": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "time_precision": {
+            "$ref": "#/components/schemas/TimePrecision"
+          },
+          "value": {
+            "type": ["number", "null"],
+            "format": "double",
+            "description": "`None` when `status = Missing`."
+          }
+        }
+      },
       "ObservationStatus": {
         "type": "string",
         "description": "Observation status flags sourced from SDMX. Subset in use across Australian\npublishers; extend as new codes appear in upstream feeds.",
@@ -918,12 +1044,113 @@
           }
         }
       },
+      "Series": {
+        "type": "object",
+        "description": "One time series within a dataflow. `dimensions` is the sorted bag of\n`(key, value)` pairs that, together with `dataflow_id`, seeds `series_key`.",
+        "required": ["series_key", "dataflow_id", "measure_id", "dimensions", "unit", "active"],
+        "properties": {
+          "active": {
+            "type": "boolean",
+            "description": "Whether the upstream source still publishes this series. Inactive\nseries are retained for historical queries but excluded from the\ndefault `/v1/series` listing."
+          },
+          "dataflow_id": {
+            "$ref": "#/components/schemas/DataflowId"
+          },
+          "dimensions": {
+            "type": "object",
+            "description": "Dimension values keyed by typed dimension ids and code ids. Stored\nsorted (via `BTreeMap`) so iteration order is stable across\nserialisation + re-hashing.",
+            "additionalProperties": {
+              "$ref": "#/components/schemas/CodeId"
+            },
+            "propertyNames": {
+              "type": "string",
+              "description": "Identifier for a dimension within a dataflow (e.g. `region`)."
+            }
+          },
+          "first_observed": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "last_observed": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "measure_id": {
+            "$ref": "#/components/schemas/MeasureId"
+          },
+          "series_key": {
+            "$ref": "#/components/schemas/SeriesKey"
+          },
+          "unit": {
+            "type": "string"
+          }
+        }
+      },
       "SeriesKey": {
         "type": "string",
         "format": "sha256-hex",
         "description": "Lowercase hex-encoded SHA-256 digest (64 chars).",
         "maxLength": 64,
         "minLength": 64
+      },
+      "SeriesLookupResponse": {
+        "type": "object",
+        "description": "Response envelope for `GET /v1/series/{dataflow}/{series_key}`.",
+        "required": ["series"],
+        "properties": {
+          "latest_observation": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/Observation",
+                "description": "Latest observation by timestamp, using `observations_latest` revision selection."
+              }
+            ]
+          },
+          "revision": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SeriesRevisionMetadata",
+                "description": "Revision metadata for `latest_observation`."
+              }
+            ]
+          },
+          "series": {
+            "$ref": "#/components/schemas/Series",
+            "description": "Series metadata."
+          }
+        }
+      },
+      "SeriesRevisionMetadata": {
+        "type": "object",
+        "description": "Revision details for the latest observation returned with a series lookup.",
+        "required": ["revision_no", "is_revision", "ingested_at", "source_artifact_id"],
+        "properties": {
+          "ingested_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "When this revision was ingested."
+          },
+          "is_revision": {
+            "type": "boolean",
+            "description": "Whether this observation supersedes the original publication."
+          },
+          "revision_no": {
+            "type": "integer",
+            "format": "int32",
+            "description": "Latest revision number for the observation timestamp.",
+            "minimum": 0
+          },
+          "source_artifact_id": {
+            "$ref": "#/components/schemas/ArtifactId",
+            "description": "Source artifact that produced this revision."
+          }
+        }
       },
       "SourceId": {
         "type": "string",
@@ -944,6 +1171,10 @@
     {
       "name": "observations",
       "description": "Time-series observations"
+    },
+    {
+      "name": "series",
+      "description": "Series metadata lookups"
     }
   ]
 }


### PR DESCRIPTION
Closes #33

## Summary

- Add `GET /v1/series/{dataflow}/{series_key}` for series metadata plus the latest observation.
- Surface revision metadata for the returned latest observation.
- Document the endpoint and schemas in generated OpenAPI output.

## Pass requirements

- [x] `GET /v1/series/{dataflow}/{series_key}` returns series metadata + latest observation
- [x] Revision metadata surfaced
- [x] `schemathesis` passes

## Test plan

- `cargo test -p au-kpis-api-http -- --nocapture`
- `cargo test -p au-kpis-openapi -- --nocapture`
- `cargo clippy -p au-kpis-api-http --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- OpenAPI normalized drift check
- `gitleaks protect --staged`
- `env -u RUST_LOG cargo nextest run --workspace` (local container-backed tests fail because `/var/run/docker.sock` is unavailable; GitHub CI passed with Docker)
- `cargo sqlx prepare --workspace` (local run cannot prepare existing query macros without a live `DATABASE_URL`; GitHub CI OpenAPI/sqlx-backed checks passed)
- GitHub CI run 26442069643: all gates passed, including `Contract (schemathesis)` and `CI OK`

## Spec impact

No Spec changes required. Endpoint is already in the issue contract and follows the existing API/OpenAPI patterns.