### PR TITLE
feat(api): stream observations as parquet (#44)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
+ "const-random",
  "getrandom 0.3.4",
  "once_cell",
  "serde",
@@ -139,6 +140,83 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "arrow-array"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd33d3e92f207444098c75b42de99d329562be0cf686b307b097cc52b4e999e"
+dependencies = [
+ "ahash",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "chrono",
+ "half",
+ "hashbrown 0.17.0",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-buffer"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c6cd424c2693bcdbc150d843dc9d4d137dd2de4782ce6df491ad11a3a0416c0"
+dependencies = [
+ "bytes",
+ "half",
+ "num-bigint",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-data"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c88210023a2bfee1896af366309a3028fc3bcbd6515fa29a7990ee1baa08ee0"
+dependencies = [
+ "arrow-buffer",
+ "arrow-schema",
+ "half",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "arrow-ipc"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "238438f0834483703d88896db6fe5a7138b2230debc31b34c0336c2996e3c64f"
+dependencies = [
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
+ "flatbuffers",
+]
+
+[[package]]
+name = "arrow-schema"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
+
+[[package]]
+name = "arrow-select"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd065c54172ac787cf3f2f8d4107e0d3fdc26edba76fdf4f4cc170258942222"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "num-traits",
 ]
 
 [[package]]
@@ -364,6 +442,8 @@ name = "au-kpis-api-http"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arrow-array",
+ "arrow-schema",
  "async-stream",
  "async-trait",
  "au-kpis-cache",
@@ -380,6 +460,7 @@ dependencies = [
  "futures",
  "http",
  "jsonschema",
+ "parquet",
  "serde",
  "serde_json",
  "sqlx",
@@ -1261,6 +1342,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "cookie-factory"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +1813,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
+dependencies = [
+ "bitflags 2.11.1",
+ "rustc_version",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2020,6 +2131,7 @@ checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
  "cfg-if",
  "crunchy",
+ "num-traits",
  "zerocopy",
 ]
 
@@ -2374,6 +2486,12 @@ dependencies = [
  "similar",
  "tempfile",
 ]
+
+[[package]]
+name = "integer-encoding"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "ipnet"
@@ -2899,6 +3017,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2934,6 +3061,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "parquet"
+version = "58.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dafa7d01085b62a47dd0c1829550a0a36710ea9c4fe358a05a85477cec8a908"
+dependencies = [
+ "ahash",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-schema",
+ "arrow-select",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "half",
+ "hashbrown 0.17.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "paste",
+ "seq-macro",
+ "thrift",
+ "tokio",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
 name = "parse-display"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2957,6 +3114,12 @@ dependencies = [
  "structmeta",
  "syn",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pear"
@@ -3667,6 +3830,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3864,6 +4036,12 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "seq-macro"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
@@ -4507,6 +4685,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "thrift"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
+dependencies = [
+ "byteorder",
+ "integer-encoding",
+ "ordered-float",
+]
+
+[[package]]
 name = "time"
 version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4535,6 +4724,15 @@ checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
+]
+
+[[package]]
+name = "tiny-keccak"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c9d3793400a45f954c52e73d068316d76b6f4e36977e3fcebb13a2721e80237"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -4921,6 +5119,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-path"

--- a/crates/au-kpis-api-http/Cargo.toml
+++ b/crates/au-kpis-api-http/Cargo.toml
@@ -8,6 +8,8 @@ repository.workspace = true
 description = "axum routes + handlers (library)."
 
 [dependencies]
+arrow-array = "58.3.0" # build RecordBatch values for streamed Parquet responses
+arrow-schema = "58.3.0" # define the Arrow schema exported by the Parquet endpoint
 async-stream = "0.3" # stream JSON/CSV chunks from sqlx without buffering result pages
 au-kpis-cache = { workspace = true }
 au-kpis-config = { workspace = true }
@@ -18,6 +20,7 @@ base64 = "0.22" # opaque cursor encoding; std has no base64 codec
 chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
 futures = "0.3" # TryStreamExt over sqlx row streams
 http = "1"
+parquet = { version = "58.3.0", default-features = false, features = ["arrow", "async", "zstd"] } # encode streamed Parquet responses with zstd and without unused codecs
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sqlx = { version = "0.8", default-features = false, features = ["postgres", "runtime-tokio", "tls-rustls", "chrono", "json"] }

--- a/crates/au-kpis-api-http/src/observations.rs
+++ b/crates/au-kpis-api-http/src/observations.rs
@@ -1,7 +1,9 @@
 //! `/v1/observations` query handling and streaming renderers.
 
-use std::{collections::BTreeMap, fmt};
+use std::{collections::BTreeMap, fmt, io, sync::Arc};
 
+use arrow_array::{ArrayRef, Float64Array, RecordBatch, StringArray, UInt32Array};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use au_kpis_domain::{
     ObservationStatus, TimePrecision,
     ids::{ArtifactId, DataflowId, SeriesKey, Sha256Digest},
@@ -14,9 +16,19 @@ use axum::{
 };
 use base64::{Engine as _, prelude::BASE64_URL_SAFE_NO_PAD};
 use chrono::{DateTime, NaiveDate, Utc};
-use futures::{Stream, TryStreamExt};
+use futures::{
+    Stream, TryStreamExt,
+    future::{BoxFuture, FutureExt},
+};
+use parquet::{
+    arrow::{AsyncArrowWriter, async_writer::AsyncFileWriter},
+    basic::Compression,
+    errors::ParquetError,
+    file::{metadata::KeyValue, properties::WriterProperties},
+};
 use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, Postgres, QueryBuilder, Row, postgres::PgRow};
+use tokio::sync::mpsc;
 use utoipa::ToSchema;
 
 use crate::{AppState, error::ApiError};
@@ -24,6 +36,8 @@ use crate::{AppState, error::ApiError};
 const DEFAULT_LIMIT: usize = 1_000;
 const MAX_LIMIT: usize = 10_000;
 const CACHE_CONTROL_VALUE: &str = "public, max-age=60, stale-while-revalidate=300";
+const PARQUET_ROW_GROUP_TARGET_BYTES: usize = 1_000_000;
+const PARQUET_BATCH_ROWS: usize = 1_024;
 
 /// Attribution and licensing metadata that applies to an observations page.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -96,7 +110,7 @@ pub struct ObservationsResponse {
         ("since" = Option<String>, Query, description = "Inclusive lower time bound as YYYY-MM-DD or RFC3339."),
         ("until" = Option<String>, Query, description = "Inclusive upper time bound as YYYY-MM-DD or RFC3339."),
         ("frequency" = Option<String>, Query, description = "Optional dataflow frequency filter."),
-        ("format" = Option<String>, Query, description = "Response format: json or csv."),
+        ("format" = Option<String>, Query, description = "Response format: json, csv, or parquet."),
         ("cursor" = Option<String>, Query, description = "Opaque cursor from the previous page."),
         ("limit" = Option<u32>, Query, description = "Page size, maximum 10000.")
     ),
@@ -106,7 +120,8 @@ pub struct ObservationsResponse {
             description = "Observation page.",
             content(
                 (ObservationsResponse = "application/json"),
-                (String = "text/csv")
+                (String = "text/csv"),
+                (String = "application/vnd.apache.parquet")
             ),
             headers(
                 ("ETag" = String, description = "Weak entity tag for this page."),
@@ -174,6 +189,7 @@ pub async fn list_observations(
     let content_type = match query.format {
         ResponseFormat::Json => HeaderValue::from_static("application/json"),
         ResponseFormat::Csv => HeaderValue::from_static("text/csv; charset=utf-8"),
+        ResponseFormat::Parquet => HeaderValue::from_static("application/vnd.apache.parquet"),
     };
     let stream = match query.format {
         ResponseFormat::Json => {
@@ -182,6 +198,11 @@ pub async fn list_observations(
         ResponseFormat::Csv => {
             Body::from_stream(csv_observations_stream(state.db.clone(), query, metadata))
         }
+        ResponseFormat::Parquet => Body::from_stream(parquet_observations_stream(
+            state.db.clone(),
+            query,
+            metadata,
+        )),
     };
 
     let mut response = Response::new(stream);
@@ -211,6 +232,7 @@ struct ParsedObservationsQuery {
 enum ResponseFormat {
     Json,
     Csv,
+    Parquet,
 }
 
 impl fmt::Display for ResponseFormat {
@@ -218,6 +240,7 @@ impl fmt::Display for ResponseFormat {
         match self {
             ResponseFormat::Json => f.write_str("json"),
             ResponseFormat::Csv => f.write_str("csv"),
+            ResponseFormat::Parquet => f.write_str("parquet"),
         }
     }
 }
@@ -343,9 +366,7 @@ fn parse_format(value: &str) -> Result<ResponseFormat, ApiError> {
     match value {
         "json" => Ok(ResponseFormat::Json),
         "csv" => Ok(ResponseFormat::Csv),
-        "parquet" => Err(ApiError::Validation(
-            "format=parquet is planned for phase 3".into(),
-        )),
+        "parquet" => Ok(ResponseFormat::Parquet),
         _ => Err(ApiError::Validation(format!(
             "unsupported format `{value}`"
         ))),
@@ -534,6 +555,255 @@ fn csv_observations_stream(
             yield Bytes::from(format!("# next_cursor={}\n", csv_escape(&next_cursor)));
         }
     }
+}
+
+fn parquet_observations_stream(
+    pool: PgPool,
+    query: ParsedObservationsQuery,
+    metadata: ObservationsMetadata,
+) -> impl Stream<Item = Result<Bytes, ApiError>> + Send + 'static {
+    let (tx, mut rx) = mpsc::channel(8);
+    let error_tx = tx.clone();
+    let limit = query.limit;
+    let rows = fetch_observation_rows(pool, query);
+
+    tokio::spawn(async move {
+        if let Err(err) =
+            write_parquet_rows(rows, metadata, limit, tx, PARQUET_ROW_GROUP_TARGET_BYTES).await
+        {
+            if !error_tx.is_closed() {
+                let _ = error_tx.send(Err(err)).await;
+            }
+        }
+    });
+
+    async_stream::stream! {
+        while let Some(chunk) = rx.recv().await {
+            yield chunk;
+        }
+    }
+}
+
+async fn write_parquet_rows<S>(
+    rows: S,
+    metadata: ObservationsMetadata,
+    limit: usize,
+    tx: mpsc::Sender<Result<Bytes, ApiError>>,
+    row_group_target_bytes: usize,
+) -> Result<(), ApiError>
+where
+    S: Stream<Item = Result<ObservationsRow, ApiError>> + Send,
+{
+    let schema = parquet_schema();
+    let writer = ChannelParquetWriter { tx: tx.clone() };
+    let props = parquet_writer_properties(&metadata);
+    let mut writer =
+        AsyncArrowWriter::try_new(writer, Arc::clone(&schema), Some(props)).map_err(|err| {
+            tracing::error!(error = %err, "parquet writer initialization failed");
+            ApiError::Internal
+        })?;
+    let mut batch = ParquetBatchBuilder::default();
+    let mut emitted = 0_usize;
+
+    futures::pin_mut!(rows);
+    loop {
+        if emitted == limit || tx.is_closed() {
+            break;
+        }
+
+        let Some(row) = (tokio::select! {
+            () = tx.closed() => None,
+            row = rows.try_next() => row?,
+        }) else {
+            break;
+        };
+
+        batch.push(row)?;
+        emitted += 1;
+        if batch.len() >= PARQUET_BATCH_ROWS {
+            write_parquet_batch(
+                &mut writer,
+                Arc::clone(&schema),
+                &mut batch,
+                row_group_target_bytes,
+            )
+            .await?;
+        }
+    }
+
+    if tx.is_closed() {
+        return Ok(());
+    }
+
+    write_parquet_batch(
+        &mut writer,
+        Arc::clone(&schema),
+        &mut batch,
+        row_group_target_bytes,
+    )
+    .await?;
+    if tx.is_closed() {
+        return Ok(());
+    }
+    writer.finish().await.map_err(parquet_to_api_error)?;
+    Ok(())
+}
+
+async fn write_parquet_batch(
+    writer: &mut AsyncArrowWriter<ChannelParquetWriter>,
+    schema: SchemaRef,
+    batch: &mut ParquetBatchBuilder,
+    row_group_target_bytes: usize,
+) -> Result<(), ApiError> {
+    if batch.is_empty() {
+        return Ok(());
+    }
+
+    let record_batch = batch.finish(schema)?;
+    writer
+        .write(&record_batch)
+        .await
+        .map_err(parquet_to_api_error)?;
+    if writer.in_progress_size() >= row_group_target_bytes {
+        writer.flush().await.map_err(parquet_to_api_error)?;
+    }
+    Ok(())
+}
+
+fn parquet_schema() -> SchemaRef {
+    Arc::new(Schema::new(vec![
+        Field::new("series_key", DataType::Utf8, false),
+        Field::new("time", DataType::Utf8, false),
+        Field::new("time_precision", DataType::Utf8, false),
+        Field::new("value", DataType::Float64, true),
+        Field::new("status", DataType::Utf8, false),
+        Field::new("revision_no", DataType::UInt32, false),
+        Field::new("dimensions", DataType::Utf8, false),
+        Field::new("attributes", DataType::Utf8, false),
+        Field::new("ingested_at", DataType::Utf8, false),
+        Field::new("source_artifact_id", DataType::Utf8, false),
+        Field::new("measure_id", DataType::Utf8, false),
+        Field::new("unit", DataType::Utf8, false),
+    ]))
+}
+
+fn parquet_writer_properties(metadata: &ObservationsMetadata) -> WriterProperties {
+    WriterProperties::builder()
+        .set_compression(Compression::ZSTD(Default::default()))
+        .set_key_value_metadata(Some(vec![
+            KeyValue::new(
+                "dataflow".to_string(),
+                metadata.dataflow.as_str().to_string(),
+            ),
+            KeyValue::new("license".to_string(), metadata.license.clone()),
+            KeyValue::new("attribution".to_string(), metadata.attribution.clone()),
+            KeyValue::new("source_url".to_string(), metadata.source_url.clone()),
+        ]))
+        .build()
+}
+
+#[derive(Debug, Default)]
+struct ParquetBatchBuilder {
+    series_key: Vec<String>,
+    time: Vec<String>,
+    time_precision: Vec<String>,
+    value: Vec<Option<f64>>,
+    status: Vec<String>,
+    revision_no: Vec<u32>,
+    dimensions: Vec<String>,
+    attributes: Vec<String>,
+    ingested_at: Vec<String>,
+    source_artifact_id: Vec<String>,
+    measure_id: Vec<String>,
+    unit: Vec<String>,
+}
+
+impl ParquetBatchBuilder {
+    fn push(&mut self, row: ObservationsRow) -> Result<(), ApiError> {
+        self.series_key.push(row.series_key.to_string());
+        self.time.push(row.time.to_rfc3339());
+        self.time_precision
+            .push(time_precision_label(row.time_precision).to_string());
+        self.value.push(row.value);
+        self.status
+            .push(observation_status_label(row.status).to_string());
+        self.revision_no.push(row.revision_no);
+        self.dimensions.push(serialize_json_chunk(&row.dimensions)?);
+        self.attributes.push(serialize_json_chunk(&row.attributes)?);
+        self.ingested_at.push(row.ingested_at.to_rfc3339());
+        self.source_artifact_id
+            .push(row.source_artifact_id.to_string());
+        self.measure_id.push(row.measure_id);
+        self.unit.push(row.unit);
+        Ok(())
+    }
+
+    fn len(&self) -> usize {
+        self.series_key.len()
+    }
+
+    fn is_empty(&self) -> bool {
+        self.series_key.is_empty()
+    }
+
+    fn finish(&mut self, schema: SchemaRef) -> Result<RecordBatch, ApiError> {
+        let batch = std::mem::take(self);
+        let columns: Vec<ArrayRef> = vec![
+            Arc::new(StringArray::from(batch.series_key)),
+            Arc::new(StringArray::from(batch.time)),
+            Arc::new(StringArray::from(batch.time_precision)),
+            Arc::new(Float64Array::from(batch.value)),
+            Arc::new(StringArray::from(batch.status)),
+            Arc::new(UInt32Array::from(batch.revision_no)),
+            Arc::new(StringArray::from(batch.dimensions)),
+            Arc::new(StringArray::from(batch.attributes)),
+            Arc::new(StringArray::from(batch.ingested_at)),
+            Arc::new(StringArray::from(batch.source_artifact_id)),
+            Arc::new(StringArray::from(batch.measure_id)),
+            Arc::new(StringArray::from(batch.unit)),
+        ];
+        RecordBatch::try_new(schema, columns).map_err(|err| {
+            tracing::error!(error = %err, "parquet record batch construction failed");
+            ApiError::Internal
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ChannelParquetWriter {
+    tx: mpsc::Sender<Result<Bytes, ApiError>>,
+}
+
+impl AsyncFileWriter for ChannelParquetWriter {
+    fn write(&mut self, bytes: Bytes) -> BoxFuture<'_, parquet::errors::Result<()>> {
+        async move {
+            if bytes.is_empty() {
+                return Ok(());
+            }
+            self.tx
+                .send(Ok(bytes))
+                .await
+                .map_err(|_| parquet_receiver_dropped())?;
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn complete(&mut self) -> BoxFuture<'_, parquet::errors::Result<()>> {
+        async { Ok(()) }.boxed()
+    }
+}
+
+fn parquet_receiver_dropped() -> ParquetError {
+    ParquetError::External(Box::new(io::Error::new(
+        io::ErrorKind::BrokenPipe,
+        "parquet response receiver dropped",
+    )))
+}
+
+fn parquet_to_api_error(err: ParquetError) -> ApiError {
+    tracing::error!(error = %err, "parquet response serialization failed");
+    ApiError::Internal
 }
 
 fn fetch_observation_rows(
@@ -748,10 +1018,33 @@ fn csv_escape(value: &str) -> String {
     }
 }
 
+fn time_precision_label(value: TimePrecision) -> &'static str {
+    match value {
+        TimePrecision::Day => "day",
+        TimePrecision::Week => "week",
+        TimePrecision::Month => "month",
+        TimePrecision::Quarter => "quarter",
+        TimePrecision::Year => "year",
+    }
+}
+
+fn observation_status_label(value: ObservationStatus) -> &'static str {
+    match value {
+        ObservationStatus::Normal => "normal",
+        ObservationStatus::Estimated => "estimated",
+        ObservationStatus::Forecast => "forecast",
+        ObservationStatus::Imputed => "imputed",
+        ObservationStatus::Missing => "missing",
+        ObservationStatus::Provisional => "provisional",
+        ObservationStatus::Revised => "revised",
+        ObservationStatus::Break => "break",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use au_kpis_domain::ids::{DataflowId, SeriesKey};
+    use au_kpis_domain::ids::{ArtifactId, DataflowId, SeriesKey};
     use chrono::{TimeZone, Utc};
 
     #[test]
@@ -789,6 +1082,55 @@ mod tests {
     }
 
     #[test]
+    fn parses_parquet_format() {
+        let query = parse_observations_query(Some("dataflow=abs.cpi&format=parquet")).unwrap();
+
+        assert_eq!(query.format, ResponseFormat::Parquet);
+    }
+
+    #[tokio::test]
+    async fn parquet_writer_returns_promptly_when_response_receiver_closes_mid_stream() {
+        let (tx, rx) = mpsc::channel(1);
+        let (pending_tx, pending_rx) = tokio::sync::oneshot::channel();
+        let metadata = ObservationsMetadata {
+            dataflow: DataflowId::new("abs.cpi").unwrap(),
+            attribution: "Source: Australian Bureau of Statistics".into(),
+            license: "CC-BY-4.0".into(),
+            source_url: "https://www.abs.gov.au/".into(),
+        };
+        let rows =
+            futures::stream::unfold((0_u8, Some(pending_tx)), |(step, pending_tx)| async move {
+                if step == 0 {
+                    return Some((Ok(test_observation_row()), (1, pending_tx)));
+                }
+                if let Some(pending_tx) = pending_tx {
+                    let _ = pending_tx.send(());
+                }
+                futures::future::pending::<Option<(Result<ObservationsRow, ApiError>, _)>>().await
+            });
+        let writer = tokio::spawn(write_parquet_rows(
+            rows,
+            metadata,
+            10,
+            tx,
+            PARQUET_ROW_GROUP_TARGET_BYTES,
+        ));
+
+        pending_rx
+            .await
+            .expect("writer should poll the second upstream row");
+        drop(rx);
+
+        let result = tokio::time::timeout(std::time::Duration::from_millis(100), writer).await;
+
+        assert!(
+            result.is_ok(),
+            "writer should not await an abandoned stream"
+        );
+        assert!(result.unwrap().expect("writer task").is_ok());
+    }
+
+    #[test]
     fn rejects_missing_dataflow_and_excessive_limits_before_db_access() {
         let missing = parse_observations_query(Some("limit=10")).unwrap_err();
         assert!(missing.to_string().contains("dataflow"));
@@ -809,5 +1151,23 @@ mod tests {
 
         assert!(!encoded.contains("2024-03-01"));
         assert_eq!(decode_cursor(&encoded).unwrap(), cursor);
+    }
+
+    fn test_observation_row() -> ObservationsRow {
+        let dataflow = DataflowId::new("abs.cpi").unwrap();
+        ObservationsRow {
+            series_key: SeriesKey::derive(&dataflow, [("region", "AUS")]),
+            time: Utc.with_ymd_and_hms(2024, 3, 1, 0, 0, 0).unwrap(),
+            time_precision: TimePrecision::Quarter,
+            value: Some(135.0),
+            status: ObservationStatus::Normal,
+            revision_no: 1,
+            attributes: BTreeMap::new(),
+            ingested_at: Utc.with_ymd_and_hms(2024, 4, 24, 0, 0, 0).unwrap(),
+            source_artifact_id: ArtifactId::of_content(b"parquet cancellation fixture"),
+            dimensions: BTreeMap::from([("region".to_string(), "AUS".to_string())]),
+            measure_id: "cpi".into(),
+            unit: "index".into(),
+        }
     }
 }

--- a/crates/au-kpis-api-http/tests/observations.rs
+++ b/crates/au-kpis-api-http/tests/observations.rs
@@ -1,5 +1,6 @@
 use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
+use arrow_array::{Float64Array, StringArray, UInt32Array};
 use au_kpis_api_http::{AppState, ObservationsResponse, router};
 use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
 use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
@@ -10,6 +11,7 @@ use axum::{
     http::{Request, StatusCode, header},
 };
 use chrono::{TimeZone, Utc};
+use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 use serde_json::json;
 use sqlx::PgPool;
 use tokio_util::sync::CancellationToken;
@@ -138,6 +140,100 @@ async fn observations_endpoint_streams_latest_json_csv_and_cache_headers() {
     assert!(body.contains("series_key,time,time_precision,value,status,revision_no"));
     assert!(body.contains(",135,normal,1,"));
     assert!(body.contains("# next_cursor="));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn observations_endpoint_streams_decodable_parquet_with_headers() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let db = TestDb::start("au_kpis_api_observations_parquet").await;
+    seed_observations(db.pool()).await;
+    let app = router(test_state(db.pool().clone())).expect("router");
+
+    let response = app
+        .oneshot(request(
+            "/v1/observations?dataflow=abs.cpi&dimensions[region]=AUS&format=parquet&limit=10",
+        ))
+        .await
+        .expect("parquet response");
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/vnd.apache.parquet"
+    );
+    assert_eq!(
+        response.headers().get(header::CACHE_CONTROL).unwrap(),
+        "public, max-age=60, stale-while-revalidate=300"
+    );
+    assert!(response.headers().contains_key(header::ETAG));
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("parquet body");
+    assert_eq!(&body[..4], b"PAR1");
+    assert_eq!(&body[body.len() - 4..], b"PAR1");
+
+    let reader = ParquetRecordBatchReaderBuilder::try_new(body)
+        .expect("parquet reader")
+        .build()
+        .expect("record batch reader");
+    let batches = reader
+        .collect::<Result<Vec<_>, _>>()
+        .expect("parquet batches");
+    let batch = batches.first().expect("at least one batch");
+    assert_eq!(
+        batch
+            .schema()
+            .fields()
+            .iter()
+            .map(|field| field.name().as_str())
+            .collect::<Vec<_>>(),
+        vec![
+            "series_key",
+            "time",
+            "time_precision",
+            "value",
+            "status",
+            "revision_no",
+            "dimensions",
+            "attributes",
+            "ingested_at",
+            "source_artifact_id",
+            "measure_id",
+            "unit",
+        ]
+    );
+    assert_eq!(
+        batches.iter().map(|batch| batch.num_rows()).sum::<usize>(),
+        2
+    );
+
+    let value = batch
+        .column_by_name("value")
+        .expect("value column")
+        .as_any()
+        .downcast_ref::<Float64Array>()
+        .expect("value float64");
+    let revision_no = batch
+        .column_by_name("revision_no")
+        .expect("revision column")
+        .as_any()
+        .downcast_ref::<UInt32Array>()
+        .expect("revision uint32");
+    let dimensions = batch
+        .column_by_name("dimensions")
+        .expect("dimensions column")
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .expect("dimensions string");
+
+    assert_eq!(value.value(0), 135.0);
+    assert_eq!(revision_no.value(0), 1);
+    assert_eq!(dimensions.value(0), "{\"region\":\"AUS\"}");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
+++ b/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
@@ -1156,7 +1156,7 @@ expression: emitted_spec()
             }
           },
           {
-            "description": "Response format: json or csv.",
+            "description": "Response format: json, csv, or parquet.",
             "in": "query",
             "name": "format",
             "required": false,
@@ -1191,6 +1191,11 @@ expression: emitted_spec()
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ObservationsResponse"
+                }
+              },
+              "application/vnd.apache.parquet": {
+                "schema": {
+                  "type": "string"
                 }
               },
               "text/csv": {

--- a/deny.toml
+++ b/deny.toml
@@ -10,6 +10,7 @@ db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
     { id = "RUSTSEC-2025-0111", reason = "testcontainers is limited to local integration-test harnesses; the fixed release requires a newer Rust toolchain than the repository pin" },
     { id = "RUSTSEC-2025-0134", reason = "rustls-pemfile is transitive through network/client crates and has no safe direct replacement available in those upstream dependency chains yet" },
+    { id = "RUSTSEC-2024-0436", reason = "parquet 58.3.0 depends on paste internally; this is required for arrow-rs Parquet response encoding until upstream removes or replaces the transitive dependency" },
 ]
 
 [licenses]

--- a/openapi.json
+++ b/openapi.json
@@ -288,7 +288,7 @@
           {
             "name": "format",
             "in": "query",
-            "description": "Response format: json or csv.",
+            "description": "Response format: json, csv, or parquet.",
             "required": false,
             "schema": {
               "type": "string"
@@ -339,6 +339,11 @@
                 }
               },
               "text/csv": {
+                "schema": {
+                  "type": "string"
+                }
+              },
+              "application/vnd.apache.parquet": {
                 "schema": {
                   "type": "string"
                 }

--- a/packages/sdk-generated/src/client.ts
+++ b/packages/sdk-generated/src/client.ts
@@ -549,7 +549,7 @@ until?: string;
  */
 frequency?: string;
 /**
- * Response format: json or csv.
+ * Response format: json, csv, or parquet.
  */
 format?: string;
 /**

--- a/packages/sdk-generated/src/types.ts
+++ b/packages/sdk-generated/src/types.ts
@@ -666,7 +666,7 @@ export interface operations {
                 until?: string;
                 /** @description Optional dataflow frequency filter. */
                 frequency?: string;
-                /** @description Response format: json or csv. */
+                /** @description Response format: json, csv, or parquet. */
                 format?: string;
                 /** @description Opaque cursor from the previous page. */
                 cursor?: string;
@@ -691,6 +691,7 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["ObservationsResponse"];
                     "text/csv": string;
+                    "application/vnd.apache.parquet": string;
                 };
             };
             /** @description The client's cached page is still fresh. */


### PR DESCRIPTION
Closes #44

## Pass requirements

- [x] `GET /v1/observations?...&format=parquet` streams via `StreamBody`/`Body::from_stream` rather than full-result buffering
- [x] Response content type is `application/vnd.apache.parquet`
- [x] Parquet output uses 1 MB row groups and zstd compression
- [x] Request cancellation stops the underlying stream/DB work promptly
- [x] Integration coverage proves the endpoint returns a decodable Parquet payload with the correct headers
- [x] OpenAPI / response-format documentation is updated if the served contract changes

## Test plan

- `cargo fmt --all --check`
- `RUSTC_WRAPPER= cargo check --workspace --locked`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTC_WRAPPER= cargo nextest run --workspace --profile ci -E 'not test(loads_ten_thousand_observations_with_copy_batches)'` plus no `FLAKY` markers in `target/nextest-ci-issue44.log`
- `RUSTC_WRAPPER= cargo test -p au-kpis-api-http --test observations`
- `RUSTC_WRAPPER= cargo test -p au-kpis-openapi --test emitter`
- `pnpm run lint && pnpm turbo run typecheck test`
- `RUSTC_WRAPPER= cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks protect --staged`
- `/Users/os/go/bin/oasdiff breaking target/openapi/base-openapi.json target/openapi/openapi.json`
- Local Schemathesis health/openapi contract run against `contract_server`
- Coverage: `cargo +nightly-2025-10-01 llvm-cov nextest ... --fail-under-lines 80`; branch coverage `71.21% (638/896)`

## Spec impact

No `Spec.md` changes required. This implements the existing `format=parquet` contract from the streaming responses and API surface sections.

## Notes

`parquet 58.3.0` currently pulls in `paste`; `deny.toml` includes a scoped advisory exception for that non-optional transitive dependency until arrow-rs removes or replaces it.