### PR TITLE
feat(web): compare and playground pages (#48)

### DIFF
--- a/apps/web/e2e/compare-playground.spec.ts
+++ b/apps/web/e2e/compare-playground.spec.ts
@@ -1,0 +1,61 @@
+import { AxeBuilder } from '@axe-core/playwright'
+import { expect, test } from '@playwright/test'
+
+test('Compare overlays multiple selected series on one chart', async ({ page }) => {
+  await page.goto('/')
+
+  await page.getByRole('button', { name: 'Compare' }).click()
+
+  await expect(page.getByRole('heading', { name: 'Compare' })).toBeVisible()
+  await expect(page.getByLabel('Dataflow')).toHaveValue('abs.cpi')
+
+  const chart = page.getByTestId('compare-chart')
+  await expect(chart.getByText('Australia', { exact: true })).toBeVisible()
+  await expect(chart.getByText('New South Wales', { exact: true })).toBeVisible()
+  await expect(chart.getByText('Victoria', { exact: true })).toBeVisible()
+
+  await expect(page.getByLabel('Queensland')).not.toBeChecked()
+  await page.getByLabel('Queensland').check()
+
+  await expect(chart.getByText('Queensland')).toBeVisible()
+  await expect(page.getByRole('table', { name: 'Compared series' })).toContainText('138.0')
+})
+
+test('Playground runs a live observations query and shows curl plus SDK snippets', async ({
+  page,
+}) => {
+  await page.goto('/')
+
+  await page.getByRole('button', { name: 'Playground' }).click()
+
+  await expect(page.getByRole('heading', { name: 'Playground' })).toBeVisible()
+  await expect(page.getByLabel('Region')).toContainText('New South Wales')
+  await page.getByLabel('Region').selectOption('NSW')
+  await page.getByLabel('Since').fill('2024-03-01')
+  await page.getByLabel('Limit').fill('2')
+  await page.getByRole('button', { name: 'Run query' }).click()
+
+  const response = page.getByTestId('playground-response')
+  await expect(response).toHaveValue(/"observations"/)
+  await expect(response).toHaveValue(/"region": "NSW"/)
+  await expect(response).toHaveValue(/"value": 139\.2/)
+
+  await expect(page.getByTestId('playground-curl')).toHaveValue(/\/v1\/observations/)
+  await expect(page.getByTestId('playground-curl')).toHaveValue(/dimensions\[region\]=NSW/)
+  await expect(page.getByTestId('playground-sdk')).toHaveValue(/client\.observations\.list/)
+  await expect(page.getByTestId('playground-sdk')).toHaveValue(/region: 'NSW'/)
+})
+
+test('Compare and Playground have no WCAG AA accessibility violations', async ({ page }) => {
+  await page.goto('/')
+
+  await page.getByRole('button', { name: 'Compare' }).click()
+  await expect(page.getByTestId('compare-chart')).toContainText('Australia')
+  let results = await new AxeBuilder({ page }).analyze()
+  expect(results.violations).toEqual([])
+
+  await page.getByRole('button', { name: 'Playground' }).click()
+  await expect(page.getByTestId('playground-response')).toHaveValue(/"observations"/)
+  results = await new AxeBuilder({ page }).analyze()
+  expect(results.violations).toEqual([])
+})

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,68 @@
+import { Button } from '@/components/ui/button'
+import { ComparePage } from '@/pages/Compare'
 import { ExplorerPage } from '@/pages/Explorer'
+import { PlaygroundPage } from '@/pages/Playground'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { Database, GitCompareArrows, LineChart, SquareTerminal } from 'lucide-react'
+import { useState } from 'react'
+
+const queryClient = new QueryClient()
+
+type PageId = 'explorer' | 'compare' | 'playground'
+
+const pages: Array<{
+  icon: typeof LineChart
+  id: PageId
+  label: string
+}> = [
+  { icon: LineChart, id: 'explorer', label: 'Explorer' },
+  { icon: GitCompareArrows, id: 'compare', label: 'Compare' },
+  { icon: SquareTerminal, id: 'playground', label: 'Playground' },
+]
 
 export function App() {
-  return <ExplorerPage />
+  const [activePage, setActivePage] = useState<PageId>('explorer')
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <main className="min-h-screen bg-background text-foreground">
+        <header className="border-b border-border bg-card">
+          <div className="mx-auto flex max-w-7xl flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-3">
+              <span className="flex size-9 items-center justify-center rounded-md bg-primary text-primary-foreground">
+                <Database aria-hidden="true" className="size-4" />
+              </span>
+              <div>
+                <p className="text-sm font-semibold">Australian KPIs</p>
+                <p className="text-xs text-muted-foreground">Reference client</p>
+              </div>
+            </div>
+            <nav aria-label="Primary" className="flex flex-wrap gap-2">
+              {pages.map((page) => {
+                const Icon = page.icon
+                const active = activePage === page.id
+                return (
+                  <Button
+                    aria-current={active ? 'page' : undefined}
+                    key={page.id}
+                    onClick={() => setActivePage(page.id)}
+                    size="sm"
+                    type="button"
+                    variant={active ? 'outline' : 'ghost'}
+                  >
+                    <Icon aria-hidden="true" className="size-4" />
+                    {page.label}
+                  </Button>
+                )
+              })}
+            </nav>
+          </div>
+        </header>
+
+        {activePage === 'explorer' ? <ExplorerPage /> : null}
+        {activePage === 'compare' ? <ComparePage /> : null}
+        {activePage === 'playground' ? <PlaygroundPage /> : null}
+      </main>
+    </QueryClientProvider>
+  )
 }

