### PR TITLE
feat(api): catalog search (#43)

### DIFF
--- a/crates/au-kpis-api-http/src/docs.rs
+++ b/crates/au-kpis-api-http/src/docs.rs
@@ -13,6 +13,7 @@ use crate::{
         PaginationMetadata,
     },
     routes::{__path_health, __path_openapi, HealthResponse},
+    search::{__path_search_catalog, SearchQuery, SearchResponse, SearchResult, SearchResultKind},
     series::{__path_get_series, SeriesLookupResponse, SeriesRevisionMetadata},
 };
 
@@ -31,7 +32,8 @@ use crate::{
         get_dataflow,
         get_dataflow_codelist,
         list_observations,
-        get_series
+        get_series,
+        search_catalog
     ),
     components(schemas(
         au_kpis_domain::Code,
@@ -50,12 +52,17 @@ use crate::{
         ObservationsRow,
         PaginationMetadata,
         ProblemDetails,
+        SearchQuery,
+        SearchResponse,
+        SearchResult,
+        SearchResultKind,
         SeriesLookupResponse,
         SeriesRevisionMetadata
     )),
     tags(
         (name = "dataflows", description = "Dataflow catalog and codelists"),
         (name = "observations", description = "Time-series observations"),
+        (name = "search", description = "Ranked catalog search"),
         (name = "series", description = "Series metadata lookups")
     )
 )]

--- a/crates/au-kpis-api-http/src/lib.rs
+++ b/crates/au-kpis-api-http/src/lib.rs
@@ -27,6 +27,7 @@ pub mod docs;
 pub mod error;
 pub mod observations;
 pub mod routes;
+pub mod search;
 pub mod series;
 pub mod state;
 
@@ -41,6 +42,7 @@ pub use observations::{
     list_observations,
 };
 pub use routes::{HealthResponse, health, openapi};
+pub use search::{SearchQuery, SearchResponse, SearchResult, SearchResultKind, search_catalog};
 pub use series::{SeriesLookupResponse, SeriesRevisionMetadata, get_series};
 pub use state::AppState;
 
@@ -84,6 +86,7 @@ pub fn router(state: AppState) -> Result<Router, RouterBuildError> {
             )
             .route("/v1/observations", get(observations::list_observations))
             .route("/v1/series/:dataflow/:series_key", get(series::get_series))
+            .route("/v1/search", get(search::search_catalog))
             .route("/v1/openapi.json", get(openapi)),
         state,
     )

