### PR TITLE
feat(auth): API key middleware (#45)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -143,6 +143,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
 name = "arrow-array"
 version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +458,7 @@ dependencies = [
  "arrow-schema",
  "async-stream",
  "async-trait",
+ "au-kpis-auth",
  "au-kpis-cache",
  "au-kpis-config",
  "au-kpis-db",
@@ -477,6 +490,25 @@ dependencies = [
 [[package]]
 name = "au-kpis-auth"
 version = "0.1.0"
+dependencies = [
+ "argon2",
+ "au-kpis-cache",
+ "au-kpis-config",
+ "au-kpis-db",
+ "au-kpis-error",
+ "au-kpis-testing",
+ "base64 0.22.1",
+ "chrono",
+ "rand 0.8.6",
+ "serde",
+ "sha2",
+ "sqlx",
+ "subtle",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+]
 
 [[package]]
 name = "au-kpis-cache"
@@ -496,6 +528,22 @@ dependencies = [
 [[package]]
 name = "au-kpis-cli"
 version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "assert_cmd",
+ "au-kpis-auth",
+ "au-kpis-cache",
+ "au-kpis-config",
+ "au-kpis-db",
+ "au-kpis-testing",
+ "chrono",
+ "clap",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "uuid",
+]
 
 [[package]]
 name = "au-kpis-config"
@@ -939,6 +987,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
 ]
 
 [[package]]
@@ -3116,6 +3173,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5285,6 +5353,7 @@ checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/crates/au-kpis-api-http/Cargo.toml
+++ b/crates/au-kpis-api-http/Cargo.toml
@@ -11,6 +11,7 @@ description = "axum routes + handlers (library)."
 arrow-array = "58.3.0" # build RecordBatch values for streamed Parquet responses
 arrow-schema = "58.3.0" # define the Arrow schema exported by the Parquet endpoint
 async-stream = "0.3" # stream JSON/CSV chunks from sqlx without buffering result pages
+au-kpis-auth = { workspace = true }
 au-kpis-cache = { workspace = true }
 au-kpis-config = { workspace = true }
 au-kpis-domain = { workspace = true }

--- a/crates/au-kpis-api-http/src/auth.rs
+++ b/crates/au-kpis-api-http/src/auth.rs
@@ -1,0 +1,41 @@
+//! API-key middleware for protected routes.
+
+use au_kpis_auth::{ApiKeyManager, AuthError};
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+
+use crate::{ApiError, AppState};
+
+/// Validate the `X-API-Key` header and attach the verified key to extensions.
+pub async fn require_api_key(
+    State(state): State<AppState>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let Some(header) = request.headers().get("x-api-key") else {
+        return unauthorized().into_response();
+    };
+    let Ok(plaintext) = header.to_str() else {
+        return unauthorized().into_response();
+    };
+
+    let manager = ApiKeyManager::new(state.db.clone(), state.cache.clone());
+    match manager.verify(plaintext).await {
+        Ok(verified) => {
+            request.extensions_mut().insert(verified);
+            next.run(request).await
+        }
+        Err(AuthError::InvalidApiKey | AuthError::Validation(_)) => unauthorized().into_response(),
+        Err(err) => {
+            tracing::error!(error = %err, "api key verification failed");
+            ApiError::Internal.into_response()
+        }
+    }
+}
+
+fn unauthorized() -> ApiError {
+    ApiError::Unauthorized("missing or invalid API key".into())
+}

--- a/crates/au-kpis-api-http/src/error.rs
+++ b/crates/au-kpis-api-http/src/error.rs
@@ -36,6 +36,9 @@ pub struct ProblemDetails {
 /// API-layer errors rendered as RFC 7807 responses.
 #[derive(Debug, Error)]
 pub enum ApiError {
+    /// Client did not supply a valid API key.
+    #[error("unauthorized: {0}")]
+    Unauthorized(String),
     /// Requested resource was not found.
     #[error("not found: {0}")]
     NotFound(String),
@@ -71,6 +74,17 @@ pub enum ApiError {
 impl IntoResponse for ApiError {
     fn into_response(self) -> Response {
         let (status, problem, rate_limit) = match self {
+            ApiError::Unauthorized(detail) => (
+                StatusCode::UNAUTHORIZED,
+                ProblemDetails {
+                    r#type: "about:blank".into(),
+                    title: "Unauthorized".into(),
+                    status: StatusCode::UNAUTHORIZED.as_u16(),
+                    detail: Some(detail),
+                    instance: None,
+                },
+                None,
+            ),
             ApiError::NotFound(detail) => (
                 StatusCode::NOT_FOUND,
                 ProblemDetails {

--- a/crates/au-kpis-api-http/src/lib.rs
+++ b/crates/au-kpis-api-http/src/lib.rs
@@ -22,6 +22,7 @@ use tower_http::{
     trace::TraceLayer,
 };
 
+pub mod auth;
 pub mod dataflows;
 pub mod docs;
 pub mod error;
@@ -31,6 +32,7 @@ pub mod search;
 pub mod series;
 pub mod state;
 
+pub use auth::require_api_key;
 pub use dataflows::{
     DataflowCodelistResponse, DataflowDetailResponse, DataflowsQuery, DataflowsResponse,
     get_dataflow, get_dataflow_codelist, list_dataflows,

--- a/crates/au-kpis-api-http/tests/auth.rs
+++ b/crates/au-kpis-api-http/tests/auth.rs
@@ -1,0 +1,203 @@
+use std::sync::Arc;
+
+use au_kpis_api_http::{AppState, auth::require_api_key, router_with};
+use au_kpis_auth::{ApiKeyManager, CreateApiKeyRequest, VerifiedApiKey};
+use au_kpis_cache::CacheClient;
+use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_db::{connect, migrate};
+use au_kpis_telemetry::Telemetry;
+use au_kpis_testing::{
+    redis::{RedisHarness, start_redis},
+    timescale::{TimescaleHarness, start_timescale},
+};
+use axum::{
+    Extension, Json, Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header},
+    middleware,
+    routing::get,
+};
+use serde_json::{Value, json};
+use sqlx::PgPool;
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+struct TestContext {
+    _postgres: TimescaleHarness,
+    _redis: RedisHarness,
+    pool: PgPool,
+    cache: Arc<CacheClient>,
+}
+
+impl TestContext {
+    async fn start(database: &str) -> Self {
+        let postgres = start_timescale(database)
+            .await
+            .expect("start timescaledb container");
+        let redis = start_redis().await.expect("start redis container");
+        let pool = connect(&DatabaseConfig {
+            url: postgres.url().to_string(),
+        })
+        .await
+        .expect("connect postgres");
+        migrate(&pool).await.expect("apply migrations");
+        let cache = Arc::new(
+            CacheClient::connect(redis.url())
+                .await
+                .expect("connect redis"),
+        );
+
+        Self {
+            _postgres: postgres,
+            _redis: redis,
+            pool,
+            cache,
+        }
+    }
+
+    fn state(&self) -> AppState {
+        test_state(self.pool.clone(), self.cache.clone())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn protected_routes_validate_x_api_key_and_reject_missing_invalid_or_revoked_keys() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let ctx = TestContext::start("au_kpis_api_auth").await;
+    let manager = ApiKeyManager::new(ctx.pool.clone(), ctx.cache.clone());
+    let created = manager
+        .create_key(CreateApiKeyRequest {
+            name: "sdk client".into(),
+            scopes: vec!["observations:read".into()],
+            rate_limit_tier: "free".into(),
+            actor: "platform-admin@example.com".into(),
+        })
+        .await
+        .expect("create api key");
+
+    let app = protected_router(ctx.state());
+
+    let valid = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/protected")
+                .header("x-api-key", &created.plaintext)
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("valid response");
+    assert_eq!(valid.status(), StatusCode::OK);
+    let body = to_json(valid).await;
+    assert_eq!(body["api_key_id"], created.id.to_string());
+    assert_eq!(body["name"], "sdk client");
+
+    let missing = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/protected")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("missing response");
+    assert_eq!(missing.status(), StatusCode::UNAUTHORIZED);
+    assert_eq!(
+        missing.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/problem+json"
+    );
+
+    let invalid = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/protected")
+                .header("x-api-key", "auk_live_invalid")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("invalid response");
+    assert_eq!(invalid.status(), StatusCode::UNAUTHORIZED);
+
+    manager
+        .revoke_key(created.id, "security-admin@example.com")
+        .await
+        .expect("revoke key");
+    let revoked = app
+        .oneshot(
+            Request::builder()
+                .uri("/protected")
+                .header("x-api-key", &created.plaintext)
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("revoked response");
+    assert_eq!(revoked.status(), StatusCode::UNAUTHORIZED);
+}
+
+fn protected_router(state: AppState) -> axum::Router {
+    let protected = Router::new()
+        .route("/protected", get(protected_handler))
+        .route_layer(middleware::from_fn_with_state(
+            state.clone(),
+            require_api_key,
+        ));
+    router_with(protected, state).expect("router")
+}
+
+async fn protected_handler(Extension(key): Extension<VerifiedApiKey>) -> Json<Value> {
+    Json(json!({
+        "api_key_id": key.id.to_string(),
+        "name": key.name,
+    }))
+}
+
+async fn to_json(response: axum::response::Response) -> Value {
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    serde_json::from_slice(&body).expect("json body")
+}
+
+fn test_state(db: PgPool, cache: Arc<CacheClient>) -> AppState {
+    let config = AppConfig {
+        http: HttpConfig {
+            bind: "127.0.0.1:0".into(),
+            cors_allowed_origins: Vec::new(),
+            shutdown_grace_period_secs: 30,
+        },
+        database: DatabaseConfig {
+            url: "postgres://postgres:postgres@localhost/au_kpis".into(),
+        },
+        cache: au_kpis_config::CacheConfig {
+            url: "redis://127.0.0.1:6379".into(),
+        },
+        telemetry: TelemetryConfig {
+            service_name: "au-kpis-test".into(),
+            log_format: LogFormat::Json,
+            log_level: "info".into(),
+            otlp_endpoint: None,
+        },
+    };
+
+    AppState::new(
+        db,
+        cache,
+        Arc::new(config),
+        Arc::new(Telemetry::disabled()),
+        CancellationToken::new(),
+    )
+}
+
+fn docker_available() -> bool {
+    std::env::var_os("DOCKER_HOST").is_some()
+        || std::path::Path::new("/var/run/docker.sock").exists()
+}

--- a/crates/au-kpis-auth/Cargo.toml
+++ b/crates/au-kpis-auth/Cargo.toml
@@ -8,3 +8,31 @@ repository.workspace = true
 description = "API key validation, Redis rate limiter."
 
 [dependencies]
+argon2 = { version = "0.5", features = ["std"] }
+au-kpis-cache = { workspace = true }
+au-kpis-error = { workspace = true }
+base64 = "0.22"
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+rand = "0.8"
+serde = { version = "1", features = ["derive"] }
+sha2 = "0.10"
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio",
+    "tls-rustls",
+    "postgres",
+    "chrono",
+    "uuid",
+] }
+subtle = "2"
+thiserror = "2"
+tracing = "0.1"
+uuid = { version = "1", features = ["serde", "v4"] }
+
+[dev-dependencies]
+au-kpis-config = { workspace = true }
+au-kpis-db = { workspace = true }
+au-kpis-testing = { workspace = true }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+
+[lints]
+workspace = true

--- a/crates/au-kpis-auth/src/lib.rs
+++ b/crates/au-kpis-auth/src/lib.rs
@@ -1,1 +1,390 @@
-//! API key validation, Redis rate limiter.
+//! API key lifecycle and verification.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::{sync::Arc, time::Duration};
+
+use argon2::{
+    Argon2, PasswordHash, PasswordHasher, PasswordVerifier,
+    password_hash::{SaltString, rand_core::OsRng as PasswordOsRng},
+};
+use au_kpis_cache::{CacheClient, CacheError};
+use au_kpis_error::{Classify, ErrorClass};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use sqlx::PgPool;
+use subtle::ConstantTimeEq;
+use thiserror::Error;
+use tracing::instrument;
+use uuid::Uuid;
+
+const API_KEY_PREFIX: &str = "auk_live_";
+const API_KEY_SECRET_BYTES: usize = 32;
+const API_KEY_CACHE_TTL: Duration = Duration::from_secs(60);
+
+/// Request body for creating an API key through an admin-only flow.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreateApiKeyRequest {
+    /// Human-readable key name.
+    pub name: String,
+    /// Authorization scopes attached to the key.
+    pub scopes: Vec<String>,
+    /// Rate-limit tier consumed by downstream rate-limit middleware.
+    pub rate_limit_tier: String,
+    /// Administrative actor issuing the key.
+    pub actor: String,
+}
+
+/// Newly-created API key.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CreatedApiKey {
+    /// Stable key identifier, embedded in the plaintext key and stored in DB.
+    pub id: Uuid,
+    /// Plaintext key shown once to the admin caller.
+    pub plaintext: String,
+    /// Human-readable key name.
+    pub name: String,
+    /// Authorization scopes attached to the key.
+    pub scopes: Vec<String>,
+    /// Rate-limit tier consumed by downstream rate-limit middleware.
+    pub rate_limit_tier: String,
+}
+
+/// API key identity produced by successful verification.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct VerifiedApiKey {
+    /// Stable API key identifier.
+    pub id: Uuid,
+    /// Human-readable key name.
+    pub name: String,
+    /// Authorization scopes attached to the key.
+    pub scopes: Vec<String>,
+    /// Rate-limit tier consumed by downstream rate-limit middleware.
+    pub rate_limit_tier: String,
+}
+
+/// Errors returned by API-key lifecycle and verification.
+#[derive(Debug, Error)]
+pub enum AuthError {
+    /// Supplied API key is missing, malformed, unknown, invalid, or revoked.
+    #[error("invalid api key")]
+    InvalidApiKey,
+    /// Caller supplied invalid admin input.
+    #[error("validation: {0}")]
+    Validation(String),
+    /// Password hashing failed.
+    #[error("password hash: {0}")]
+    PasswordHash(#[from] argon2::password_hash::Error),
+    /// Database access failed.
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+    /// Cache access failed.
+    #[error(transparent)]
+    Cache(#[from] CacheError),
+}
+
+impl Classify for AuthError {
+    fn class(&self) -> ErrorClass {
+        match self {
+            AuthError::InvalidApiKey | AuthError::Validation(_) => ErrorClass::Validation,
+            AuthError::PasswordHash(_) => ErrorClass::Permanent,
+            AuthError::Db(_) | AuthError::Cache(_) => ErrorClass::Transient,
+        }
+    }
+}
+
+/// API-key lifecycle and verification service.
+#[derive(Debug, Clone)]
+pub struct ApiKeyManager {
+    db: PgPool,
+    cache: Arc<CacheClient>,
+}
+
+impl ApiKeyManager {
+    /// Construct a manager from shared database and cache clients.
+    pub fn new(db: PgPool, cache: Arc<CacheClient>) -> Self {
+        Self { db, cache }
+    }
+
+    /// Create a new API key, persist only its argon2id hash, and audit issuance.
+    #[instrument(skip(self, request), fields(api_key.name = %request.name, actor = %request.actor))]
+    pub async fn create_key(
+        &self,
+        request: CreateApiKeyRequest,
+    ) -> Result<CreatedApiKey, AuthError> {
+        validate_create_request(&request)?;
+
+        let id = Uuid::new_v4();
+        let plaintext = generate_plaintext_key(id);
+        let key_hash = hash_key(&plaintext)?;
+        let mut tx = self.db.begin().await?;
+
+        sqlx::query(
+            "INSERT INTO api_keys (id, key_hash, name, scopes, rate_limit_tier)
+             VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(id)
+        .bind(&key_hash)
+        .bind(&request.name)
+        .bind(&request.scopes)
+        .bind(&request.rate_limit_tier)
+        .execute(&mut *tx)
+        .await?;
+
+        insert_audit_log(&mut tx, id, "created", &request.actor).await?;
+        tx.commit().await?;
+
+        Ok(CreatedApiKey {
+            id,
+            plaintext,
+            name: request.name,
+            scopes: request.scopes,
+            rate_limit_tier: request.rate_limit_tier,
+        })
+    }
+
+    /// Verify a plaintext API key using Redis cache and constant-time comparison.
+    #[instrument(skip(self, plaintext_key), fields(api_key.id))]
+    pub async fn verify(&self, plaintext_key: &str) -> Result<VerifiedApiKey, AuthError> {
+        let parsed = parse_plaintext_key(plaintext_key)?;
+        tracing::Span::current().record("api_key.id", parsed.id.to_string());
+
+        let cache_key = cache_key(parsed.id);
+        if let Some(cached) = self.cache.get_json::<CachedApiKey>(&cache_key).await? {
+            return verify_cached_key(plaintext_key, cached);
+        }
+
+        let Some(stored) = fetch_active_key(&self.db, parsed.id).await? else {
+            return Err(AuthError::InvalidApiKey);
+        };
+
+        verify_argon2_hash(plaintext_key, &stored.key_hash)?;
+        let verified = VerifiedApiKey {
+            id: stored.id,
+            name: stored.name,
+            scopes: stored.scopes,
+            rate_limit_tier: stored.rate_limit_tier,
+        };
+        let cached = CachedApiKey::from_verified(plaintext_key, &verified);
+        self.cache
+            .set_json(&cache_key, &cached, API_KEY_CACHE_TTL)
+            .await?;
+
+        sqlx::query("UPDATE api_keys SET last_used_at = now() WHERE id = $1")
+            .bind(stored.id)
+            .execute(&self.db)
+            .await?;
+
+        Ok(verified)
+    }
+
+    /// Revoke an API key, audit the action, and evict the cached verifier.
+    #[instrument(skip(self, actor), fields(api_key.id = %id, actor = %actor))]
+    pub async fn revoke_key(&self, id: Uuid, actor: &str) -> Result<(), AuthError> {
+        if actor.trim().is_empty() {
+            return Err(AuthError::Validation("actor is required".into()));
+        }
+
+        let mut tx = self.db.begin().await?;
+        let result = sqlx::query(
+            "UPDATE api_keys
+             SET revoked_at = COALESCE(revoked_at, now())
+             WHERE id = $1",
+        )
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+        if result.rows_affected() == 0 {
+            return Err(AuthError::InvalidApiKey);
+        }
+
+        insert_audit_log(&mut tx, id, "revoked", actor).await?;
+        tx.commit().await?;
+        self.cache.delete(&cache_key(id)).await?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParsedApiKey {
+    id: Uuid,
+}
+
+#[derive(Debug)]
+struct StoredApiKey {
+    id: Uuid,
+    key_hash: String,
+    name: String,
+    scopes: Vec<String>,
+    rate_limit_tier: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CachedApiKey {
+    fingerprint: String,
+    verified: VerifiedApiKey,
+}
+
+impl CachedApiKey {
+    fn from_verified(plaintext_key: &str, verified: &VerifiedApiKey) -> Self {
+        Self {
+            fingerprint: key_fingerprint(plaintext_key),
+            verified: verified.clone(),
+        }
+    }
+}
+
+fn validate_create_request(request: &CreateApiKeyRequest) -> Result<(), AuthError> {
+    if request.name.trim().is_empty() {
+        return Err(AuthError::Validation("name is required".into()));
+    }
+    if request.rate_limit_tier.trim().is_empty() {
+        return Err(AuthError::Validation("rate_limit_tier is required".into()));
+    }
+    if request.actor.trim().is_empty() {
+        return Err(AuthError::Validation("actor is required".into()));
+    }
+    Ok(())
+}
+
+fn generate_plaintext_key(id: Uuid) -> String {
+    let mut secret = [0_u8; API_KEY_SECRET_BYTES];
+    rand::rngs::OsRng.fill_bytes(&mut secret);
+    format!(
+        "{API_KEY_PREFIX}{}_{}",
+        id.simple(),
+        URL_SAFE_NO_PAD.encode(secret)
+    )
+}
+
+fn parse_plaintext_key(plaintext_key: &str) -> Result<ParsedApiKey, AuthError> {
+    let Some(remainder) = plaintext_key.strip_prefix(API_KEY_PREFIX) else {
+        return Err(AuthError::InvalidApiKey);
+    };
+    let Some((id, secret)) = remainder.split_once('_') else {
+        return Err(AuthError::InvalidApiKey);
+    };
+    if secret.is_empty() || id.is_empty() {
+        return Err(AuthError::InvalidApiKey);
+    }
+    let id = Uuid::parse_str(id).map_err(|_| AuthError::InvalidApiKey)?;
+    Ok(ParsedApiKey { id })
+}
+
+fn hash_key(plaintext_key: &str) -> Result<String, AuthError> {
+    let salt = SaltString::generate(&mut PasswordOsRng);
+    Ok(Argon2::default()
+        .hash_password(plaintext_key.as_bytes(), &salt)?
+        .to_string())
+}
+
+fn verify_argon2_hash(plaintext_key: &str, key_hash: &str) -> Result<(), AuthError> {
+    let parsed_hash = PasswordHash::new(key_hash)?;
+    Argon2::default()
+        .verify_password(plaintext_key.as_bytes(), &parsed_hash)
+        .map_err(|_| AuthError::InvalidApiKey)
+}
+
+fn key_fingerprint(plaintext_key: &str) -> String {
+    URL_SAFE_NO_PAD.encode(Sha256::digest(plaintext_key.as_bytes()))
+}
+
+fn verify_cached_key(
+    plaintext_key: &str,
+    cached: CachedApiKey,
+) -> Result<VerifiedApiKey, AuthError> {
+    let supplied = key_fingerprint(plaintext_key);
+    if supplied
+        .as_bytes()
+        .ct_eq(cached.fingerprint.as_bytes())
+        .into()
+    {
+        Ok(cached.verified)
+    } else {
+        Err(AuthError::InvalidApiKey)
+    }
+}
+
+fn cache_key(id: Uuid) -> String {
+    format!("auth:api-key:{id}")
+}
+
+async fn fetch_active_key(db: &PgPool, id: Uuid) -> Result<Option<StoredApiKey>, AuthError> {
+    sqlx::query_as::<_, (Uuid, String, String, Vec<String>, String)>(
+        "SELECT id, key_hash, name, scopes, rate_limit_tier
+         FROM api_keys
+         WHERE id = $1 AND revoked_at IS NULL",
+    )
+    .bind(id)
+    .fetch_optional(db)
+    .await
+    .map(|row| {
+        row.map(
+            |(id, key_hash, name, scopes, rate_limit_tier)| StoredApiKey {
+                id,
+                key_hash,
+                name,
+                scopes,
+                rate_limit_tier,
+            },
+        )
+    })
+    .map_err(AuthError::from)
+}
+
+async fn insert_audit_log(
+    tx: &mut sqlx::Transaction<'_, sqlx::Postgres>,
+    api_key_id: Uuid,
+    action: &str,
+    actor: &str,
+) -> Result<(), AuthError> {
+    sqlx::query(
+        "INSERT INTO api_key_audit_log (api_key_id, action, actor)
+         VALUES ($1, $2, $3)",
+    )
+    .bind(api_key_id)
+    .bind(action)
+    .bind(actor)
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generated_key_roundtrips_id_and_prefix() {
+        let id = Uuid::new_v4();
+        let plaintext = generate_plaintext_key(id);
+
+        assert!(plaintext.starts_with(API_KEY_PREFIX));
+        assert_eq!(parse_plaintext_key(&plaintext).expect("parse key").id, id);
+    }
+
+    #[test]
+    fn cached_verifier_uses_constant_time_fingerprint_match() {
+        let verified = VerifiedApiKey {
+            id: Uuid::new_v4(),
+            name: "client".into(),
+            scopes: vec!["observations:read".into()],
+            rate_limit_tier: "free".into(),
+        };
+        let plaintext = generate_plaintext_key(verified.id);
+        let cached = CachedApiKey::from_verified(&plaintext, &verified);
+
+        assert_eq!(
+            verify_cached_key(&plaintext, cached.clone()).expect("cache hit"),
+            verified
+        );
+        assert!(matches!(
+            verify_cached_key("auk_live_00000000000000000000000000000000_bad", cached),
+            Err(AuthError::InvalidApiKey)
+        ));
+    }
+}

--- a/crates/au-kpis-auth/tests/api_keys.rs
+++ b/crates/au-kpis-auth/tests/api_keys.rs
@@ -1,0 +1,153 @@
+use std::sync::Arc;
+
+use au_kpis_auth::{ApiKeyManager, AuthError, CreateApiKeyRequest};
+use au_kpis_cache::CacheClient;
+use au_kpis_config::DatabaseConfig;
+use au_kpis_db::{connect, migrate};
+use au_kpis_testing::{
+    redis::{RedisHarness, start_redis},
+    timescale::{TimescaleHarness, start_timescale},
+};
+use chrono::{DateTime, Utc};
+use sqlx::PgPool;
+
+struct TestContext {
+    _postgres: TimescaleHarness,
+    _redis: RedisHarness,
+    pool: PgPool,
+    manager: ApiKeyManager,
+}
+
+impl TestContext {
+    async fn start(database: &str) -> Self {
+        let postgres = start_timescale(database)
+            .await
+            .expect("start timescaledb container");
+        let redis = start_redis().await.expect("start redis container");
+        let pool = connect(&DatabaseConfig {
+            url: postgres.url().to_string(),
+        })
+        .await
+        .expect("connect postgres");
+        migrate(&pool).await.expect("apply migrations");
+        let cache = Arc::new(
+            CacheClient::connect(redis.url())
+                .await
+                .expect("connect redis"),
+        );
+        let manager = ApiKeyManager::new(pool.clone(), cache);
+
+        Self {
+            _postgres: postgres,
+            _redis: redis,
+            pool,
+            manager,
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_verify_revoke_hashes_keys_uses_cache_and_audits() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let ctx = TestContext::start("au_kpis_auth_roundtrip").await;
+    let created = ctx
+        .manager
+        .create_key(CreateApiKeyRequest {
+            name: "daily batch".into(),
+            scopes: vec!["observations:read".into()],
+            rate_limit_tier: "free".into(),
+            actor: "platform-admin@example.com".into(),
+        })
+        .await
+        .expect("create api key");
+
+    assert!(
+        created.plaintext.starts_with("auk_live_"),
+        "new keys must use the leak-detection prefix"
+    );
+
+    let persisted: (String, Vec<String>, String, String) = sqlx::query_as(
+        "SELECT key_hash, scopes, rate_limit_tier, row_to_json(api_keys)::text
+         FROM api_keys
+         WHERE id = $1",
+    )
+    .bind(created.id)
+    .fetch_one(&ctx.pool)
+    .await
+    .expect("fetch stored key");
+
+    assert!(persisted.0.starts_with("$argon2id$"));
+    assert_ne!(persisted.0, created.plaintext);
+    assert!(
+        !persisted.3.contains(&created.plaintext),
+        "plaintext key must never be persisted"
+    );
+    assert_eq!(persisted.1, vec!["observations:read".to_string()]);
+    assert_eq!(persisted.2, "free");
+
+    let verified = ctx
+        .manager
+        .verify(&created.plaintext)
+        .await
+        .expect("valid key verifies");
+    assert_eq!(verified.id, created.id);
+    assert_eq!(verified.name, "daily batch");
+    assert_eq!(verified.scopes, vec!["observations:read".to_string()]);
+    assert_eq!(verified.rate_limit_tier, "free");
+
+    sqlx::query("UPDATE api_keys SET name = 'renamed in database' WHERE id = $1")
+        .bind(created.id)
+        .execute(&ctx.pool)
+        .await
+        .expect("rename stored key");
+    let cached = ctx
+        .manager
+        .verify(&created.plaintext)
+        .await
+        .expect("cached key verifies");
+    assert_eq!(
+        cached.name, "daily batch",
+        "second verification should read the Redis-cached lookup"
+    );
+
+    let invalid = ctx.manager.verify("auk_live_invalid").await;
+    assert!(matches!(invalid, Err(AuthError::InvalidApiKey)));
+
+    ctx.manager
+        .revoke_key(created.id, "security-admin@example.com")
+        .await
+        .expect("revoke key");
+    let revoked = ctx.manager.verify(&created.plaintext).await;
+    assert!(matches!(revoked, Err(AuthError::InvalidApiKey)));
+
+    let audit_rows: Vec<(String, String, DateTime<Utc>, DateTime<Utc>)> = sqlx::query_as(
+        "SELECT action, actor, occurred_at, retention_until
+         FROM api_key_audit_log
+         WHERE api_key_id = $1
+         ORDER BY occurred_at ASC",
+    )
+    .bind(created.id)
+    .fetch_all(&ctx.pool)
+    .await
+    .expect("fetch audit log");
+
+    assert_eq!(audit_rows.len(), 2);
+    assert_eq!(audit_rows[0].0, "created");
+    assert_eq!(audit_rows[0].1, "platform-admin@example.com");
+    assert_eq!(audit_rows[1].0, "revoked");
+    assert_eq!(audit_rows[1].1, "security-admin@example.com");
+    for (_, _, occurred_at, retention_until) in audit_rows {
+        let retention = retention_until - occurred_at;
+        assert!(retention >= chrono::Duration::days(365));
+        assert!(retention <= chrono::Duration::days(366));
+    }
+}
+
+fn docker_available() -> bool {
+    std::env::var_os("DOCKER_HOST").is_some()
+        || std::path::Path::new("/var/run/docker.sock").exists()
+}

--- a/crates/au-kpis-db/tests/migrations.rs
+++ b/crates/au-kpis-db/tests/migrations.rs
@@ -174,6 +174,7 @@ async fn migration_creates_hypertable_and_compression_policy() {
     .expect("list tables");
     let table_names: Vec<&str> = tables.iter().map(|t| t.0.as_str()).collect();
     for expected in [
+        "api_key_audit_log",
         "api_keys",
         "artifacts",
         "codelists",

--- a/crates/bins/au-kpis-cli/Cargo.toml
+++ b/crates/bins/au-kpis-cli/Cargo.toml
@@ -8,3 +8,28 @@ repository.workspace = true
 description = "Admin CLI (migrations, backfills)."
 
 [dependencies]
+anyhow = "1"
+au-kpis-auth = { workspace = true }
+au-kpis-cache = { workspace = true }
+au-kpis-config = { workspace = true }
+au-kpis-db = { workspace = true }
+clap = { version = "4", features = ["derive", "env"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+uuid = { version = "1", features = ["serde"] }
+
+[dev-dependencies]
+assert_cmd = "2"
+au-kpis-testing = { workspace = true }
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+sqlx = { version = "0.8", default-features = false, features = [
+    "runtime-tokio",
+    "tls-rustls",
+    "postgres",
+    "chrono",
+    "uuid",
+] }
+
+[lints]
+workspace = true

--- a/crates/bins/au-kpis-cli/src/main.rs
+++ b/crates/bins/au-kpis-cli/src/main.rs
@@ -1,2 +1,122 @@
 //! Admin CLI (migrations, backfills).
-fn main() {}
+
+use std::sync::Arc;
+
+use anyhow::Context;
+use au_kpis_auth::{ApiKeyManager, CreateApiKeyRequest};
+use au_kpis_cache::CacheClient;
+use au_kpis_config::load;
+use au_kpis_db::connect as connect_db;
+use clap::{Parser, Subcommand};
+use serde::Serialize;
+use uuid::Uuid;
+
+#[derive(Debug, Parser)]
+#[command(name = "au-kpis-cli")]
+#[command(about = "Administrative tools for australian-kpis")]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+enum Commands {
+    #[command(name = "api-keys")]
+    ApiKeys {
+        #[command(subcommand)]
+        command: ApiKeyCommand,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum ApiKeyCommand {
+    Create {
+        #[arg(long)]
+        name: String,
+        #[arg(long = "scope")]
+        scopes: Vec<String>,
+        #[arg(long, default_value = "free")]
+        rate_limit_tier: String,
+        #[arg(long)]
+        actor: String,
+    },
+    Revoke {
+        #[arg(long)]
+        id: Uuid,
+        #[arg(long)]
+        actor: String,
+    },
+}
+
+#[derive(Debug, Serialize)]
+struct CreatedApiKeyOutput {
+    id: Uuid,
+    name: String,
+    scopes: Vec<String>,
+    rate_limit_tier: String,
+    api_key: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RevokedApiKeyOutput {
+    id: Uuid,
+    revoked: bool,
+}
+
+#[tokio::main(flavor = "multi_thread")]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let config = load(None).context("load config")?;
+    let db = connect_db(&config.database)
+        .await
+        .context("connect postgres database")?;
+    let cache = Arc::new(
+        CacheClient::connect(&config.cache.url)
+            .await
+            .context("connect redis cache")?,
+    );
+    let manager = ApiKeyManager::new(db, cache);
+
+    match cli.command {
+        Commands::ApiKeys { command } => match command {
+            ApiKeyCommand::Create {
+                name,
+                scopes,
+                rate_limit_tier,
+                actor,
+            } => {
+                let created = manager
+                    .create_key(CreateApiKeyRequest {
+                        name,
+                        scopes,
+                        rate_limit_tier,
+                        actor,
+                    })
+                    .await
+                    .context("create api key")?;
+                print_json(&CreatedApiKeyOutput {
+                    id: created.id,
+                    name: created.name,
+                    scopes: created.scopes,
+                    rate_limit_tier: created.rate_limit_tier,
+                    api_key: created.plaintext,
+                })?;
+            }
+            ApiKeyCommand::Revoke { id, actor } => {
+                manager
+                    .revoke_key(id, &actor)
+                    .await
+                    .context("revoke api key")?;
+                print_json(&RevokedApiKeyOutput { id, revoked: true })?;
+            }
+        },
+    }
+
+    Ok(())
+}
+
+fn print_json<T: Serialize>(value: &T) -> anyhow::Result<()> {
+    serde_json::to_writer_pretty(std::io::stdout(), value).context("write json output")?;
+    println!();
+    Ok(())
+}

--- a/crates/bins/au-kpis-cli/tests/api_keys.rs
+++ b/crates/bins/au-kpis-cli/tests/api_keys.rs
@@ -1,0 +1,108 @@
+use assert_cmd::cargo::cargo_bin;
+use au_kpis_config::DatabaseConfig;
+use au_kpis_db::{connect, migrate};
+use au_kpis_testing::{redis::start_redis, timescale::start_timescale};
+use serde_json::Value;
+use sqlx::PgPool;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn api_key_admin_commands_create_print_once_and_revoke_with_audit() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let postgres = start_timescale("au_kpis_cli_api_keys")
+        .await
+        .expect("start timescaledb container");
+    let redis = start_redis().await.expect("start redis container");
+    let pool = connect(&DatabaseConfig {
+        url: postgres.url().to_string(),
+    })
+    .await
+    .expect("connect postgres");
+    migrate(&pool).await.expect("apply migrations");
+
+    let create = cli(postgres.url(), redis.url())
+        .args([
+            "api-keys",
+            "create",
+            "--name",
+            "sdk client",
+            "--scope",
+            "observations:read",
+            "--actor",
+            "platform-admin@example.com",
+        ])
+        .output()
+        .expect("run api key create");
+    assert!(
+        create.status.success(),
+        "create command failed: {}",
+        String::from_utf8_lossy(&create.stderr)
+    );
+    assert!(
+        create.stderr.is_empty(),
+        "plaintext key should not be echoed to stderr"
+    );
+
+    let body: Value = serde_json::from_slice(&create.stdout).expect("create json");
+    let id = body["id"].as_str().expect("id");
+    let plaintext = body["api_key"].as_str().expect("api_key");
+    assert!(plaintext.starts_with("auk_live_"));
+    assert_eq!(body["name"], "sdk client");
+    assert_eq!(body["scopes"], serde_json::json!(["observations:read"]));
+
+    let stored: String = sqlx::query_scalar("SELECT row_to_json(api_keys)::text FROM api_keys")
+        .fetch_one(&pool)
+        .await
+        .expect("fetch stored key");
+    assert!(!stored.contains(plaintext));
+
+    let revoke = cli(postgres.url(), redis.url())
+        .args([
+            "api-keys",
+            "revoke",
+            "--id",
+            id,
+            "--actor",
+            "security-admin@example.com",
+        ])
+        .output()
+        .expect("run api key revoke");
+    assert!(
+        revoke.status.success(),
+        "revoke command failed: {}",
+        String::from_utf8_lossy(&revoke.stderr)
+    );
+
+    let audit_actions: Vec<String> =
+        sqlx::query_scalar("SELECT action FROM api_key_audit_log ORDER BY occurred_at ASC")
+            .fetch_all(&pool)
+            .await
+            .expect("fetch audit actions");
+    assert_eq!(audit_actions, vec!["created", "revoked"]);
+    assert_revoked(&pool).await;
+}
+
+fn cli(database_url: &str, cache_url: &str) -> std::process::Command {
+    let mut command = std::process::Command::new(cargo_bin("au-kpis-cli"));
+    command
+        .env("AU_KPIS_DATABASE__URL", database_url)
+        .env("AU_KPIS_CACHE__URL", cache_url);
+    command
+}
+
+async fn assert_revoked(pool: &PgPool) {
+    let revoked: Option<chrono::DateTime<chrono::Utc>> =
+        sqlx::query_scalar("SELECT revoked_at FROM api_keys LIMIT 1")
+            .fetch_one(pool)
+            .await
+            .expect("fetch revoked_at");
+    assert!(revoked.is_some());
+}
+
+fn docker_available() -> bool {
+    std::env::var_os("DOCKER_HOST").is_some()
+        || std::path::Path::new("/var/run/docker.sock").exists()
+}

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,0 +1,33 @@
+# Security Operations
+
+## API Key Rotation
+
+API keys are created and revoked through `au-kpis-cli`, which uses the
+configured Postgres and Redis connections. The plaintext key is printed only by
+the create command and is never stored.
+
+1. Create a replacement key with the scopes and tier the client needs:
+
+   ```bash
+   au-kpis-cli api-keys create \
+     --name "client name" \
+     --scope observations:read \
+     --rate-limit-tier free \
+     --actor admin@example.com
+   ```
+
+2. Copy the returned `api_key` value into the client's secret store and deploy
+   the client change.
+
+3. Confirm the client can call protected routes with the new `X-API-Key`.
+
+4. Revoke the old key by id:
+
+   ```bash
+   au-kpis-cli api-keys revoke \
+     --id 00000000-0000-0000-0000-000000000000 \
+     --actor admin@example.com
+   ```
+
+5. Watch for any remaining requests using the revoked key. Issuance and
+   revocation events are retained in `api_key_audit_log` for one year.

--- a/infra/migrations/0005_api_key_audit_log.down.sql
+++ b/infra/migrations/0005_api_key_audit_log.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS api_key_audit_log;

--- a/infra/migrations/0005_api_key_audit_log.up.sql
+++ b/infra/migrations/0005_api_key_audit_log.up.sql
@@ -1,0 +1,19 @@
+-- API-key issuance/revocation audit log.
+-- Retention follows `Spec.md § Security posture`: keep lifecycle events for
+-- one year so leaked or abused keys can be investigated without storing key
+-- plaintext.
+
+CREATE TABLE api_key_audit_log (
+    id              BIGSERIAL PRIMARY KEY,
+    api_key_id      UUID NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+    action          TEXT NOT NULL CHECK (action IN ('created', 'revoked')),
+    actor           TEXT NOT NULL CHECK (char_length(actor) BETWEEN 1 AND 320),
+    occurred_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    retention_until TIMESTAMPTZ NOT NULL DEFAULT (now() + INTERVAL '1 year')
+);
+
+CREATE INDEX api_key_audit_log_key_idx
+ON api_key_audit_log (api_key_id, occurred_at DESC);
+
+CREATE INDEX api_key_audit_log_retention_idx
+ON api_key_audit_log (retention_until);


### PR DESCRIPTION
Closes #45

## Pass requirements

- [x] Protected routes can validate `X-API-Key` through middleware
- [x] API keys are stored argon2id-hashed and plaintext is never persisted
- [x] New keys use the `auk_live_` prefix for leak detection
- [x] Verification uses Redis-cached lookup and constant-time comparison
- [x] Admin-only create/revoke flow is implemented and audit-logged with 1-year retention
- [x] Rotation flow is documented
- [x] No admin HTTP endpoints were added; OpenAPI has no semantic drift and no `Spec.md` amendment is required

## Test plan

- `cargo fmt --all --check`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo check --workspace --locked`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo nextest run --workspace --profile ci -j 1 --retries 0`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks protect --staged`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo run -p au-kpis-openapi --locked > target/openapi/issue45-openapi.json`
- `oasdiff breaking openapi.json target/openapi/issue45-openapi.json`

## Spec impact

No Spec changes required. The admin lifecycle is exposed through `au-kpis-cli`, not through new HTTP admin endpoints.