--- a/apps/web/src/components/field.tsx
+++ b/apps/web/src/components/field.tsx
@@ -1,0 +1,18 @@
+import type { ReactNode } from 'react'
+
+type FieldProps = {
+  children: ReactNode
+  htmlFor: string
+  label: string
+}
+
+export function Field({ children, htmlFor, label }: FieldProps) {
+  return (
+    <div className="flex flex-col gap-2">
+      <label className="text-sm font-medium" htmlFor={htmlFor}>
+        {label}
+      </label>
+      {children}
+    </div>
+  )
+}

--- a/apps/web/src/lib/observations.ts
+++ b/apps/web/src/lib/observations.ts
@@ -1,0 +1,64 @@
+import type { ChartPoint } from '@/components/plot-chart'
+import { client } from '@/lib/api'
+import { formatDate } from '@/lib/format'
+import type { Code, ObservationsRow } from '@au-kpis/sdk-generated/client'
+
+export const nationalRegion = 'AUS'
+
+export const comparisonColors: Record<string, string> = {
+  Australia: '#0f766e',
+  'New South Wales': '#c2410c',
+  Queensland: '#2563eb',
+  Victoria: '#b45309',
+}
+
+export async function collectObservations(
+  dataflow: string,
+  region: string,
+  limit = 100,
+): Promise<ObservationsRow[]> {
+  const observations: ObservationsRow[] = []
+  for await (const observation of client.observations.stream({
+    dataflow,
+    dimensions: { region },
+    limit,
+  })) {
+    observations.push(observation)
+  }
+
+  return observations.sort((left, right) => Date.parse(left.time) - Date.parse(right.time))
+}
+
+export function toChartPoints(rows: ObservationsRow[], region: string): ChartPoint[] {
+  return rows.flatMap((row) =>
+    row.value === null || row.value === undefined
+      ? []
+      : [
+          {
+            date: new Date(row.time),
+            label: formatDate(row.time),
+            region,
+            value: row.value,
+          },
+        ],
+  )
+}
+
+export function regionName(regions: Code[], id: string): string {
+  return regions.find((region) => region.id === id)?.name ?? id
+}
+
+export function regionById(regions: Code[], id: string): Code {
+  return (
+    regions.find((region) => region.id === id) ?? {
+      codelist_id: 'CL_REGION_AU',
+      id,
+      name: id,
+      parent_id: null,
+    }
+  )
+}
+
+export function stateRegions(regions: Code[]): Code[] {
+  return regions.filter((code) => code.id !== nationalRegion && code.parent_id === nationalRegion)
+}