--- a/crates/au-kpis-api-http/src/search.rs
+++ b/crates/au-kpis-api-http/src/search.rs
@@ -1,0 +1,309 @@
+//! `/v1/search` catalog search endpoint.
+
+use std::time::Duration;
+
+use au_kpis_domain::ids::{DataflowId, SourceId};
+use axum::{
+    Json,
+    extract::State,
+    http::{HeaderValue, Uri, header},
+    response::{IntoResponse, Response},
+};
+use serde::{Deserialize, Serialize};
+use sqlx::{PgPool, Row};
+use utoipa::ToSchema;
+
+use crate::{ApiError, AppState};
+
+const SEARCH_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
+const SEARCH_CACHE_CONTROL: &str = "public, max-age=3600, stale-while-revalidate=86400";
+const DEFAULT_LIMIT: u16 = 20;
+const MAX_LIMIT: u16 = 100;
+
+/// Query parameters for `GET /v1/search`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct SearchQuery {
+    /// Search text. Blank queries are rejected.
+    pub q: String,
+    /// Maximum number of catalog results to return.
+    pub limit: Option<u16>,
+}
+
+/// Response envelope for `GET /v1/search`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct SearchResponse {
+    /// Normalized query text used for ranking.
+    pub query: String,
+    /// Ranked catalog matches.
+    pub results: Vec<SearchResult>,
+}
+
+/// A ranked catalog search result.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct SearchResult {
+    /// Matched catalog object type.
+    pub kind: SearchResultKind,
+    /// Stable catalog identifier.
+    pub id: String,
+    /// Human-readable name.
+    pub name: String,
+    /// Optional catalog description.
+    pub description: Option<String>,
+    /// Relevance score. Larger scores rank first.
+    pub score: f64,
+    /// Source id for dataflow results.
+    pub source_id: Option<SourceId>,
+    /// Dataflows directly represented by this match.
+    pub dataflow_ids: Vec<DataflowId>,
+}
+
+/// Catalog object types returned by search.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SearchResultKind {
+    /// A dataflow catalog entry.
+    Dataflow,
+    /// A measure catalog entry.
+    Measure,
+}
+
+/// `GET /v1/search`.
+#[utoipa::path(
+    get,
+    path = "/v1/search",
+    operation_id = "searchCatalog",
+    params(
+        ("q" = String, Query, description = "Search text."),
+        ("limit" = Option<u16>, Query, description = "Maximum number of results, capped at 100.")
+    ),
+    responses(
+        (status = 200, description = "Ranked catalog search results.", body = SearchResponse, content_type = "application/json", headers(
+            ("Cache-Control" = String, description = "Public CDN cache policy.")
+        )),
+        (status = 400, description = "Invalid query.", body = crate::ProblemDetails, content_type = "application/problem+json"),
+        (status = 500, description = "Internal error.", body = crate::ProblemDetails, content_type = "application/problem+json")
+    ),
+    tag = "search"
+)]
+pub async fn search_catalog(State(state): State<AppState>, uri: Uri) -> Result<Response, ApiError> {
+    let query = parse_search_query(uri.query())?;
+    let cache_key = search_cache_key(&query);
+    if let Some(cached) = state.cache.get_json::<SearchResponse>(&cache_key).await? {
+        return Ok(search_response(cached));
+    }
+
+    let response = SearchResponse {
+        results: load_search_results(&state.db, &query).await?,
+        query: query.q,
+    };
+    state
+        .cache
+        .set_json(&cache_key, &response, SEARCH_CACHE_TTL)
+        .await?;
+    Ok(search_response(response))
+}
+
+fn search_response<T>(body: T) -> Response
+where
+    T: Serialize,
+{
+    let mut response = Json(body).into_response();
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        HeaderValue::from_static(SEARCH_CACHE_CONTROL),
+    );
+    response
+}
+
+fn parse_search_query(raw: Option<&str>) -> Result<SearchQuery, ApiError> {
+    let mut q = None;
+    let mut limit = None;
+
+    for (key, value) in url::form_urlencoded::parse(raw.unwrap_or_default().as_bytes()) {
+        match key.as_ref() {
+            "q" => q = Some(value.trim().to_string()),
+            "limit" => limit = Some(parse_limit(&value)?),
+            _ => {}
+        }
+    }
+
+    let q = q.ok_or_else(|| ApiError::Validation("missing search query `q`".into()))?;
+    if q.is_empty() {
+        return Err(ApiError::Validation(
+            "search query `q` must not be blank".into(),
+        ));
+    }
+
+    Ok(SearchQuery { q, limit })
+}
+
+fn parse_limit(value: &str) -> Result<u16, ApiError> {
+    let limit = value
+        .parse::<u16>()
+        .map_err(|err| ApiError::Validation(format!("invalid search limit `{value}`: {err}")))?;
+    Ok(limit.clamp(1, MAX_LIMIT))
+}
+
+fn search_cache_key(query: &SearchQuery) -> String {
+    let limit = query.limit.unwrap_or(DEFAULT_LIMIT);
+    let encoded_query: String = url::form_urlencoded::byte_serialize(query.q.as_bytes()).collect();
+    format!("api:search:q={encoded_query}:limit={limit}")
+}
+
+async fn load_search_results(
+    pool: &PgPool,
+    query: &SearchQuery,
+) -> Result<Vec<SearchResult>, ApiError> {
+    let rows = sqlx::query(
+        "WITH search_input AS (
+            SELECT websearch_to_tsquery('english', $1) AS tsq,
+                   $1::text AS raw
+         ),
+         dataflow_matches AS (
+            SELECT 'dataflow' AS kind,
+                   d.id,
+                   d.name,
+                   d.description,
+                   d.source_id,
+                   ARRAY[d.id]::text[] AS dataflow_ids,
+                   (
+                       ts_rank_cd(
+                           to_tsvector('english', d.name || ' ' || COALESCE(d.description, '')),
+                           si.tsq
+                       )
+                       + GREATEST(
+                           similarity(d.name, si.raw),
+                           similarity(COALESCE(d.description, ''), si.raw)
+                       ) * 0.2
+                       + 0.5
+                   )::double precision AS score
+            FROM dataflows d
+            CROSS JOIN search_input si
+            WHERE to_tsvector('english', d.name || ' ' || COALESCE(d.description, '')) @@ si.tsq
+               OR d.name % si.raw
+               OR d.description % si.raw
+         ),
+         measure_matches AS (
+            SELECT 'measure' AS kind,
+                   m.id,
+                   m.name,
+                   m.description,
+                   NULL::text AS source_id,
+                   COALESCE(
+                       array_agg(DISTINCT d.id ORDER BY d.id) FILTER (WHERE d.id IS NOT NULL),
+                       ARRAY[]::text[]
+                   ) AS dataflow_ids,
+                   (
+                       ts_rank_cd(
+                           to_tsvector('english', m.name || ' ' || COALESCE(m.description, '')),
+                           si.tsq
+                       )
+                       + GREATEST(
+                           similarity(m.name, si.raw),
+                           similarity(COALESCE(m.description, ''), si.raw)
+                       ) * 0.2
+                   )::double precision AS score
+            FROM measures m
+            CROSS JOIN search_input si
+            LEFT JOIN dataflows d ON m.id = ANY(d.measures)
+            WHERE to_tsvector('english', m.name || ' ' || COALESCE(m.description, '')) @@ si.tsq
+               OR m.name % si.raw
+               OR m.description % si.raw
+            GROUP BY m.id, m.name, m.description, si.tsq, si.raw
+         )
+         SELECT kind, id, name, description, source_id, dataflow_ids, score
+         FROM (
+            SELECT * FROM dataflow_matches
+            UNION ALL
+            SELECT * FROM measure_matches
+         ) matches
+         WHERE score > 0
+         ORDER BY score DESC, kind, id
+         LIMIT $2",
+    )
+    .bind(&query.q)
+    .bind(i64::from(query.limit.unwrap_or(DEFAULT_LIMIT)))
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter().map(search_result_from_row).collect()
+}
+
+fn search_result_from_row(row: sqlx::postgres::PgRow) -> Result<SearchResult, ApiError> {
+    let kind = match row.try_get::<String, _>("kind")?.as_str() {
+        "dataflow" => SearchResultKind::Dataflow,
+        "measure" => SearchResultKind::Measure,
+        other => {
+            tracing::error!(kind = other, "database returned invalid search result kind");
+            return Err(ApiError::Internal);
+        }
+    };
+    let source_id = row
+        .try_get::<Option<String>, _>("source_id")?
+        .map(source_id_from_str)
+        .transpose()?;
+    let dataflow_ids = row
+        .try_get::<Vec<String>, _>("dataflow_ids")?
+        .into_iter()
+        .map(dataflow_id_from_str)
+        .collect::<Result<Vec<_>, _>>()?;
+
+    Ok(SearchResult {
+        kind,
+        id: row.try_get("id")?,
+        name: row.try_get("name")?,
+        description: row.try_get("description")?,
+        score: row.try_get("score")?,
+        source_id,
+        dataflow_ids,
+    })
+}
+
+fn source_id_from_str(value: String) -> Result<SourceId, ApiError> {
+    SourceId::new(value).map_err(invalid_db_id)
+}
+
+fn dataflow_id_from_str(value: String) -> Result<DataflowId, ApiError> {
+    DataflowId::new(value).map_err(invalid_db_id)
+}
+
+fn invalid_db_id(err: au_kpis_domain::ids::IdError) -> ApiError {
+    tracing::error!(%err, "database returned invalid identifier");
+    ApiError::Internal
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn search_query_trims_and_cache_key_encodes_form_query() {
+        let query = parse_search_query(Some("q=%20price%20index%20")).unwrap();
+
+        assert_eq!(
+            query,
+            SearchQuery {
+                q: "price index".into(),
+                limit: None,
+            }
+        );
+        assert_eq!(
+            search_cache_key(&query),
+            "api:search:q=price+index:limit=20"
+        );
+    }
+
+    #[test]
+    fn search_query_rejects_missing_or_blank_query() {
+        assert!(parse_search_query(None).is_err());
+        assert!(parse_search_query(Some("q=%20")).is_err());
+    }
+
+    #[test]
+    fn search_query_clamps_limit_to_public_cap() {
+        let query = parse_search_query(Some("q=cpi&limit=1000")).unwrap();
+
+        assert_eq!(query.limit, Some(MAX_LIMIT));
+        assert_eq!(search_cache_key(&query), "api:search:q=cpi:limit=100");
+    }
+}

