### PR TITLE
test(rust): add property invariant suite (#36)

### DIFF
--- a/crates/au-kpis-api-http/tests/observations.rs
+++ b/crates/au-kpis-api-http/tests/observations.rs
@@ -1,6 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
-use au_kpis_api_http::{AppState, router};
+use au_kpis_api_http::{AppState, ObservationsResponse, router};
 use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
 use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
 use au_kpis_domain::ids::{ArtifactId, DataflowId, SeriesKey};
@@ -140,11 +140,60 @@ async fn observations_endpoint_streams_latest_json_csv_and_cache_headers() {
     assert!(body.contains("# next_cursor="));
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn paginated_observations_concatenate_to_the_full_result() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let db = TestDb::start("au_kpis_api_observations_pagination").await;
+    seed_observations(db.pool()).await;
+    let artifact = ArtifactId::of_content(b"api observations fixture");
+    seed_extra_pagination_observations(db.pool(), artifact).await;
+    let app = router(test_state(db.pool().clone())).expect("router");
+
+    let full = get_observations_json(app.clone(), "/v1/observations?dataflow=abs.cpi&limit=100")
+        .await
+        .observations;
+    assert!(full.len() > 8, "fixture should exercise multiple pages");
+
+    for limit in 1..=5 {
+        let mut cursor = None;
+        let mut paged = Vec::new();
+        for _ in 0..20 {
+            let uri = match &cursor {
+                Some(cursor) => {
+                    format!("/v1/observations?dataflow=abs.cpi&limit={limit}&cursor={cursor}")
+                }
+                None => format!("/v1/observations?dataflow=abs.cpi&limit={limit}"),
+            };
+            let page = get_observations_json(app.clone(), &uri).await;
+            cursor = page.pagination.next_cursor;
+            paged.extend(page.observations);
+            if cursor.is_none() {
+                break;
+            }
+        }
+
+        assert_eq!(paged, full, "page size {limit} did not concatenate cleanly");
+    }
+}
+
 fn request(uri: &str) -> Request<Body> {
     Request::builder()
         .uri(uri)
         .body(Body::empty())
         .expect("request")
+}
+
+async fn get_observations_json(app: axum::Router, uri: &str) -> ObservationsResponse {
+    let response = app.oneshot(request(uri)).await.expect("json response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("json body");
+    serde_json::from_slice(&body).expect("observations response")
 }
 
 fn test_state(db: PgPool) -> AppState {
@@ -285,6 +334,32 @@ async fn seed_observations(pool: &PgPool) {
         ObservationSeed::new(nsw_key, artifact, (2024, 3, 1), 0, 137.1),
     )
     .await;
+}
+
+async fn seed_extra_pagination_observations(pool: &PgPool, artifact: ArtifactId) {
+    for (region, base) in [("VIC", 140.0), ("QLD", 150.0)] {
+        let key = insert_series(pool, region).await;
+        for (offset, date) in [
+            (0.0, (2024, 3, 1)),
+            (1.0, (2024, 6, 1)),
+            (2.0, (2024, 9, 1)),
+        ] {
+            insert_observation(
+                pool,
+                ObservationSeed::new(key, artifact, date, 0, base + offset),
+            )
+            .await;
+        }
+    }
+
+    let aus = SeriesKey::derive(&DataflowId::new("abs.cpi").unwrap(), [("region", "AUS")]);
+    for (offset, date) in [(0.0, (2024, 9, 1)), (1.0, (2024, 12, 1))] {
+        insert_observation(
+            pool,
+            ObservationSeed::new(aus, artifact, date, 0, 138.0 + offset),
+        )
+        .await;
+    }
 }
 
 async fn insert_series(pool: &PgPool, region: &str) -> SeriesKey {

--- a/crates/au-kpis-domain/src/ids.rs
+++ b/crates/au-kpis-domain/src/ids.rs
@@ -379,7 +379,7 @@ impl ObservationId {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, HashSet};
 
     use proptest::prelude::*;
 
@@ -426,6 +426,36 @@ mod tests {
 
         let different = SeriesKey::derive(&df, [("region", "VIC"), ("measure", "index")]);
         assert_ne!(a, different);
+    }
+
+    #[test]
+    fn series_key_has_no_collisions_over_one_million_dimension_combos() {
+        const CASES: usize = 1_000_000;
+
+        let mut seen = HashSet::with_capacity(CASES);
+        let mut seed = 0xa11c_e551_5eed_u64;
+
+        for case in 0..CASES {
+            let dataflow =
+                DataflowId::new(format!("df.{:04}", next_u64(&mut seed) % 10_000)).unwrap();
+            let case_code = format!("C{case:06}");
+            let region = format!("R{:05}", next_u64(&mut seed) % 100_000);
+            let measure = format!("M{:05}", next_u64(&mut seed) % 100_000);
+            let dimensions = [
+                ("case", case_code.as_str()),
+                ("region", region.as_str()),
+                ("measure", measure.as_str()),
+            ];
+
+            let forward = SeriesKey::derive(&dataflow, dimensions);
+            let reverse = SeriesKey::derive(&dataflow, dimensions.into_iter().rev());
+
+            assert_eq!(forward, reverse, "series key changed with dimension order");
+            assert!(
+                seen.insert(forward),
+                "series key collision after {case} unique dimension combinations: {forward}"
+            );
+        }
     }
 
     #[test]
@@ -546,5 +576,10 @@ mod tests {
 
             prop_assert_eq!(forward, backward);
         }
+    }
+
+    fn next_u64(seed: &mut u64) -> u64 {
+        *seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+        *seed
     }
 }

--- a/crates/au-kpis-domain/src/observation.rs
+++ b/crates/au-kpis-domain/src/observation.rs
@@ -56,7 +56,9 @@ pub struct Observation {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::ids::DataflowId;
+    use crate::ids::{ArtifactId, DataflowId, SeriesKey, Sha256Digest};
+    use chrono::TimeZone;
+    use proptest::{collection::btree_map, prelude::*};
 
     #[test]
     fn roundtrips() {
@@ -122,5 +124,89 @@ mod tests {
             serde_json::to_string(&ObservationStatus::Provisional).unwrap(),
             "\"provisional\""
         );
+    }
+
+    fn arb_datetime() -> impl Strategy<Value = DateTime<Utc>> {
+        (946_684_800_i64..1_893_456_000_i64, 0_u32..1_000_000_000_u32)
+            .prop_map(|(secs, nanos)| Utc.timestamp_opt(secs, nanos).single().unwrap())
+    }
+
+    fn arb_time_precision() -> impl Strategy<Value = TimePrecision> {
+        prop_oneof![
+            Just(TimePrecision::Day),
+            Just(TimePrecision::Week),
+            Just(TimePrecision::Month),
+            Just(TimePrecision::Quarter),
+            Just(TimePrecision::Year),
+        ]
+    }
+
+    fn arb_observation_status() -> impl Strategy<Value = ObservationStatus> {
+        prop_oneof![
+            Just(ObservationStatus::Normal),
+            Just(ObservationStatus::Estimated),
+            Just(ObservationStatus::Forecast),
+            Just(ObservationStatus::Imputed),
+            Just(ObservationStatus::Provisional),
+            Just(ObservationStatus::Revised),
+            Just(ObservationStatus::Break),
+        ]
+    }
+
+    fn arb_observation() -> impl Strategy<Value = Observation> {
+        (
+            any::<[u8; 32]>(),
+            arb_datetime(),
+            arb_time_precision(),
+            prop::option::of(
+                (-1_000_000_000_i64..1_000_000_000_i64).prop_map(|value| value as f64 / 100.0),
+            ),
+            arb_observation_status(),
+            0_u32..1_000,
+            btree_map("[A-Z_]{1,16}", "[A-Za-z0-9 ._:/-]{0,48}", 0..8),
+            arb_datetime(),
+            any::<[u8; 32]>(),
+        )
+            .prop_map(
+                |(
+                    series_key,
+                    time,
+                    time_precision,
+                    value,
+                    status,
+                    revision_no,
+                    attributes,
+                    ingested_at,
+                    artifact_id,
+                )| Observation {
+                    series_key: SeriesKey::from_digest(Sha256Digest::from_bytes(series_key)),
+                    time,
+                    time_precision,
+                    value,
+                    status: if value.is_some() {
+                        status
+                    } else {
+                        ObservationStatus::Missing
+                    },
+                    revision_no,
+                    attributes,
+                    ingested_at,
+                    source_artifact_id: ArtifactId::from_digest(Sha256Digest::from_bytes(
+                        artifact_id,
+                    )),
+                },
+            )
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+        #[test]
+        fn observation_json_roundtrips_for_generated_values(obs in arb_observation()) {
+            let json = serde_json::to_string(&obs).unwrap();
+            let back: Observation = serde_json::from_str(&json).unwrap();
+
+            prop_assert_eq!(obs, back);
+        }
     }
 }

--- a/crates/au-kpis-loader/tests/load_batch.rs
+++ b/crates/au-kpis-loader/tests/load_batch.rs
@@ -160,6 +160,25 @@ fn ts(year: i32, month: u32, day: u32) -> DateTime<Utc> {
         .unwrap()
 }
 
+fn permutations<T: Clone>(values: &[T]) -> Vec<Vec<T>> {
+    if values.is_empty() {
+        return vec![Vec::new()];
+    }
+
+    let mut result = Vec::new();
+    for index in 0..values.len() {
+        let mut remaining = values.to_vec();
+        let value = remaining.remove(index);
+        for mut suffix in permutations(&remaining) {
+            let mut order = Vec::with_capacity(values.len());
+            order.push(value.clone());
+            order.append(&mut suffix);
+            result.push(order);
+        }
+    }
+    result
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn upserts_series_and_latest_revision() {
     let _guard = TEST_LOCK.lock().await;
@@ -201,6 +220,49 @@ async fn upserts_series_and_latest_revision() {
     assert_eq!(row.get::<DateTime<Utc>, _>("last_observed"), time);
     assert_eq!(row.get::<i32, _>("revision_no"), 1);
     assert_eq!(row.get::<Option<f64>, _>("value"), Some(135.0));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn latest_revision_wins_for_every_insertion_order() {
+    let _guard = TEST_LOCK.lock().await;
+    let db = test_db().await;
+    let pool = &db.pool;
+    let artifact_id = ArtifactId::of_content(b"loader revision permutation fixture");
+    seed_reference_data(pool, artifact_id).await;
+    let aus = descriptor("AUS");
+    let revisions = [(0_u32, 134.2), (1, 135.0), (2, 133.9), (3, 136.4)];
+    let orders = permutations(&revisions);
+
+    for (case, order) in orders.iter().enumerate() {
+        let time = ts(2024, 3, 1) + ChronoDuration::days(case as i64);
+        let rows = order
+            .iter()
+            .map(|(revision_no, value)| item(&aus, artifact_id, time, *revision_no, *value))
+            .collect();
+        let stats = load_batch(pool, rows)
+            .await
+            .expect("load revision permutation");
+
+        assert_eq!(stats.observations_loaded, revisions.len() as u64);
+        assert_eq!(stats.parse_errors, 0);
+    }
+
+    let rows = sqlx::query(
+        "SELECT time, revision_no, value
+         FROM observations_latest
+         WHERE series_key = $1
+         ORDER BY time",
+    )
+    .bind(aus.series_key.digest().as_bytes().as_slice())
+    .fetch_all(pool)
+    .await
+    .expect("fetch latest revisions");
+
+    assert_eq!(rows.len(), orders.len());
+    for row in rows {
+        assert_eq!(row.get::<i32, _>("revision_no"), 3);
+        assert_eq!(row.get::<Option<f64>, _>("value"), Some(136.4));
+    }
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
Closes #36

## Pass requirements

- [x] Observation serialize/deserialize round-trip (10k cases)
- [x] `SeriesKey` determinism + no collisions (1M random dimension combos)
- [x] Pagination: `concat(pages) == full_result`
- [x] Revision chain: latest always wins regardless of insertion order

## Test plan

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test -p au-kpis-domain`
- `cargo test -p au-kpis-api-http paginated_observations_concatenate_to_the_full_result --test observations`
- `cargo test -p au-kpis-loader latest_revision_wins_for_every_insertion_order --test load_batch`
- `cargo nextest run --workspace`
- `cargo check --workspace --locked`
- `pnpm run lint`
- `pnpm turbo run typecheck test --cache-dir=.turbo`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks protect --staged`

## Spec impact

No Spec changes required. This implements the `Spec.md § Testing strategy` property-based invariants for issue #36.