--- a/apps/web/src/pages/Compare.tsx
+++ b/apps/web/src/pages/Compare.tsx
@@ -1,0 +1,276 @@
+import { Field } from '@/components/field'
+import { PlotChart } from '@/components/plot-chart'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { NativeSelect } from '@/components/ui/native-select'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { client } from '@/lib/api'
+import { formatDate, formatValue } from '@/lib/format'
+import {
+  collectObservations,
+  comparisonColors,
+  nationalRegion,
+  regionById,
+  stateRegions,
+  toChartPoints,
+} from '@/lib/observations'
+import type { ObservationsRow } from '@au-kpis/sdk-generated/client'
+import { useQuery } from '@tanstack/react-query'
+import { GitCompareArrows, RefreshCw } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+
+const defaultComparedRegions = [nationalRegion, 'NSW', 'VIC']
+
+export function ComparePage() {
+  const [selectedDataflow, setSelectedDataflow] = useState('abs.cpi')
+  const [selectedRegions, setSelectedRegions] = useState<string[]>(defaultComparedRegions)
+
+  const dataflowsQuery = useQuery({
+    queryFn: () => client.dataflows.list(),
+    queryKey: ['dataflows'],
+  })
+
+  const dataflows = dataflowsQuery.data?.dataflows ?? []
+  const activeDataflow = dataflows.find((dataflow) => dataflow.id === selectedDataflow)
+
+  useEffect(() => {
+    if (activeDataflow === undefined && dataflows[0] !== undefined) {
+      setSelectedDataflow(dataflows[0].id)
+      setSelectedRegions(defaultComparedRegions)
+    }
+  }, [activeDataflow, dataflows])
+
+  const detailQuery = useQuery({
+    enabled: selectedDataflow.length > 0,
+    queryFn: () => client.dataflows.get(selectedDataflow),
+    queryKey: ['dataflow', selectedDataflow],
+  })
+
+  const regionDimension = detailQuery.data?.dimensions.find(
+    (dimension) => dimension.id === 'region',
+  )
+
+  const regionsQuery = useQuery({
+    enabled: selectedDataflow.length > 0 && regionDimension !== undefined,
+    queryFn: () => client.dataflows.codelists(selectedDataflow, 'region'),
+    queryKey: ['codelist', selectedDataflow, 'region'],
+  })
+
+  const regions = regionsQuery.data?.codelist.codes ?? []
+  const regionOptions = useMemo(
+    () => [regionById(regions, nationalRegion), ...stateRegions(regions)],
+    [regions],
+  )
+
+  const comparisonQuery = useQuery({
+    enabled: selectedDataflow.length > 0 && selectedRegions.length > 0 && regions.length > 0,
+    queryFn: async () =>
+      Promise.all(
+        selectedRegions.map(async (regionId) => {
+          const region = regionById(regions, regionId)
+          return {
+            observations: await collectObservations(selectedDataflow, region.id),
+            region,
+          }
+        }),
+      ),
+    queryKey: ['compare-observations', selectedDataflow, selectedRegions.join(',')],
+  })
+
+  const comparisonRows = comparisonQuery.data ?? []
+  const chartPoints = comparisonRows.flatMap(({ observations, region }) =>
+    toChartPoints(observations, region.name),
+  )
+  const latestRows = comparisonRows.map(({ observations, region }) => ({
+    latest: observations.at(-1),
+    region,
+  }))
+
+  const loading = [dataflowsQuery, detailQuery, regionsQuery, comparisonQuery].some(
+    (query) => query.isLoading,
+  )
+  const error = [dataflowsQuery, detailQuery, regionsQuery, comparisonQuery].find(
+    (query) => query.isError,
+  )?.error
+
+  const toggleRegion = (regionId: string, checked: boolean) => {
+    setSelectedRegions((current) => {
+      if (checked) {
+        return current.includes(regionId) ? current : [...current, regionId]
+      }
+      return current.length === 1 ? current : current.filter((id) => id !== regionId)
+    })
+  }
+
+  return (
+    <div className="mx-auto grid max-w-7xl grid-cols-1 gap-5 px-6 py-6 lg:grid-cols-[280px_minmax(0,1fr)]">
+      <aside className="flex flex-col gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Series controls</CardTitle>
+            <CardDescription>Overlay regional series from the same dataflow.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <Field label="Dataflow" htmlFor="compare-dataflow">
+              <NativeSelect
+                disabled={dataflows.length === 0}
+                id="compare-dataflow"
+                onChange={(event) => {
+                  setSelectedDataflow(event.target.value)
+                  setSelectedRegions(defaultComparedRegions)
+                }}
+                value={selectedDataflow}
+              >
+                {dataflows.map((dataflow) => (
+                  <option key={dataflow.id} value={dataflow.id}>
+                    {dataflow.name}
+                  </option>
+                ))}
+              </NativeSelect>
+            </Field>
+
+            <fieldset className="flex flex-col gap-3">
+              <legend className="text-sm font-medium">Series</legend>
+              {regionOptions.map((region) => (
+                <label
+                  className="flex items-center justify-between gap-3 rounded-md border border-border bg-card px-3 py-2 text-sm"
+                  key={region.id}
+                >
+                  <span className="flex items-center gap-2">
+                    <span
+                      aria-hidden="true"
+                      className="size-2 rounded-full"
+                      style={{ backgroundColor: comparisonColors[region.name] ?? '#475569' }}
+                    />
+                    {region.name}
+                  </span>
+                  <input
+                    checked={selectedRegions.includes(region.id)}
+                    className="size-4 accent-primary"
+                    disabled={selectedRegions.length === 1 && selectedRegions.includes(region.id)}
+                    onChange={(event) => toggleRegion(region.id, event.target.checked)}
+                    type="checkbox"
+                  />
+                </label>
+              ))}
+            </fieldset>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Selected series</CardTitle>
+            <CardDescription>{selectedRegions.length} active lines</CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            {activeDataflow?.frequency ?? 'quarterly'} observations ordered by quarter.
+          </CardContent>
+        </Card>
+      </aside>
+
+      <section className="flex min-w-0 flex-col gap-5">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-normal">Compare</h1>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Multiple regional CPI series rendered on one chart for direct comparison.
+          </p>
+        </div>
+
+        {error instanceof Error ? <ErrorBanner message={error.message} /> : null}
+        {loading ? <LoadingBanner /> : null}
+
+        <Card data-testid="compare-chart">
+          <CardHeader className="flex-row items-start justify-between gap-4">
+            <div>
+              <CardTitle>Consumer Price Index</CardTitle>
+              <CardDescription>
+                {activeDataflow?.description ??
+                  'Quarterly Consumer Price Index across Australian regions.'}
+              </CardDescription>
+            </div>
+            <GitCompareArrows aria-hidden="true" className="mt-1 size-5 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <PlotChart
+              ariaLabel="Compared CPI line chart"
+              colors={comparisonColors}
+              data={chartPoints}
+              height={320}
+            />
+            <ul className="mt-3 flex flex-wrap gap-3 text-xs text-muted-foreground">
+              {latestRows.map(({ region }) => (
+                <li className="flex items-center gap-2" key={region.id}>
+                  <span
+                    aria-hidden="true"
+                    className="size-2 rounded-full"
+                    style={{ backgroundColor: comparisonColors[region.name] ?? '#475569' }}
+                  />
+                  {region.name}
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Latest values</CardTitle>
+            <CardDescription>Last observation per selected series.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table aria-label="Compared series">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Region</TableHead>
+                  <TableHead>Quarter</TableHead>
+                  <TableHead className="text-right">Index</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {latestRows.map(({ latest, region }) => (
+                  <TableRow key={region.id}>
+                    <TableCell>{region.name}</TableCell>
+                    <TableCell>
+                      {latest === undefined ? 'waiting' : formatDate(latest.time)}
+                    </TableCell>
+                    <TableCell className="text-right font-medium">
+                      {formatValue(latest?.value)}
+                    </TableCell>
+                    <TableCell>{latest?.status ?? 'waiting'}</TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      </section>
+    </div>
+  )
+}
+
+function ErrorBanner({ message }: { message: string }) {
+  return (
+    <div
+      className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-900"
+      role="alert"
+    >
+      Compare could not load API data: {message}
+    </div>
+  )
+}
+
+function LoadingBanner() {
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-card p-3 text-sm text-muted-foreground">
+      <RefreshCw aria-hidden="true" className="size-4 animate-spin" />
+      Loading comparison data
+    </div>
+  )
+}

--- a/apps/web/src/pages/Explorer.tsx
+++ b/apps/web/src/pages/Explorer.tsx
@@ -1,5 +1,5 @@
-import { type ChartPoint, PlotChart } from '@/components/plot-chart'
-import { Button } from '@/components/ui/button'
+import { Field } from '@/components/field'
+import { PlotChart } from '@/components/plot-chart'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { NativeSelect } from '@/components/ui/native-select'
 import {
@@ -12,32 +12,21 @@ import {
 } from '@/components/ui/table'
 import { apiBaseUrl, client } from '@/lib/api'
 import { formatDate, formatValue } from '@/lib/format'
+import {
+  collectObservations,
+  comparisonColors,
+  nationalRegion,
+  regionName,
+  stateRegions,
+  toChartPoints,
+} from '@/lib/observations'
 import type { Code, ObservationsRow } from '@au-kpis/sdk-generated/client'
-import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query'
-import { Database, LineChart, RefreshCw } from 'lucide-react'
+import { useQuery } from '@tanstack/react-query'
+import { RefreshCw } from 'lucide-react'
 import type { ReactNode } from 'react'
 import { useEffect, useMemo, useState } from 'react'
 
-const queryClient = new QueryClient()
-
-const nationalRegion = 'AUS'
-
-const comparisonColors: Record<string, string> = {
-  Australia: '#0f766e',
-  'New South Wales': '#c2410c',
-  Queensland: '#2563eb',
-  Victoria: '#b45309',
-}
-
 export function ExplorerPage() {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <ExplorerView />
-    </QueryClientProvider>
-  )
-}
-
-function ExplorerView() {
   const [selectedDataflow, setSelectedDataflow] = useState('abs.cpi')
   const [selectedRegion, setSelectedRegion] = useState(nationalRegion)
 
@@ -72,10 +61,7 @@ function ExplorerView() {
   })
 
   const regions = regionsQuery.data?.codelist.codes ?? []
-  const stateRegions = useMemo(
-    () => regions.filter((code) => code.id !== nationalRegion && code.parent_id === nationalRegion),
-    [regions],
-  )
+  const states = useMemo(() => stateRegions(regions), [regions])
 
   const nationalQuery = useQuery({
     enabled: selectedDataflow.length > 0,
@@ -90,17 +76,17 @@ function ExplorerView() {
   })
 
   const comparisonQuery = useQuery({
-    enabled: selectedDataflow.length > 0 && stateRegions.length > 0,
+    enabled: selectedDataflow.length > 0 && states.length > 0,
     queryFn: async () => {
       const rows = await Promise.all(
-        stateRegions.map(async (region) => ({
+        states.map(async (region) => ({
           observations: await collectObservations(selectedDataflow, region.id),
           region,
         })),
       )
       return rows
     },
-    queryKey: ['comparison', selectedDataflow, stateRegions.map((region) => region.id).join(',')],
+    queryKey: ['comparison', selectedDataflow, states.map((region) => region.id).join(',')],
   })
 
   const nationalRows = nationalQuery.data ?? []
@@ -133,198 +119,159 @@ function ExplorerView() {
   ].find((query) => query.isError)?.error
 
   return (
-    <main className="min-h-screen bg-background text-foreground">
-      <header className="border-b border-border bg-card">
-        <div className="mx-auto flex max-w-7xl items-center justify-between px-6 py-4">
-          <div className="flex items-center gap-3">
-            <span className="flex size-9 items-center justify-center rounded-md bg-primary text-primary-foreground">
-              <Database aria-hidden="true" className="size-4" />
-            </span>
-            <div>
-              <p className="text-sm font-semibold">Australian KPIs</p>
-              <p className="text-xs text-muted-foreground">Reference client</p>
+    <div className="mx-auto grid max-w-7xl grid-cols-1 gap-5 px-6 py-6 lg:grid-cols-[280px_minmax(0,1fr)]">
+      <aside className="flex flex-col gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Explorer</CardTitle>
+            <CardDescription>Browse dataflows and dimensions through the SDK.</CardDescription>
+          </CardHeader>
+          <CardContent className="flex flex-col gap-4">
+            <Field label="Dataflow" htmlFor="dataflow">
+              <NativeSelect
+                disabled={dataflows.length === 0}
+                id="dataflow"
+                onChange={(event) => {
+                  setSelectedDataflow(event.target.value)
+                  setSelectedRegion(nationalRegion)
+                }}
+                value={selectedDataflow}
+              >
+                {dataflows.map((dataflow) => (
+                  <option key={dataflow.id} value={dataflow.id}>
+                    {dataflow.name}
+                  </option>
+                ))}
+              </NativeSelect>
+            </Field>
+
+            <Field label="Region" htmlFor="region">
+              <NativeSelect
+                disabled={regions.length === 0}
+                id="region"
+                onChange={(event) => setSelectedRegion(event.target.value)}
+                value={selectedRegion}
+              >
+                {regions.map((region) => (
+                  <option key={region.id} value={region.id}>
+                    {region.name}
+                  </option>
+                ))}
+              </NativeSelect>
+            </Field>
+
+            <div className="rounded-md border border-border bg-muted/40 p-3 text-sm">
+              <p className="font-medium">{activeDataflow?.frequency ?? 'quarterly'}</p>
+              <p className="mt-1 text-muted-foreground">
+                API base: <span className="break-all font-mono text-xs">{apiBaseUrl}</span>
+              </p>
             </div>
-          </div>
-          <nav aria-label="Primary">
-            <Button aria-current="page" size="sm" variant="outline">
-              <LineChart data-icon="inline-start" />
-              Explorer
-            </Button>
-          </nav>
-        </div>
-      </header>
+          </CardContent>
+        </Card>
 
-      <div className="mx-auto grid max-w-7xl grid-cols-1 gap-5 px-6 py-6 lg:grid-cols-[280px_minmax(0,1fr)]">
-        <aside className="flex flex-col gap-4">
-          <Card>
-            <CardHeader>
-              <CardTitle>Explorer</CardTitle>
-              <CardDescription>Browse dataflows and dimensions through the SDK.</CardDescription>
-            </CardHeader>
-            <CardContent className="flex flex-col gap-4">
-              <Field label="Dataflow" htmlFor="dataflow">
-                <NativeSelect
-                  disabled={dataflows.length === 0}
-                  id="dataflow"
-                  onChange={(event) => {
-                    setSelectedDataflow(event.target.value)
-                    setSelectedRegion(nationalRegion)
-                  }}
-                  value={selectedDataflow}
-                >
-                  {dataflows.map((dataflow) => (
-                    <option key={dataflow.id} value={dataflow.id}>
-                      {dataflow.name}
-                    </option>
-                  ))}
-                </NativeSelect>
-              </Field>
+        <Card>
+          <CardHeader>
+            <CardTitle>Latest observation</CardTitle>
+            <CardDescription>{selectedRegionName}</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div data-testid="latest-observation">
+              <p className="text-3xl font-semibold">
+                {formatValue(latestObservation?.value)}
+                <span className="ml-2 text-sm font-normal text-muted-foreground">index</span>
+              </p>
+              <p className="mt-2 text-sm text-muted-foreground">
+                {latestObservation === undefined
+                  ? 'Waiting for observations'
+                  : formatDate(latestObservation.time)}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </aside>
 
-              <Field label="Region" htmlFor="region">
-                <NativeSelect
-                  disabled={regions.length === 0}
-                  id="region"
-                  onChange={(event) => setSelectedRegion(event.target.value)}
-                  value={selectedRegion}
-                >
-                  {regions.map((region) => (
-                    <option key={region.id} value={region.id}>
-                      {region.name}
-                    </option>
-                  ))}
-                </NativeSelect>
-              </Field>
-
-              <div className="rounded-md border border-border bg-muted/40 p-3 text-sm">
-                <p className="font-medium">{activeDataflow?.frequency ?? 'quarterly'}</p>
-                <p className="mt-1 text-muted-foreground">
-                  API base: <span className="break-all font-mono text-xs">{apiBaseUrl}</span>
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Latest observation</CardTitle>
-              <CardDescription>{selectedRegionName}</CardDescription>
-            </CardHeader>
-            <CardContent>
-              <div data-testid="latest-observation">
-                <p className="text-3xl font-semibold">
-                  {formatValue(latestObservation?.value)}
-                  <span className="ml-2 text-sm font-normal text-muted-foreground">index</span>
-                </p>
-                <p className="mt-2 text-sm text-muted-foreground">
-                  {latestObservation === undefined
-                    ? 'Waiting for observations'
-                    : formatDate(latestObservation.time)}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        </aside>
-
-        <section className="flex min-w-0 flex-col gap-5">
-          <div>
-            <h1 className="text-2xl font-semibold tracking-normal">Consumer Price Index</h1>
-            <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
-              {activeDataflow?.description ??
-                'Quarterly Consumer Price Index observations from the Australian Bureau of Statistics.'}
-            </p>
-          </div>
-
-          {error instanceof Error ? <ErrorBanner message={error.message} /> : null}
-          {loading ? <LoadingBanner /> : null}
-
-          <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
-            <ChartCard
-              chart={
-                <PlotChart
-                  ariaLabel="National CPI line chart"
-                  colors={comparisonColors}
-                  data={nationalChart}
-                />
-              }
-              description="Australia, quarterly index"
-              latest={nationalRows.at(-1)}
-              testId="national-cpi-chart"
-              title="National CPI"
-            />
-            <ChartCard
-              chart={
-                <PlotChart
-                  ariaLabel="State comparison line chart"
-                  colors={comparisonColors}
-                  data={stateChart}
-                />
-              }
-              description="State and territory comparison"
-              legend={stateRegions}
-              testId="state-comparison-chart"
-              title="State comparison"
-            />
-          </div>
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Observations</CardTitle>
-              <CardDescription>
-                {selectedRegionName} observations returned by{' '}
-                <code>client.observations.stream()</code>.
-              </CardDescription>
-            </CardHeader>
-            <CardContent>
-              <Table aria-label="Observations">
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Region</TableHead>
-                    <TableHead>Quarter</TableHead>
-                    <TableHead className="text-right">Index</TableHead>
-                    <TableHead>Status</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {selectedRows
-                    .slice()
-                    .reverse()
-                    .map((observation) => (
-                      <TableRow key={`${observation.series_key}-${observation.time}`}>
-                        <TableCell>{selectedRegionName}</TableCell>
-                        <TableCell>{formatDate(observation.time)}</TableCell>
-                        <TableCell className="text-right font-medium">
-                          {formatValue(observation.value)}
-                        </TableCell>
-                        <TableCell>{observation.status}</TableCell>
-                      </TableRow>
-                    ))}
-                </TableBody>
-              </Table>
-            </CardContent>
-          </Card>
-
-          <p className="text-xs text-muted-foreground">
-            {activeDataflow?.attribution ?? 'Source: Australian Bureau of Statistics'}
+      <section className="flex min-w-0 flex-col gap-5">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-normal">Consumer Price Index</h1>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            {activeDataflow?.description ??
+              'Quarterly Consumer Price Index observations from the Australian Bureau of Statistics.'}
           </p>
-        </section>
-      </div>
-    </main>
-  )
-}
+        </div>
 
-type FieldProps = {
-  children: ReactNode
-  htmlFor: string
-  label: string
-}
+        {error instanceof Error ? <ErrorBanner message={error.message} /> : null}
+        {loading ? <LoadingBanner /> : null}
 
-function Field({ children, htmlFor, label }: FieldProps) {
-  return (
-    <div className="flex flex-col gap-2">
-      <label className="text-sm font-medium" htmlFor={htmlFor}>
-        {label}
-      </label>
-      {children}
+        <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
+          <ChartCard
+            chart={
+              <PlotChart
+                ariaLabel="National CPI line chart"
+                colors={comparisonColors}
+                data={nationalChart}
+              />
+            }
+            description="Australia, quarterly index"
+            latest={nationalRows.at(-1)}
+            testId="national-cpi-chart"
+            title="National CPI"
+          />
+          <ChartCard
+            chart={
+              <PlotChart
+                ariaLabel="State comparison line chart"
+                colors={comparisonColors}
+                data={stateChart}
+              />
+            }
+            description="State and territory comparison"
+            legend={states}
+            testId="state-comparison-chart"
+            title="State comparison"
+          />
+        </div>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Observations</CardTitle>
+            <CardDescription>
+              {selectedRegionName} observations returned by{' '}
+              <code>client.observations.stream()</code>.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table aria-label="Observations">
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Region</TableHead>
+                  <TableHead>Quarter</TableHead>
+                  <TableHead className="text-right">Index</TableHead>
+                  <TableHead>Status</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {selectedRows
+                  .slice()
+                  .reverse()
+                  .map((observation) => (
+                    <TableRow key={`${observation.series_key}-${observation.time}`}>
+                      <TableCell>{selectedRegionName}</TableCell>
+                      <TableCell>{formatDate(observation.time)}</TableCell>
+                      <TableCell className="text-right font-medium">
+                        {formatValue(observation.value)}
+                      </TableCell>
+                      <TableCell>{observation.status}</TableCell>
+                    </TableRow>
+                  ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+
+        <p className="text-xs text-muted-foreground">
+          {activeDataflow?.attribution ?? 'Source: Australian Bureau of Statistics'}
+        </p>
+      </section>
     </div>
   )
 }
@@ -392,36 +339,4 @@ function LoadingBanner() {
       Loading CPI data
     </div>
   )
-}
-
-async function collectObservations(dataflow: string, region: string): Promise<ObservationsRow[]> {
-  const observations: ObservationsRow[] = []
-  for await (const observation of client.observations.stream({
-    dataflow,
-    dimensions: { region },
-    limit: 100,
-  })) {
-    observations.push(observation)
-  }
-
-  return observations.sort((left, right) => Date.parse(left.time) - Date.parse(right.time))
-}
-
-function toChartPoints(rows: ObservationsRow[], region: string): ChartPoint[] {
-  return rows.flatMap((row) =>
-    row.value === null || row.value === undefined
-      ? []
-      : [
-          {
-            date: new Date(row.time),
-            label: formatDate(row.time),
-            region,
-            value: row.value,
-          },
-        ],
-  )
-}
-
-function regionName(regions: Code[], id: string): string {
-  return regions.find((region) => region.id === id)?.name ?? id
 }

--- a/apps/web/src/pages/Playground.tsx
+++ b/apps/web/src/pages/Playground.tsx
@@ -1,0 +1,343 @@
+import { Field } from '@/components/field'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { NativeSelect } from '@/components/ui/native-select'
+import { apiBaseUrl, client } from '@/lib/api'
+import { nationalRegion } from '@/lib/observations'
+import { useQuery } from '@tanstack/react-query'
+import { Play, RefreshCw, SquareTerminal } from 'lucide-react'
+import { type FormEvent, useEffect, useMemo, useState } from 'react'
+
+type PlaygroundForm = {
+  dataflow: string
+  limit: string
+  region: string
+  since: string
+  until: string
+}
+
+type PlaygroundParams = {
+  dataflow: string
+  limit: number
+  region: string
+  since?: string
+  until?: string
+}
+
+const initialForm: PlaygroundForm = {
+  dataflow: 'abs.cpi',
+  limit: '4',
+  region: nationalRegion,
+  since: '2024-03-01',
+  until: '',
+}
+
+export function PlaygroundPage() {
+  const [form, setForm] = useState<PlaygroundForm>(initialForm)
+  const [submittedParams, setSubmittedParams] = useState<PlaygroundParams>(() =>
+    normalizeForm(initialForm),
+  )
+
+  const dataflowsQuery = useQuery({
+    queryFn: () => client.dataflows.list(),
+    queryKey: ['dataflows'],
+  })
+
+  const dataflows = dataflowsQuery.data?.dataflows ?? []
+  const activeDataflow = dataflows.find((dataflow) => dataflow.id === form.dataflow)
+
+  useEffect(() => {
+    if (activeDataflow === undefined && dataflows[0] !== undefined) {
+      const nextForm = { ...form, dataflow: dataflows[0].id, region: nationalRegion }
+      setForm(nextForm)
+      setSubmittedParams(normalizeForm(nextForm))
+    }
+  }, [activeDataflow, dataflows, form])
+
+  const detailQuery = useQuery({
+    enabled: form.dataflow.length > 0,
+    queryFn: () => client.dataflows.get(form.dataflow),
+    queryKey: ['dataflow', form.dataflow],
+  })
+
+  const regionDimension = detailQuery.data?.dimensions.find(
+    (dimension) => dimension.id === 'region',
+  )
+
+  const regionsQuery = useQuery({
+    enabled: form.dataflow.length > 0 && regionDimension !== undefined,
+    queryFn: () => client.dataflows.codelists(form.dataflow, 'region'),
+    queryKey: ['codelist', form.dataflow, 'region'],
+  })
+
+  const regions = regionsQuery.data?.codelist.codes ?? []
+
+  const responseQuery = useQuery({
+    enabled: submittedParams.dataflow.length > 0,
+    queryFn: () =>
+      client.observations.list({
+        dataflow: submittedParams.dataflow,
+        dimensions: { region: submittedParams.region },
+        limit: submittedParams.limit,
+        since: submittedParams.since,
+        until: submittedParams.until,
+      }),
+    queryKey: ['playground-observations', submittedParams],
+  })
+
+  const previewParams = useMemo(() => normalizeForm(form), [form])
+  const curlSnippet = useMemo(() => buildCurlSnippet(apiBaseUrl, previewParams), [previewParams])
+  const sdkSnippet = useMemo(() => buildSdkSnippet(previewParams), [previewParams])
+  const responseText =
+    responseQuery.data === undefined
+      ? responseQuery.error instanceof Error
+        ? responseQuery.error.message
+        : 'Loading response'
+      : JSON.stringify(responseQuery.data, null, 2)
+
+  const loading = [dataflowsQuery, detailQuery, regionsQuery, responseQuery].some(
+    (query) => query.isLoading,
+  )
+
+  const runQuery = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    setSubmittedParams(normalizeForm(form))
+  }
+
+  return (
+    <div className="mx-auto grid max-w-7xl grid-cols-1 gap-5 px-6 py-6 xl:grid-cols-[360px_minmax(0,1fr)]">
+      <aside className="flex flex-col gap-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Query controls</CardTitle>
+            <CardDescription>Build and run a live observations query.</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <form className="flex flex-col gap-4" onSubmit={runQuery}>
+              <Field label="Dataflow" htmlFor="playground-dataflow">
+                <NativeSelect
+                  disabled={dataflows.length === 0}
+                  id="playground-dataflow"
+                  onChange={(event) =>
+                    setForm((current) => ({
+                      ...current,
+                      dataflow: event.target.value,
+                      region: nationalRegion,
+                    }))
+                  }
+                  value={form.dataflow}
+                >
+                  {dataflows.map((dataflow) => (
+                    <option key={dataflow.id} value={dataflow.id}>
+                      {dataflow.name}
+                    </option>
+                  ))}
+                </NativeSelect>
+              </Field>
+
+              <Field label="Region" htmlFor="playground-region">
+                <NativeSelect
+                  disabled={regions.length === 0}
+                  id="playground-region"
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, region: event.target.value }))
+                  }
+                  value={form.region}
+                >
+                  {regions.map((region) => (
+                    <option key={region.id} value={region.id}>
+                      {region.name}
+                    </option>
+                  ))}
+                </NativeSelect>
+              </Field>
+
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-1">
+                <Field label="Since" htmlFor="playground-since">
+                  <input
+                    className="h-10 rounded-md border border-border bg-card px-3 text-sm text-foreground shadow-panel outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-ring/20"
+                    id="playground-since"
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, since: event.target.value }))
+                    }
+                    type="date"
+                    value={form.since}
+                  />
+                </Field>
+
+                <Field label="Until" htmlFor="playground-until">
+                  <input
+                    className="h-10 rounded-md border border-border bg-card px-3 text-sm text-foreground shadow-panel outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-ring/20"
+                    id="playground-until"
+                    onChange={(event) =>
+                      setForm((current) => ({ ...current, until: event.target.value }))
+                    }
+                    type="date"
+                    value={form.until}
+                  />
+                </Field>
+              </div>
+
+              <Field label="Limit" htmlFor="playground-limit">
+                <input
+                  className="h-10 rounded-md border border-border bg-card px-3 text-sm text-foreground shadow-panel outline-none transition-colors focus:border-primary focus:ring-2 focus:ring-ring/20"
+                  id="playground-limit"
+                  max={10000}
+                  min={1}
+                  onChange={(event) =>
+                    setForm((current) => ({ ...current, limit: event.target.value }))
+                  }
+                  type="number"
+                  value={form.limit}
+                />
+              </Field>
+
+              <Button type="submit">
+                <Play aria-hidden="true" className="size-4" />
+                Run query
+              </Button>
+            </form>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Request</CardTitle>
+            <CardDescription>{activeDataflow?.frequency ?? 'quarterly'} data</CardDescription>
+          </CardHeader>
+          <CardContent className="text-sm text-muted-foreground">
+            {submittedParams.dataflow} · {submittedParams.region} · limit {submittedParams.limit}
+          </CardContent>
+        </Card>
+      </aside>
+
+      <section className="flex min-w-0 flex-col gap-5">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-normal">Playground</h1>
+          <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+            Try observation filters and copy the equivalent curl or SDK call.
+          </p>
+        </div>
+
+        {loading ? <LoadingBanner /> : null}
+
+        <Card>
+          <CardHeader className="flex-row items-start justify-between gap-4">
+            <div>
+              <CardTitle>Response</CardTitle>
+              <CardDescription>
+                JSON returned by <code>client.observations.list()</code>.
+              </CardDescription>
+            </div>
+            <SquareTerminal aria-hidden="true" className="mt-1 size-5 text-muted-foreground" />
+          </CardHeader>
+          <CardContent>
+            <textarea
+              aria-label="Playground response JSON"
+              className="h-[520px] w-full resize-none overflow-auto rounded-md border border-border bg-muted/40 p-4 font-mono text-xs leading-relaxed text-foreground outline-none focus:border-primary focus:ring-2 focus:ring-ring/20"
+              data-testid="playground-response"
+              readOnly
+              spellCheck={false}
+              value={responseText}
+            />
+          </CardContent>
+        </Card>
+
+        <div className="grid grid-cols-1 gap-5 xl:grid-cols-2">
+          <SnippetCard label="Curl" testId="playground-curl" value={curlSnippet} />
+          <SnippetCard label="SDK" testId="playground-sdk" value={sdkSnippet} />
+        </div>
+      </section>
+    </div>
+  )
+}
+
+function LoadingBanner() {
+  return (
+    <div className="flex items-center gap-2 rounded-md border border-border bg-card p-3 text-sm text-muted-foreground">
+      <RefreshCw aria-hidden="true" className="size-4 animate-spin" />
+      Running observations query
+    </div>
+  )
+}
+
+function SnippetCard({ label, testId, value }: { label: string; testId: string; value: string }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <textarea
+          aria-label={`${label} snippet`}
+          className="min-h-40 w-full resize-none overflow-auto rounded-md border border-border bg-muted/40 p-4 font-mono text-xs leading-relaxed text-foreground outline-none focus:border-primary focus:ring-2 focus:ring-ring/20"
+          data-testid={testId}
+          readOnly
+          spellCheck={false}
+          value={value}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+function normalizeForm(form: PlaygroundForm): PlaygroundParams {
+  return {
+    dataflow: form.dataflow,
+    limit: normalizeLimit(form.limit),
+    region: form.region,
+    since: form.since.length > 0 ? form.since : undefined,
+    until: form.until.length > 0 ? form.until : undefined,
+  }
+}
+
+function normalizeLimit(value: string): number {
+  const parsed = Number.parseInt(value, 10)
+  if (!Number.isFinite(parsed)) {
+    return 10
+  }
+  return Math.min(10_000, Math.max(1, parsed))
+}
+
+function buildCurlSnippet(baseUrl: string, params: PlaygroundParams): string {
+  const lines = [
+    `curl -sS --get '${baseUrl}/v1/observations'`,
+    `  --data-urlencode 'dataflow=${params.dataflow}'`,
+    `  --data-urlencode 'dimensions[region]=${params.region}'`,
+    `  --data-urlencode 'limit=${params.limit}'`,
+  ]
+
+  if (params.since !== undefined) {
+    lines.push(`  --data-urlencode 'since=${params.since}'`)
+  }
+  if (params.until !== undefined) {
+    lines.push(`  --data-urlencode 'until=${params.until}'`)
+  }
+
+  return lines.join(' \\\n')
+}
+
+function buildSdkSnippet(params: PlaygroundParams): string {
+  const lines = [
+    'const response = await client.observations.list({',
+    `  dataflow: '${escapeSnippet(params.dataflow)}',`,
+    '  dimensions: {',
+    `    region: '${escapeSnippet(params.region)}',`,
+    '  },',
+    `  limit: ${params.limit},`,
+  ]
+
+  if (params.since !== undefined) {
+    lines.push(`  since: '${escapeSnippet(params.since)}',`)
+  }
+  if (params.until !== undefined) {
+    lines.push(`  until: '${escapeSnippet(params.until)}',`)
+  }
+
+  lines.push('})')
+  return lines.join('\n')
+}
+
+function escapeSnippet(value: string): string {
+  return value.replaceAll("'", "\\'")
+}


### PR DESCRIPTION
Closes #48

## Pass requirements
- [x] Compare: multiple series overlaid on one chart
- [x] Playground: live query form -> response viewer with curl + SDK snippets
- [x] E2E coverage (Playwright)
- [x] axe-core passes

## Test plan
- cargo fmt --all --check
- RUSTC_WRAPPER= cargo check --workspace --locked
- RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings
- pnpm run lint
- pnpm turbo run typecheck test --cache-dir=.turbo
- pnpm --filter @au-kpis/web build
- gitleaks protect --staged
- cargo audit --db /private/tmp/au-kpis-cargo-home-48/advisory-dbs/advisory-db-3157b0e258782691 --no-fetch --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111
- cargo deny check --disable-fetch --metadata-path /private/tmp/au-kpis-cargo-metadata-48.json

Local sandbox limitations: cargo nextest and Playwright cannot bind local ports or start Testcontainers here (Operation not permitted); pnpm audit cannot resolve registry.npmjs.org. CI is expected to run those gates in the proper environment.

## Spec impact
No Spec changes required.