--- a/crates/au-kpis-api-http/tests/routes.rs
+++ b/crates/au-kpis-api-http/tests/routes.rs
@@ -171,6 +171,10 @@ async fn openapi_route_serves_generated_spec() {
         "getSeries"
     );
     assert_eq!(
+        parsed["paths"]["/v1/search"]["get"]["operationId"],
+        "searchCatalog"
+    );
+    assert_eq!(
         parsed["paths"]["/v1/health"]["get"]["responses"]["408"]["content"]["application/problem+json"]
             ["schema"]["$ref"],
         "#/components/schemas/ProblemDetails"

--- a/crates/au-kpis-api-http/tests/search.rs
+++ b/crates/au-kpis-api-http/tests/search.rs
@@ -1,0 +1,406 @@
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
+
+use au_kpis_api_http::{AppState, router};
+use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
+use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_telemetry::Telemetry;
+use axum::{
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header},
+};
+use serde_json::Value;
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+const LONG_TTL: Duration = Duration::from_secs(60 * 60);
+
+#[derive(Debug, Clone, Default)]
+struct RecordingCacheBackend {
+    inner: Arc<RecordingCacheState>,
+}
+
+#[derive(Debug, Default)]
+struct RecordingCacheState {
+    values: Mutex<BTreeMap<String, String>>,
+    sets: Mutex<Vec<CacheSet>>,
+}
+
+#[derive(Debug, Clone)]
+struct CacheSet {
+    key: String,
+    ttl: Duration,
+}
+
+#[derive(Debug, Clone, Default)]
+struct NoopCacheBackend;
+
+#[async_trait::async_trait]
+impl CacheBackend for NoopCacheBackend {
+    async fn get(&self, _key: &str) -> Result<Option<String>, CacheError> {
+        Ok(None)
+    }
+
+    async fn set(&self, _key: &str, _value: String, _ttl: Duration) -> Result<(), CacheError> {
+        Ok(())
+    }
+
+    async fn delete(&self, _key: &str) -> Result<bool, CacheError> {
+        Ok(false)
+    }
+
+    async fn take_token_bucket(
+        &self,
+        _key: &str,
+        _config: TokenBucketConfig,
+        _requested: u32,
+        _now_ms: u64,
+    ) -> Result<RateLimitDecision, CacheError> {
+        Ok(RateLimitDecision {
+            allowed: true,
+            remaining: 0,
+            retry_after: Duration::ZERO,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl CacheBackend for RecordingCacheBackend {
+    async fn get(&self, key: &str) -> Result<Option<String>, CacheError> {
+        Ok(self
+            .inner
+            .values
+            .lock()
+            .expect("cache values lock")
+            .get(key)
+            .cloned())
+    }
+
+    async fn set(&self, key: &str, value: String, ttl: Duration) -> Result<(), CacheError> {
+        self.inner
+            .values
+            .lock()
+            .expect("cache values lock")
+            .insert(key.to_string(), value);
+        self.inner
+            .sets
+            .lock()
+            .expect("cache sets lock")
+            .push(CacheSet {
+                key: key.to_string(),
+                ttl,
+            });
+        Ok(())
+    }
+
+    async fn delete(&self, key: &str) -> Result<bool, CacheError> {
+        Ok(self
+            .inner
+            .values
+            .lock()
+            .expect("cache values lock")
+            .remove(key)
+            .is_some())
+    }
+
+    async fn take_token_bucket(
+        &self,
+        _key: &str,
+        _config: TokenBucketConfig,
+        _requested: u32,
+        _now_ms: u64,
+    ) -> Result<RateLimitDecision, CacheError> {
+        Ok(RateLimitDecision {
+            allowed: true,
+            remaining: 0,
+            retry_after: Duration::ZERO,
+        })
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_catalog_single_term_query_stays_under_p95_budget() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let db = TestDb::start("au_kpis_api_search_perf").await;
+    seed_catalog(db.pool()).await;
+
+    let app = router(test_state(
+        db.pool().clone(),
+        Arc::new(CacheClient::from_backend(NoopCacheBackend)),
+    ))
+    .expect("router");
+
+    for _ in 0..3 {
+        assert_search_ok(app.clone(), "/v1/search?q=index").await;
+    }
+
+    let mut samples = Vec::with_capacity(30);
+    for _ in 0..30 {
+        let started = Instant::now();
+        assert_search_ok(app.clone(), "/v1/search?q=index").await;
+        samples.push(started.elapsed());
+    }
+    samples.sort_unstable();
+    let p95_index = (samples.len() * 95).div_ceil(100).saturating_sub(1);
+    let p95 = samples[p95_index];
+
+    assert!(
+        p95 < Duration::from_millis(100),
+        "single-term catalog search p95 should stay under 100 ms; p95={p95:?}, samples={samples:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_catalog_returns_ranked_dataflows_and_measures_with_cache() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let db = TestDb::start("au_kpis_api_search").await;
+    seed_catalog(db.pool()).await;
+
+    let cache = RecordingCacheBackend::default();
+    let app = router(test_state(
+        db.pool().clone(),
+        Arc::new(CacheClient::from_backend(cache.clone())),
+    ))
+    .expect("router");
+
+    let response = app
+        .clone()
+        .oneshot(request("/v1/search?q=price%20index"))
+        .await
+        .expect("search response");
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CACHE_CONTROL).unwrap(),
+        "public, max-age=3600, stale-while-revalidate=86400"
+    );
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("search body");
+    let parsed: Value = serde_json::from_slice(&body).expect("search json");
+
+    assert_eq!(parsed["query"], "price index");
+    let results = parsed["results"].as_array().expect("results array");
+    assert!(
+        results.len() >= 2,
+        "expected dataflow and measure matches, got {parsed}"
+    );
+    assert_eq!(results[0]["kind"], "dataflow");
+    assert_eq!(results[0]["id"], "abs.cpi");
+    assert_eq!(results[0]["source_id"], "abs");
+    assert_eq!(results[0]["dataflow_ids"][0], "abs.cpi");
+    assert!(
+        results[0]["score"].as_f64().expect("score") > 0.0,
+        "ranked results should expose positive scores"
+    );
+    assert!(
+        results
+            .iter()
+            .any(|result| result["kind"] == "measure" && result["id"] == "index"),
+        "expected index measure result in {parsed}"
+    );
+    assert!(
+        results.iter().all(|result| result["id"] != "rba.cash_rate"),
+        "unrelated cash-rate dataflow should not match {parsed}"
+    );
+
+    let sets = cache.inner.sets.lock().expect("cache sets lock").clone();
+    assert!(
+        sets.iter()
+            .any(|set| set.key == "api:search:q=price+index:limit=20" && set.ttl >= LONG_TTL),
+        "search response should be cached with a catalog TTL, got {sets:?}"
+    );
+
+    sqlx::query("DELETE FROM dataflows WHERE id = 'abs.cpi'")
+        .execute(db.pool())
+        .await
+        .expect("delete dataflow after cache warm");
+    let cached = app
+        .oneshot(request("/v1/search?q=price%20index"))
+        .await
+        .expect("cached search response");
+    assert_eq!(cached.status(), StatusCode::OK);
+    let body = to_bytes(cached.into_body(), usize::MAX)
+        .await
+        .expect("cached search body");
+    let parsed: Value = serde_json::from_slice(&body).expect("cached search json");
+    assert_eq!(parsed["results"][0]["id"], "abs.cpi");
+}
+
+async fn assert_search_ok(app: axum::Router, uri: &str) {
+    let response = app.oneshot(request(uri)).await.expect("search response");
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("search body");
+    let parsed: Value = serde_json::from_slice(&body).expect("search json");
+    assert!(
+        !parsed["results"]
+            .as_array()
+            .expect("results array")
+            .is_empty(),
+        "expected at least one result for {uri}: {parsed}"
+    );
+}
+
+#[tokio::test]
+async fn search_catalog_rejects_blank_query_before_database_access() {
+    let app = router(test_state(
+        lazy_pool(),
+        Arc::new(CacheClient::from_backend(RecordingCacheBackend::default())),
+    ))
+    .expect("router");
+
+    let response = app
+        .oneshot(request("/v1/search?q=%20%20"))
+        .await
+        .expect("search response");
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/problem+json"
+    );
+}
+
+fn request(uri: &str) -> Request<Body> {
+    Request::builder()
+        .uri(uri)
+        .body(Body::empty())
+        .expect("request")
+}
+
+fn test_state(db: PgPool, cache: Arc<CacheClient>) -> AppState {
+    AppState::new(
+        db,
+        cache,
+        Arc::new(AppConfig {
+            http: HttpConfig {
+                bind: "127.0.0.1:0".into(),
+                cors_allowed_origins: Vec::new(),
+                shutdown_grace_period_secs: 30,
+            },
+            database: DatabaseConfig {
+                url: "postgres://postgres:postgres@localhost/au_kpis".into(),
+            },
+            cache: au_kpis_config::CacheConfig {
+                url: "redis://127.0.0.1:6379".into(),
+            },
+            telemetry: TelemetryConfig {
+                service_name: "au-kpis-test".into(),
+                log_format: LogFormat::Json,
+                log_level: "info".into(),
+                otlp_endpoint: None,
+            },
+        }),
+        Arc::new(Telemetry::disabled()),
+        CancellationToken::new(),
+    )
+}
+
+fn lazy_pool() -> PgPool {
+    PgPoolOptions::new()
+        .max_connections(1)
+        .connect_lazy("postgres://postgres:postgres@127.0.0.1/au_kpis_unreachable")
+        .expect("lazy postgres pool")
+}
+
+#[derive(Debug)]
+struct TestDb {
+    pool: PgPool,
+    _timescale: au_kpis_testing::timescale::TimescaleHarness,
+}
+
+impl TestDb {
+    async fn start(database: &str) -> Self {
+        let timescale = au_kpis_testing::timescale::start_timescale(database)
+            .await
+            .expect("start timescale test container");
+        let cfg = DatabaseConfig {
+            url: timescale.url().to_string(),
+        };
+
+        let mut last_err = None;
+        for _ in 0..10 {
+            match au_kpis_db::connect(&cfg).await {
+                Ok(pool) => {
+                    au_kpis_db::migrate(&pool).await.expect("apply migrations");
+                    return Self {
+                        pool,
+                        _timescale: timescale,
+                    };
+                }
+                Err(err) => {
+                    last_err = Some(err);
+                    tokio::time::sleep(Duration::from_millis(500)).await;
+                }
+            }
+        }
+        panic!("timescaledb did not accept connections: {last_err:?}");
+    }
+
+    fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+}
+
+async fn seed_catalog(pool: &PgPool) {
+    sqlx::query(
+        "INSERT INTO sources (id, name, homepage, description)
+         VALUES
+         ('abs', 'Australian Bureau of Statistics', 'https://www.abs.gov.au', NULL),
+         ('rba', 'Reserve Bank of Australia', 'https://www.rba.gov.au', NULL)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert sources");
+
+    sqlx::query(
+        "INSERT INTO measures (id, name, description, unit, scale)
+         VALUES
+         ('index', 'Index', 'Price index level', 'index', NULL),
+         ('rate', 'Rate', 'Interest rate percent', 'percent', NULL)",
+    )
+    .execute(pool)
+    .await
+    .expect("insert measures");
+
+    sqlx::query(
+        "INSERT INTO dataflows (
+             id, source_id, name, description, dimensions, measures,
+             frequency, license, attribution, source_url
+         )
+         VALUES
+         (
+             'abs.cpi', 'abs', 'Consumer Price Index',
+             'Quarterly CPI across Australian regions.',
+             ARRAY['region', 'measure'], ARRAY['index'], 'quarterly', 'CC-BY-4.0',
+             'Source: Australian Bureau of Statistics',
+             'https://www.abs.gov.au/statistics/economy/price-indexes-and-inflation/consumer-price-index-australia'
+         ),
+         (
+             'rba.cash_rate', 'rba', 'Cash Rate Target', NULL,
+             ARRAY['measure'], ARRAY['rate'], 'daily', 'CC-BY-4.0',
+             'Source: Reserve Bank of Australia',
+             'https://www.rba.gov.au/statistics/cash-rate/'
+         )",
+    )
+    .execute(pool)
+    .await
+    .expect("insert dataflows");
+}
+
+fn docker_available() -> bool {
+    std::env::var_os("DOCKER_HOST").is_some()
+        || std::path::Path::new("/var/run/docker.sock").exists()
+}

--- a/crates/au-kpis-db/tests/migrations.rs
+++ b/crates/au-kpis-db/tests/migrations.rs
@@ -64,6 +64,22 @@ async fn has_compression_policy(pool: &PgPool, name: &str) -> bool {
     row.0
 }
 
+async fn index_exists(pool: &PgPool, name: &str) -> bool {
+    let row: (bool,) = sqlx::query_as(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM   pg_indexes
+            WHERE  schemaname = 'public'
+            AND    indexname = $1
+        )",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("query index existence");
+    row.0
+}
+
 async fn column_default(pool: &PgPool, table: &str, column: &str) -> Option<String> {
     sqlx::query_scalar(
         "SELECT column_default
@@ -174,6 +190,20 @@ async fn migration_creates_hypertable_and_compression_policy() {
         assert!(
             table_names.contains(&expected),
             "expected `{expected}` to exist; found {table_names:?}"
+        );
+    }
+
+    for expected in [
+        "dataflows_search_tsv_gin",
+        "dataflows_name_trgm_gin",
+        "dataflows_description_trgm_gin",
+        "measures_search_tsv_gin",
+        "measures_name_trgm_gin",
+        "measures_description_trgm_gin",
+    ] {
+        assert!(
+            index_exists(&pool, expected).await,
+            "expected catalog search index `{expected}` to exist"
         );
     }
 }

--- a/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
+++ b/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
@@ -614,6 +614,112 @@ expression: emitted_spec()
         ],
         "type": "object"
       },
+      "SearchQuery": {
+        "description": "Query parameters for `GET /v1/search`.",
+        "properties": {
+          "limit": {
+            "description": "Maximum number of catalog results to return.",
+            "format": "int32",
+            "minimum": 0,
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "q": {
+            "description": "Search text. Blank queries are rejected.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "q"
+        ],
+        "type": "object"
+      },
+      "SearchResponse": {
+        "description": "Response envelope for `GET /v1/search`.",
+        "properties": {
+          "query": {
+            "description": "Normalized query text used for ranking.",
+            "type": "string"
+          },
+          "results": {
+            "description": "Ranked catalog matches.",
+            "items": {
+              "$ref": "#/components/schemas/SearchResult"
+            },
+            "type": "array"
+          }
+        },
+        "required": [
+          "query",
+          "results"
+        ],
+        "type": "object"
+      },
+      "SearchResult": {
+        "description": "A ranked catalog search result.",
+        "properties": {
+          "dataflow_ids": {
+            "description": "Dataflows directly represented by this match.",
+            "items": {
+              "$ref": "#/components/schemas/DataflowId"
+            },
+            "type": "array"
+          },
+          "description": {
+            "description": "Optional catalog description.",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "id": {
+            "description": "Stable catalog identifier.",
+            "type": "string"
+          },
+          "kind": {
+            "$ref": "#/components/schemas/SearchResultKind",
+            "description": "Matched catalog object type."
+          },
+          "name": {
+            "description": "Human-readable name.",
+            "type": "string"
+          },
+          "score": {
+            "description": "Relevance score. Larger scores rank first.",
+            "format": "double",
+            "type": "number"
+          },
+          "source_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceId",
+                "description": "Source id for dataflow results."
+              }
+            ]
+          }
+        },
+        "required": [
+          "kind",
+          "id",
+          "name",
+          "score",
+          "dataflow_ids"
+        ],
+        "type": "object"
+      },
+      "SearchResultKind": {
+        "description": "Catalog object types returned by search.",
+        "enum": [
+          "dataflow",
+          "measure"
+        ],
+        "type": "string"
+      },
       "Series": {
         "description": "One time series within a dataflow. `dimensions` is the sorted bag of\n`(key, value)` pairs that, together with `dataflow_id`, seeds `series_key`.",
         "properties": {
@@ -1212,6 +1318,77 @@ expression: emitted_spec()
         "tags": []
       }
     },
+    "/v1/search": {
+      "get": {
+        "operationId": "searchCatalog",
+        "parameters": [
+          {
+            "description": "Search text.",
+            "in": "query",
+            "name": "q",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Maximum number of results, capped at 100.",
+            "in": "query",
+            "name": "limit",
+            "required": false,
+            "schema": {
+              "format": "int32",
+              "minimum": 0,
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            },
+            "description": "Ranked catalog search results.",
+            "headers": {
+              "Cache-Control": {
+                "description": "Public CDN cache policy.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Invalid query."
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Internal error."
+          }
+        },
+        "summary": "`GET /v1/search`.",
+        "tags": [
+          "search"
+        ]
+      }
+    },
     "/v1/series/{dataflow}/{series_key}": {
       "get": {
         "operationId": "getSeries",
@@ -1292,6 +1469,10 @@ expression: emitted_spec()
     {
       "description": "Time-series observations",
       "name": "observations"
+    },
+    {
+      "description": "Ranked catalog search",
+      "name": "search"
     },
     {
       "description": "Series metadata lookups",

--- a/infra/migrations/0004_catalog_search.down.sql
+++ b/infra/migrations/0004_catalog_search.down.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS measures_description_trgm_gin;
+DROP INDEX IF EXISTS measures_name_trgm_gin;
+DROP INDEX IF EXISTS measures_search_tsv_gin;
+DROP INDEX IF EXISTS dataflows_description_trgm_gin;
+DROP INDEX IF EXISTS dataflows_name_trgm_gin;
+DROP INDEX IF EXISTS dataflows_search_tsv_gin;
+
+-- Intentionally keep `pg_trgm`: extensions are database-level resources and may
+-- be shared by other schemas or later migrations.

--- a/infra/migrations/0004_catalog_search.up.sql
+++ b/infra/migrations/0004_catalog_search.up.sql
@@ -1,0 +1,29 @@
+-- Catalog search indexes for `/v1/search`.
+-- Full-text indexes handle ranked token search; trigram indexes keep fuzzy
+-- name/description matches fast without coupling the API to Postgres forever.
+
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX dataflows_search_tsv_gin
+ON dataflows
+USING GIN (to_tsvector('english', name || ' ' || COALESCE(description, '')));
+
+CREATE INDEX dataflows_name_trgm_gin
+ON dataflows
+USING GIN (name gin_trgm_ops);
+
+CREATE INDEX dataflows_description_trgm_gin
+ON dataflows
+USING GIN (description gin_trgm_ops);
+
+CREATE INDEX measures_search_tsv_gin
+ON measures
+USING GIN (to_tsvector('english', name || ' ' || COALESCE(description, '')));
+
+CREATE INDEX measures_name_trgm_gin
+ON measures
+USING GIN (name gin_trgm_ops);
+
+CREATE INDEX measures_description_trgm_gin
+ON measures
+USING GIN (description gin_trgm_ops);

--- a/openapi.json
+++ b/openapi.json
@@ -444,6 +444,75 @@
         }
       }
     },
+    "/v1/search": {
+      "get": {
+        "tags": ["search"],
+        "summary": "`GET /v1/search`.",
+        "operationId": "searchCatalog",
+        "parameters": [
+          {
+            "name": "q",
+            "in": "query",
+            "description": "Search text.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "description": "Maximum number of results, capped at 100.",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Ranked catalog search results.",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                },
+                "description": "Public CDN cache policy."
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SearchResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/v1/series/{dataflow}/{series_key}": {
       "get": {
         "tags": ["series"],
@@ -1044,6 +1113,92 @@
           }
         }
       },
+      "SearchQuery": {
+        "type": "object",
+        "description": "Query parameters for `GET /v1/search`.",
+        "required": ["q"],
+        "properties": {
+          "limit": {
+            "type": ["integer", "null"],
+            "format": "int32",
+            "description": "Maximum number of catalog results to return.",
+            "minimum": 0
+          },
+          "q": {
+            "type": "string",
+            "description": "Search text. Blank queries are rejected."
+          }
+        }
+      },
+      "SearchResponse": {
+        "type": "object",
+        "description": "Response envelope for `GET /v1/search`.",
+        "required": ["query", "results"],
+        "properties": {
+          "query": {
+            "type": "string",
+            "description": "Normalized query text used for ranking."
+          },
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SearchResult"
+            },
+            "description": "Ranked catalog matches."
+          }
+        }
+      },
+      "SearchResult": {
+        "type": "object",
+        "description": "A ranked catalog search result.",
+        "required": ["kind", "id", "name", "score", "dataflow_ids"],
+        "properties": {
+          "dataflow_ids": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataflowId"
+            },
+            "description": "Dataflows directly represented by this match."
+          },
+          "description": {
+            "type": ["string", "null"],
+            "description": "Optional catalog description."
+          },
+          "id": {
+            "type": "string",
+            "description": "Stable catalog identifier."
+          },
+          "kind": {
+            "$ref": "#/components/schemas/SearchResultKind",
+            "description": "Matched catalog object type."
+          },
+          "name": {
+            "type": "string",
+            "description": "Human-readable name."
+          },
+          "score": {
+            "type": "number",
+            "format": "double",
+            "description": "Relevance score. Larger scores rank first."
+          },
+          "source_id": {
+            "oneOf": [
+              {
+                "type": "null"
+              },
+              {
+                "$ref": "#/components/schemas/SourceId",
+                "description": "Source id for dataflow results."
+              }
+            ]
+          }
+        }
+      },
+      "SearchResultKind": {
+        "type": "string",
+        "description": "Catalog object types returned by search.",
+        "enum": ["dataflow", "measure"]
+      },
       "Series": {
         "type": "object",
         "description": "One time series within a dataflow. `dimensions` is the sorted bag of\n`(key, value)` pairs that, together with `dataflow_id`, seeds `series_key`.",
@@ -1171,6 +1326,10 @@
     {
       "name": "observations",
       "description": "Time-series observations"
+    },
+    {
+      "name": "search",
+      "description": "Ranked catalog search"
     },
     {
       "name": "series",

--- a/packages/sdk-generated/src/client.ts
+++ b/packages/sdk-generated/src/client.ts
@@ -359,6 +359,73 @@ export interface ProblemDetails {
 }
 
 /**
+ * Maximum number of catalog results to return.
+ * @minimum 0
+ */
+export type SearchQueryLimit = number | null;
+
+/**
+ * Query parameters for `GET /v1/search`.
+ */
+export interface SearchQuery {
+  /**
+   * Maximum number of catalog results to return.
+   * @minimum 0
+   */
+  limit?: SearchQueryLimit;
+  /** Search text. Blank queries are rejected. */
+  q: string;
+}
+
+/**
+ * Response envelope for `GET /v1/search`.
+ */
+export interface SearchResponse {
+  /** Normalized query text used for ranking. */
+  query: string;
+  /** Ranked catalog matches. */
+  results: SearchResult[];
+}
+
+/**
+ * Optional catalog description.
+ */
+export type SearchResultDescription = string | null;
+
+export type SearchResultSourceId = null | SourceId;
+
+/**
+ * A ranked catalog search result.
+ */
+export interface SearchResult {
+  /** Dataflows directly represented by this match. */
+  dataflow_ids: DataflowId[];
+  /** Optional catalog description. */
+  description?: SearchResultDescription;
+  /** Stable catalog identifier. */
+  id: string;
+  /** Matched catalog object type. */
+  kind: SearchResultKind;
+  /** Human-readable name. */
+  name: string;
+  /** Relevance score. Larger scores rank first. */
+  score: number;
+  source_id?: SearchResultSourceId;
+}
+
+/**
+ * Catalog object types returned by search.
+ */
+export type SearchResultKind = typeof SearchResultKind[keyof typeof SearchResultKind];
+
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export const SearchResultKind = {
+  dataflow: 'dataflow',
+  measure: 'measure',
+} as const;
+
+/**
  * Dimension values keyed by typed dimension ids and code ids. Stored
 sorted (via `BTreeMap`) so iteration order is stable across
 serialisation + re-hashing.
@@ -497,6 +564,18 @@ limit?: number;
 };
 
 export type Openapi200 = { [key: string]: unknown };
+
+export type SearchCatalogParams = {
+/**
+ * Search text.
+ */
+q: string;
+/**
+ * Maximum number of results, capped at 100.
+ * @minimum 0
+ */
+limit?: number;
+};
 
 /**
  * @summary `GET /v1/dataflows`.
@@ -857,6 +936,67 @@ export const openapi = async ( options?: RequestInit): Promise<openapiResponse> 
 
   const data: openapiResponse['data'] = body ? JSON.parse(body) : {}
   return { data, status: res.status, headers: res.headers } as openapiResponse
+}
+
+
+
+/**
+ * @summary `GET /v1/search`.
+ */
+export type searchCatalogResponse200 = {
+  data: SearchResponse
+  status: 200
+}
+
+export type searchCatalogResponse400 = {
+  data: ProblemDetails
+  status: 400
+}
+
+export type searchCatalogResponse500 = {
+  data: ProblemDetails
+  status: 500
+}
+
+export type searchCatalogResponseSuccess = (searchCatalogResponse200) & {
+  headers: Headers;
+};
+export type searchCatalogResponseError = (searchCatalogResponse400 | searchCatalogResponse500) & {
+  headers: Headers;
+};
+
+export type searchCatalogResponse = (searchCatalogResponseSuccess | searchCatalogResponseError)
+
+export const getSearchCatalogUrl = (params: SearchCatalogParams,) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? 'null' : value.toString())
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0 ? `/v1/search?${stringifiedParams}` : `/v1/search`
+}
+
+export const searchCatalog = async (params: SearchCatalogParams, options?: RequestInit): Promise<searchCatalogResponse> => {
+
+  const res = await fetch(getSearchCatalogUrl(params),
+  {
+    ...options,
+    method: 'GET'
+
+
+  }
+)
+
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+
+  const data: searchCatalogResponse['data'] = body ? JSON.parse(body) : {}
+  return { data, status: res.status, headers: res.headers } as searchCatalogResponse
 }
 
 

--- a/packages/sdk-generated/src/types.ts
+++ b/packages/sdk-generated/src/types.ts
@@ -106,6 +106,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/search": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** `GET /v1/search`. */
+        get: operations["searchCatalog"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/v1/series/{dataflow}/{series_key}": {
         parameters: {
             query?: never;
@@ -359,6 +376,47 @@ export interface components {
             /** @description Problem type URI. */
             type: string;
         };
+        /** @description Query parameters for `GET /v1/search`. */
+        SearchQuery: {
+            /**
+             * Format: int32
+             * @description Maximum number of catalog results to return.
+             */
+            limit?: number | null;
+            /** @description Search text. Blank queries are rejected. */
+            q: string;
+        };
+        /** @description Response envelope for `GET /v1/search`. */
+        SearchResponse: {
+            /** @description Normalized query text used for ranking. */
+            query: string;
+            /** @description Ranked catalog matches. */
+            results: components["schemas"]["SearchResult"][];
+        };
+        /** @description A ranked catalog search result. */
+        SearchResult: {
+            /** @description Dataflows directly represented by this match. */
+            dataflow_ids: components["schemas"]["DataflowId"][];
+            /** @description Optional catalog description. */
+            description?: string | null;
+            /** @description Stable catalog identifier. */
+            id: string;
+            /** @description Matched catalog object type. */
+            kind: components["schemas"]["SearchResultKind"];
+            /** @description Human-readable name. */
+            name: string;
+            /**
+             * Format: double
+             * @description Relevance score. Larger scores rank first.
+             */
+            score: number;
+            source_id?: null | components["schemas"]["SourceId"];
+        };
+        /**
+         * @description Catalog object types returned by search.
+         * @enum {string}
+         */
+        SearchResultKind: "dataflow" | "measure";
         /**
          * @description One time series within a dataflow. `dimensions` is the sorted bag of
          *     `(key, value)` pairs that, together with `dataflow_id`, seeds `series_key`.
@@ -712,6 +770,51 @@ export interface operations {
                 };
             };
             /** @description OpenAPI generation failed. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+        };
+    };
+    searchCatalog: {
+        parameters: {
+            query: {
+                /** @description Search text. */
+                q: string;
+                /** @description Maximum number of results, capped at 100. */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Ranked catalog search results. */
+            200: {
+                headers: {
+                    /** @description Public CDN cache policy. */
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SearchResponse"];
+                };
+            };
+            /** @description Invalid query. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Internal error. */
             500: {
                 headers: {
                     [name: string]: unknown;

--- a/packages/sdk-generated/src/zod.ts
+++ b/packages/sdk-generated/src/zod.ts
@@ -121,6 +121,20 @@ type ObservationsRow = {
 type PaginationMetadata = Partial<{
   next_cursor: string | null;
 }>;
+type SearchResponse = {
+  query: string;
+  results: Array<SearchResult>;
+};
+type SearchResult = {
+  dataflow_ids: Array<DataflowId>;
+  description?: (string | null) | undefined;
+  id: string;
+  kind: SearchResultKind;
+  name: string;
+  score: number;
+  source_id?: (null | SourceId) | undefined;
+};
+type SearchResultKind = "dataflow" | "measure";
 type Series = {
   active: boolean;
   dataflow_id: DataflowId;
@@ -266,6 +280,21 @@ const ObservationsResponse: z.ZodType<ObservationsResponse> = z
     pagination: PaginationMetadata,
   })
   .passthrough();
+const SearchResultKind = z.enum(["dataflow", "measure"]);
+const SearchResult: z.ZodType<SearchResult> = z
+  .object({
+    dataflow_ids: z.array(DataflowId),
+    description: z.union([z.string(), z.null()]).optional(),
+    id: z.string(),
+    kind: SearchResultKind,
+    name: z.string(),
+    score: z.number(),
+    source_id: z.union([z.null(), SourceId]).optional(),
+  })
+  .passthrough();
+const SearchResponse: z.ZodType<SearchResponse> = z
+  .object({ query: z.string(), results: z.array(SearchResult) })
+  .passthrough();
 const Observation: z.ZodType<Observation> = z
   .object({
     attributes: z.record(z.string()),
@@ -322,6 +351,9 @@ const ProblemDetails = z
     type: z.string(),
   })
   .passthrough();
+const SearchQuery = z
+  .object({ limit: z.union([z.number(), z.null()]).optional(), q: z.string() })
+  .passthrough();
 
 export const schemas = {
   DimensionId,
@@ -348,10 +380,14 @@ export const schemas = {
   ObservationsRow,
   PaginationMetadata,
   ObservationsResponse,
+  SearchResultKind,
+  SearchResult,
+  SearchResponse,
   Observation,
   SeriesRevisionMetadata,
   Series,
   SeriesLookupResponse,
   DataflowsQuery,
   ProblemDetails,
+  SearchQuery,
 };


### PR DESCRIPTION
## Summary

- Add `GET /v1/search?q=...` backed by Postgres FTS + trigram ranking across dataflows and measures.
- Add catalog search indexes and reversible migration coverage.
- Regenerate OpenAPI and generated TypeScript client artifacts.

Closes #43

## Pass requirements

- [x] `GET /v1/search?q=...` returns dataflows + measures ranked
- [x] GIN + `pg_trgm` indexes on name/description
- [x] <100 ms p95 for single-term query
- [x] `schemathesis` passes
- [x] Ready for OpenSearch swap in M5 if needed

## Test plan

- `cargo fmt --all --check`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTC_WRAPPER= cargo nextest run --workspace --status-level fail`
- `RUSTC_WRAPPER= cargo nextest run --workspace --profile ci -E 'not test(loads_ten_thousand_observations_with_copy_batches)'`
- `RUSTC_WRAPPER= cargo test -p au-kpis-api-http --test search`
- `RUSTC_WRAPPER= cargo test -p au-kpis-db --test migrations`
- `RUSTC_WRAPPER= cargo test -p au-kpis-openapi --test emitter`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `RUSTC_WRAPPER= cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks protect --staged`
- `oasdiff breaking target/openapi/base-openapi.json target/openapi/openapi.json`
- `schemathesis run --checks all --request-timeout 5 --max-examples 16 --include-path /v1/health --include-path /v1/openapi.json --url <local contract server> target/openapi/openapi.json`
- `RUSTC_WRAPPER= cargo +nightly-2025-10-01 llvm-cov nextest --workspace --profile ci -E 'not test(loads_ten_thousand_observations_with_copy_batches)' --skip-functions --branch --lcov --output-path target/llvm-cov/lcov.info --fail-under-lines 80`

## Spec impact

No Spec changes required; this implements the existing API surface entry for `GET /v1/search?q=unemployment`.