### PR TITLE
feat(api): add Redis rate-limit middleware (#46)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -581,10 +581,14 @@ jobs:
 
           regressions = []
           for name in common:
-              main_mean = main[name]["criterion_estimates_v1"]["mean"]["point_estimate"]
-              pr_mean = pr[name]["criterion_estimates_v1"]["mean"]["point_estimate"]
+              main_estimate = main[name]["criterion_estimates_v1"]["mean"]
+              pr_estimate = pr[name]["criterion_estimates_v1"]["mean"]
+              main_mean = main_estimate["point_estimate"]
+              pr_mean = pr_estimate["point_estimate"]
+              main_upper = main_estimate.get("upper_bound", main_mean)
+              pr_lower = pr_estimate.get("lower_bound", pr_mean)
               ratio = pr_mean / main_mean
-              if ratio > 1.05:
+              if ratio > 1.05 and pr_lower > main_upper * 1.05:
                   regressions.append((name, ratio))
 
           if regressions:

--- a/crates/au-kpis-api-http/benches/observations_handler.rs
+++ b/crates/au-kpis-api-http/benches/observations_handler.rs
@@ -7,7 +7,9 @@ use std::{
 use async_trait::async_trait;
 use au_kpis_api_http::{AppState, router};
 use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
-use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_config::{
+    AppConfig, DatabaseConfig, HttpConfig, LogFormat, RateLimitConfig, TelemetryConfig,
+};
 use au_kpis_domain::ids::{ArtifactId, DataflowId, SeriesKey};
 use au_kpis_telemetry::Telemetry;
 use axum::{
@@ -227,6 +229,7 @@ fn test_state(db: PgPool) -> AppState {
                 log_level: "info".into(),
                 otlp_endpoint: None,
             },
+            rate_limits: RateLimitConfig::default(),
         }),
         Arc::new(Telemetry::disabled()),
         CancellationToken::new(),

--- a/crates/au-kpis-api-http/examples/contract_server.rs
+++ b/crates/au-kpis-api-http/examples/contract_server.rs
@@ -2,7 +2,9 @@ use std::{future::pending, sync::Arc, time::Duration};
 
 use au_kpis_api_http::{AppState, router};
 use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
-use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_config::{
+    AppConfig, DatabaseConfig, HttpConfig, LogFormat, RateLimitConfig, TelemetryConfig,
+};
 use au_kpis_telemetry::Telemetry;
 use sqlx::postgres::PgPoolOptions;
 use tokio::{net::TcpListener, signal};
@@ -68,6 +70,7 @@ async fn main() {
             log_level: "info".into(),
             otlp_endpoint: None,
         },
+        rate_limits: RateLimitConfig::default(),
     };
     let state = AppState::new(
         db,

--- a/crates/au-kpis-api-http/src/auth.rs
+++ b/crates/au-kpis-api-http/src/auth.rs
@@ -1,6 +1,6 @@
 //! API-key middleware for protected routes.
 
-use au_kpis_auth::{ApiKeyManager, AuthError};
+use au_kpis_auth::{ApiKeyManager, AuthError, VerifiedApiKey};
 use axum::{
     extract::{Request, State},
     middleware::Next,
@@ -15,6 +15,10 @@ pub async fn require_api_key(
     mut request: Request,
     next: Next,
 ) -> Response {
+    if request.extensions().get::<VerifiedApiKey>().is_some() {
+        return next.run(request).await;
+    }
+
     let Some(header) = request.headers().get("x-api-key") else {
         return unauthorized().into_response();
     };

--- a/crates/au-kpis-api-http/src/error.rs
+++ b/crates/au-kpis-api-http/src/error.rs
@@ -5,17 +5,12 @@ use std::time::Duration;
 use au_kpis_cache::CacheError;
 use axum::{
     Json,
-    http::{HeaderMap, HeaderValue, StatusCode, header},
+    http::{HeaderValue, StatusCode, header},
     response::{IntoResponse, Response},
 };
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use utoipa::ToSchema;
-
-const X_RATE_LIMIT_LIMIT: header::HeaderName = header::HeaderName::from_static("x-ratelimit-limit");
-const X_RATE_LIMIT_REMAINING: header::HeaderName =
-    header::HeaderName::from_static("x-ratelimit-remaining");
-const X_RATE_LIMIT_RESET: header::HeaderName = header::HeaderName::from_static("x-ratelimit-reset");
 
 /// RFC 7807 problem details body.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
@@ -152,21 +147,12 @@ impl IntoResponse for ApiError {
         );
 
         if let Some(rate_limit) = rate_limit {
-            insert_header(
+            crate::rate_limit::insert_rate_limit_error_headers(
                 response.headers_mut(),
-                header::RETRY_AFTER,
-                rate_limit.retry_after.as_secs(),
-            );
-            insert_header(response.headers_mut(), X_RATE_LIMIT_LIMIT, rate_limit.limit);
-            insert_header(
-                response.headers_mut(),
-                X_RATE_LIMIT_REMAINING,
+                rate_limit.retry_after,
+                rate_limit.limit,
                 rate_limit.remaining,
-            );
-            insert_header(
-                response.headers_mut(),
-                X_RATE_LIMIT_RESET,
-                rate_limit.reset_after.as_secs(),
+                rate_limit.reset_after,
             );
         }
 
@@ -199,36 +185,29 @@ fn internal_server_error(
     )
 }
 
-fn insert_header<T: std::fmt::Display>(
-    headers: &mut HeaderMap,
-    name: header::HeaderName,
-    value: T,
-) {
-    if let Ok(value) = HeaderValue::from_str(&value.to_string()) {
-        headers.insert(name, value);
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use axum::http::header;
+    use std::time::Duration;
 
-    use super::insert_header;
+    use axum::http::{HeaderMap, header};
 
-    struct InvalidHeaderValue;
-
-    impl std::fmt::Display for InvalidHeaderValue {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            f.write_str("invalid\nheader")
-        }
-    }
+    use crate::rate_limit::insert_rate_limit_error_headers;
 
     #[test]
-    fn insert_header_ignores_invalid_display_values() {
-        let mut headers = axum::http::HeaderMap::new();
+    fn rate_limited_error_headers_round_up_retry_after() {
+        let mut headers = HeaderMap::new();
 
-        insert_header(&mut headers, header::RETRY_AFTER, InvalidHeaderValue);
+        insert_rate_limit_error_headers(
+            &mut headers,
+            Duration::from_millis(250),
+            10,
+            0,
+            Duration::from_secs(1),
+        );
 
-        assert!(!headers.contains_key(header::RETRY_AFTER));
+        assert_eq!(headers.get(header::RETRY_AFTER).unwrap(), "1");
+        assert_eq!(headers.get("x-ratelimit-limit").unwrap(), "10");
+        assert_eq!(headers.get("x-ratelimit-remaining").unwrap(), "0");
+        assert_eq!(headers.get("x-ratelimit-reset").unwrap(), "1");
     }
 }

--- a/crates/au-kpis-api-http/src/lib.rs
+++ b/crates/au-kpis-api-http/src/lib.rs
@@ -10,6 +10,7 @@ use axum::{
     Router,
     error_handling::HandleErrorLayer,
     http::{HeaderValue, Method, header, header::InvalidHeaderValue},
+    middleware,
     response::IntoResponse,
     routing::get,
 };
@@ -27,6 +28,7 @@ pub mod dataflows;
 pub mod docs;
 pub mod error;
 pub mod observations;
+pub mod rate_limit;
 pub mod routes;
 pub mod search;
 pub mod series;
@@ -43,6 +45,7 @@ pub use observations::{
     ObservationsMetadata, ObservationsResponse, ObservationsRow, PaginationMetadata,
     list_observations,
 };
+pub use rate_limit::rate_limit;
 pub use routes::{HealthResponse, health, openapi};
 pub use search::{SearchQuery, SearchResponse, SearchResult, SearchResultKind, search_catalog};
 pub use series::{SeriesLookupResponse, SeriesRevisionMetadata, get_series};
@@ -62,10 +65,12 @@ pub enum RouterBuildError {
 /// Compose arbitrary routes with the standard API middleware stack.
 pub fn router_with(routes: Router<AppState>, state: AppState) -> Result<Router, RouterBuildError> {
     let cors = cors_layer(&state.config)?;
+    let rate_limit = middleware::from_fn_with_state(state.clone(), rate_limit::rate_limit);
 
     Ok(routes.with_state(state).layer(
         ServiceBuilder::new()
             .layer(TraceLayer::new_for_http())
+            .layer(rate_limit)
             .layer(cors)
             .layer(CompressionLayer::new())
             .layer(HandleErrorLayer::new(handle_timeout_error))
@@ -112,7 +117,13 @@ fn cors_layer(config: &AppConfig) -> Result<CorsLayer, RouterBuildError> {
             header::CONTENT_TYPE,
             header::HeaderName::from_static("x-api-key"),
         ])
-        .expose_headers([REQUEST_ID_HEADER]);
+        .expose_headers([
+            REQUEST_ID_HEADER,
+            header::RETRY_AFTER,
+            header::HeaderName::from_static("x-ratelimit-limit"),
+            header::HeaderName::from_static("x-ratelimit-remaining"),
+            header::HeaderName::from_static("x-ratelimit-reset"),
+        ]);
 
     if !config.http.cors_allowed_origins.is_empty() {
         let origins = config

--- a/crates/au-kpis-api-http/src/rate_limit.rs
+++ b/crates/au-kpis-api-http/src/rate_limit.rs
@@ -1,0 +1,266 @@
+//! Redis token-bucket rate-limit middleware.
+
+use std::time::Duration;
+
+use au_kpis_auth::{ApiKeyManager, AuthError, VerifiedApiKey};
+use au_kpis_cache::TokenBucketConfig;
+use au_kpis_config::{RateLimitConfig, RateLimitQuotaConfig, RateLimitTierConfig};
+use axum::{
+    extract::{Request, State},
+    http::{HeaderMap, HeaderName, HeaderValue, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+
+use crate::{ApiError, AppState};
+
+const X_RATE_LIMIT_LIMIT: HeaderName = HeaderName::from_static("x-ratelimit-limit");
+const X_RATE_LIMIT_REMAINING: HeaderName = HeaderName::from_static("x-ratelimit-remaining");
+const X_RATE_LIMIT_RESET: HeaderName = HeaderName::from_static("x-ratelimit-reset");
+
+/// Enforce per-key and per-IP Redis token-bucket rate limits.
+pub async fn rate_limit(
+    State(state): State<AppState>,
+    mut request: Request,
+    next: Next,
+) -> Response {
+    let verified = match verified_key(&state, &mut request).await {
+        Ok(verified) => verified,
+        Err(err) => return err.into_response(),
+    };
+    let client_ip = client_ip(request.headers());
+
+    let outcome = match check_request_limit(&state, client_ip.as_deref(), verified.as_ref()).await {
+        Ok(outcome) => outcome,
+        Err(err) => return err.into_response(),
+    };
+
+    let mut response = next.run(request).await;
+    insert_rate_limit_headers(response.headers_mut(), &outcome);
+    response
+}
+
+async fn verified_key(
+    state: &AppState,
+    request: &mut Request,
+) -> Result<Option<VerifiedApiKey>, ApiError> {
+    if let Some(verified) = request.extensions().get::<VerifiedApiKey>().cloned() {
+        return Ok(Some(verified));
+    }
+
+    let Some(header) = request.headers().get("x-api-key") else {
+        return Ok(None);
+    };
+    let plaintext = header
+        .to_str()
+        .map_err(|_| ApiError::Unauthorized("missing or invalid API key".into()))?
+        .to_owned();
+
+    let manager = ApiKeyManager::new(state.db.clone(), state.cache.clone());
+    match manager.verify(&plaintext).await {
+        Ok(verified) => {
+            request.extensions_mut().insert(verified.clone());
+            Ok(Some(verified))
+        }
+        Err(AuthError::InvalidApiKey | AuthError::Validation(_)) => {
+            Err(ApiError::Unauthorized("missing or invalid API key".into()))
+        }
+        Err(err) => {
+            tracing::error!(error = %err, "api key verification failed during rate limiting");
+            Err(ApiError::Internal)
+        }
+    }
+}
+
+async fn check_request_limit(
+    state: &AppState,
+    client_ip: Option<&str>,
+    verified: Option<&VerifiedApiKey>,
+) -> Result<RateLimitOutcome, ApiError> {
+    let mut selected = None;
+    let ip = client_ip.unwrap_or("unknown");
+
+    let rate_limits = &state.config.rate_limits;
+    let (ip_quota, key_quota) = match verified {
+        Some(key) => {
+            let tier = tier_config(rate_limits, &key.rate_limit_tier)?;
+            (tier.per_ip, Some((key.id.to_string(), tier.per_key)))
+        }
+        None => (rate_limits.anonymous, None),
+    };
+
+    for bucket in buckets_for_quota(&format!("ip:{ip}"), ip_quota)? {
+        let outcome = take_bucket(state, bucket).await?;
+        if !outcome.allowed {
+            return Err(outcome.into_rate_limited());
+        }
+        selected = Some(outcome);
+    }
+
+    if let Some((key_id, quota)) = key_quota {
+        for bucket in buckets_for_quota(&format!("key:{key_id}"), quota)? {
+            let outcome = take_bucket(state, bucket).await?;
+            if !outcome.allowed {
+                return Err(outcome.into_rate_limited());
+            }
+            selected = Some(outcome);
+        }
+    }
+
+    selected.ok_or(ApiError::Internal)
+}
+
+fn tier_config<'a>(
+    rate_limits: &'a RateLimitConfig,
+    tier: &str,
+) -> Result<&'a RateLimitTierConfig, ApiError> {
+    rate_limits
+        .tiers
+        .get(tier)
+        .or_else(|| rate_limits.tiers.get(&rate_limits.default_tier))
+        .ok_or_else(|| ApiError::Validation("rate-limit tier is not configured".into()))
+}
+
+#[derive(Debug, Clone)]
+struct BucketCheck {
+    key: String,
+    config: TokenBucketConfig,
+    limit: u32,
+    reset_after: Duration,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RateLimitOutcome {
+    allowed: bool,
+    limit: u32,
+    remaining: u32,
+    retry_after: Duration,
+    reset_after: Duration,
+}
+
+impl RateLimitOutcome {
+    fn into_rate_limited(self) -> ApiError {
+        ApiError::RateLimited {
+            retry_after: self.retry_after,
+            limit: self.limit,
+            remaining: self.remaining,
+            reset_after: self.retry_after,
+        }
+    }
+}
+
+fn buckets_for_quota(
+    prefix: &str,
+    quota: RateLimitQuotaConfig,
+) -> Result<[BucketCheck; 2], ApiError> {
+    Ok([
+        bucket_check(
+            prefix,
+            "hour",
+            quota.per_hour,
+            Duration::from_secs(60 * 60),
+            quota.burst_multiplier,
+        )?,
+        bucket_check(
+            prefix,
+            "second",
+            quota.per_second,
+            Duration::from_secs(1),
+            quota.burst_multiplier,
+        )?,
+    ])
+}
+
+fn bucket_check(
+    prefix: &str,
+    window: &str,
+    refill_tokens: u32,
+    refill_interval: Duration,
+    burst_multiplier: u32,
+) -> Result<BucketCheck, ApiError> {
+    let burst_multiplier = burst_multiplier.max(1);
+    let capacity = refill_tokens.saturating_mul(burst_multiplier).max(1);
+    let refill_tokens = refill_tokens.max(1);
+    Ok(BucketCheck {
+        key: format!("rate-limit:{prefix}:{window}"),
+        config: TokenBucketConfig::new(capacity, refill_tokens, refill_interval)?,
+        limit: capacity,
+        reset_after: refill_interval,
+    })
+}
+
+async fn take_bucket(state: &AppState, bucket: BucketCheck) -> Result<RateLimitOutcome, ApiError> {
+    let decision = state
+        .cache
+        .take_token_bucket(&bucket.key, bucket.config, 1)
+        .await?;
+    Ok(RateLimitOutcome {
+        allowed: decision.allowed,
+        limit: bucket.limit,
+        remaining: decision.remaining,
+        retry_after: decision.retry_after,
+        reset_after: bucket.reset_after,
+    })
+}
+
+fn insert_rate_limit_headers(headers: &mut HeaderMap, outcome: &RateLimitOutcome) {
+    insert_header(headers, X_RATE_LIMIT_LIMIT, outcome.limit);
+    insert_header(headers, X_RATE_LIMIT_REMAINING, outcome.remaining);
+    insert_header(
+        headers,
+        X_RATE_LIMIT_RESET,
+        duration_header_secs(outcome.reset_after),
+    );
+}
+
+fn insert_header<T: std::fmt::Display>(headers: &mut HeaderMap, name: HeaderName, value: T) {
+    if let Ok(value) = HeaderValue::from_str(&value.to_string()) {
+        headers.insert(name, value);
+    }
+}
+
+fn client_ip(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("x-forwarded-for")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|value| value.split(',').next())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .or_else(|| {
+            headers
+                .get("x-real-ip")
+                .and_then(|value| value.to_str().ok())
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned)
+        })
+}
+
+fn duration_header_secs(duration: Duration) -> u64 {
+    if duration.is_zero() {
+        return 0;
+    }
+    duration.as_secs() + u64::from(duration.subsec_nanos() > 0)
+}
+
+pub(crate) fn insert_rate_limit_error_headers(
+    headers: &mut HeaderMap,
+    retry_after: Duration,
+    limit: u32,
+    remaining: u32,
+    reset_after: Duration,
+) {
+    insert_header(
+        headers,
+        header::RETRY_AFTER,
+        duration_header_secs(retry_after),
+    );
+    insert_header(headers, X_RATE_LIMIT_LIMIT, limit);
+    insert_header(headers, X_RATE_LIMIT_REMAINING, remaining);
+    insert_header(
+        headers,
+        X_RATE_LIMIT_RESET,
+        duration_header_secs(reset_after),
+    );
+}

--- a/crates/au-kpis-api-http/tests/auth.rs
+++ b/crates/au-kpis-api-http/tests/auth.rs
@@ -3,7 +3,9 @@ use std::sync::Arc;
 use au_kpis_api_http::{AppState, auth::require_api_key, router_with};
 use au_kpis_auth::{ApiKeyManager, CreateApiKeyRequest, VerifiedApiKey};
 use au_kpis_cache::CacheClient;
-use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_config::{
+    AppConfig, DatabaseConfig, HttpConfig, LogFormat, RateLimitConfig, TelemetryConfig,
+};
 use au_kpis_db::{connect, migrate};
 use au_kpis_telemetry::Telemetry;
 use au_kpis_testing::{
@@ -186,6 +188,7 @@ fn test_state(db: PgPool, cache: Arc<CacheClient>) -> AppState {
             log_level: "info".into(),
             otlp_endpoint: None,
         },
+        rate_limits: RateLimitConfig::default(),
     };
 
     AppState::new(

--- a/crates/au-kpis-api-http/tests/dataflows.rs
+++ b/crates/au-kpis-api-http/tests/dataflows.rs
@@ -6,7 +6,9 @@ use std::{
 
 use au_kpis_api_http::{AppState, router};
 use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
-use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_config::{
+    AppConfig, DatabaseConfig, HttpConfig, LogFormat, RateLimitConfig, TelemetryConfig,
+};
 use au_kpis_telemetry::Telemetry;
 use axum::{
     body::{Body, to_bytes},
@@ -341,6 +343,7 @@ fn test_state(db: PgPool, cache: Arc<CacheClient>) -> AppState {
                 log_level: "info".into(),
                 otlp_endpoint: None,
             },
+            rate_limits: RateLimitConfig::default(),
         }),
         Arc::new(Telemetry::disabled()),
         CancellationToken::new(),

--- a/crates/au-kpis-api-http/tests/graceful_shutdown.rs
+++ b/crates/au-kpis-api-http/tests/graceful_shutdown.rs
@@ -2,7 +2,9 @@ use std::{sync::Arc, time::Duration};
 
 use au_kpis_api_http::{AppState, router};
 use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
-use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_config::{
+    AppConfig, DatabaseConfig, HttpConfig, LogFormat, RateLimitConfig, TelemetryConfig,
+};
 use au_kpis_telemetry::Telemetry;
 use sqlx::postgres::PgPoolOptions;
 use tokio::net::TcpListener;
@@ -64,6 +66,7 @@ fn test_state(token: CancellationToken) -> AppState {
             log_level: "info".into(),
             otlp_endpoint: None,
         },
+        rate_limits: RateLimitConfig::default(),
     };
 
     AppState::new(

--- a/crates/au-kpis-api-http/tests/observations.rs
+++ b/crates/au-kpis-api-http/tests/observations.rs
@@ -3,7 +3,9 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 use arrow_array::{Float64Array, StringArray, UInt32Array};
 use au_kpis_api_http::{AppState, ObservationsResponse, router};
 use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
-use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_config::{
+    AppConfig, DatabaseConfig, HttpConfig, LogFormat, RateLimitConfig, TelemetryConfig,
+};
 use au_kpis_domain::ids::{ArtifactId, DataflowId, SeriesKey};
 use au_kpis_telemetry::Telemetry;
 use axum::{
@@ -314,6 +316,7 @@ fn test_state(db: PgPool) -> AppState {
                 log_level: "info".into(),
                 otlp_endpoint: None,
             },
+            rate_limits: RateLimitConfig::default(),
         }),
         Arc::new(Telemetry::disabled()),
         CancellationToken::new(),

--- a/crates/au-kpis-api-http/tests/rate_limit.rs
+++ b/crates/au-kpis-api-http/tests/rate_limit.rs
@@ -1,0 +1,263 @@
+use std::{sync::Arc, time::Duration};
+
+use au_kpis_api_http::{AppState, router_with};
+use au_kpis_auth::{ApiKeyManager, CreateApiKeyRequest};
+use au_kpis_cache::CacheClient;
+use au_kpis_config::{
+    AppConfig, CacheConfig, DatabaseConfig, HttpConfig, LogFormat, RateLimitConfig,
+    RateLimitQuotaConfig, TelemetryConfig,
+};
+use au_kpis_db::{connect, migrate};
+use au_kpis_telemetry::Telemetry;
+use au_kpis_testing::{
+    redis::{RedisHarness, start_redis},
+    timescale::{TimescaleHarness, start_timescale},
+};
+use axum::{
+    Router,
+    body::Body,
+    http::{Request, StatusCode, header},
+    routing::get,
+};
+use sqlx::{PgPool, postgres::PgPoolOptions};
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+struct RedisContext {
+    _redis: RedisHarness,
+    cache: Arc<CacheClient>,
+}
+
+impl RedisContext {
+    async fn start() -> Self {
+        let redis = start_redis().await.expect("start redis container");
+        let cache = Arc::new(
+            CacheClient::connect(redis.url())
+                .await
+                .expect("connect redis"),
+        );
+
+        Self {
+            _redis: redis,
+            cache,
+        }
+    }
+}
+
+struct AuthContext {
+    _postgres: TimescaleHarness,
+    _redis: RedisHarness,
+    pool: PgPool,
+    cache: Arc<CacheClient>,
+}
+
+impl AuthContext {
+    async fn start(database: &str) -> Self {
+        let postgres = start_timescale(database)
+            .await
+            .expect("start timescaledb container");
+        let redis = start_redis().await.expect("start redis container");
+        let pool = connect(&DatabaseConfig {
+            url: postgres.url().to_string(),
+        })
+        .await
+        .expect("connect postgres");
+        migrate(&pool).await.expect("apply migrations");
+        let cache = Arc::new(
+            CacheClient::connect(redis.url())
+                .await
+                .expect("connect redis"),
+        );
+
+        Self {
+            _postgres: postgres,
+            _redis: redis,
+            pool,
+            cache,
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn anonymous_requests_are_limited_by_ip_and_recover_after_refill() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let ctx = RedisContext::start().await;
+    let app = public_router(test_state(
+        lazy_pool(),
+        ctx.cache,
+        test_config_with_limits(RateLimitConfig {
+            anonymous: RateLimitQuotaConfig {
+                per_second: 1,
+                per_hour: 100,
+                burst_multiplier: 1,
+            },
+            ..RateLimitConfig::default()
+        }),
+    ));
+
+    let first = app
+        .clone()
+        .oneshot(request("/public", None, "203.0.113.10"))
+        .await
+        .expect("first response");
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_rate_limit_headers(first.headers(), "1");
+    assert!(first.headers().get(header::RETRY_AFTER).is_none());
+
+    let limited = app
+        .clone()
+        .oneshot(request("/public", None, "203.0.113.10"))
+        .await
+        .expect("limited response");
+    assert_eq!(limited.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_rate_limit_headers(limited.headers(), "1");
+    assert!(
+        limited.headers().get(header::RETRY_AFTER).is_some(),
+        "429 responses must include Retry-After"
+    );
+
+    tokio::time::sleep(Duration::from_millis(1_100)).await;
+    let recovered = app
+        .oneshot(request("/public", None, "203.0.113.10"))
+        .await
+        .expect("recovered response");
+    assert_eq!(recovered.status(), StatusCode::OK);
+    assert_rate_limit_headers(recovered.headers(), "1");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn authenticated_requests_are_limited_by_key_even_across_ips() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let ctx = AuthContext::start("au_kpis_api_rate_limit").await;
+    let manager = ApiKeyManager::new(ctx.pool.clone(), ctx.cache.clone());
+    let created = manager
+        .create_key(CreateApiKeyRequest {
+            name: "load-test client".into(),
+            scopes: vec!["observations:read".into()],
+            rate_limit_tier: "free".into(),
+            actor: "platform-admin@example.com".into(),
+        })
+        .await
+        .expect("create api key");
+
+    let mut config = RateLimitConfig::default();
+    config.tiers.get_mut("free").expect("free tier").per_key = RateLimitQuotaConfig {
+        per_second: 1,
+        per_hour: 100,
+        burst_multiplier: 1,
+    };
+    config.tiers.get_mut("free").expect("free tier").per_ip = RateLimitQuotaConfig {
+        per_second: 100,
+        per_hour: 1_000,
+        burst_multiplier: 1,
+    };
+
+    let app = public_router(test_state(
+        ctx.pool,
+        ctx.cache,
+        test_config_with_limits(config),
+    ));
+
+    let first = app
+        .clone()
+        .oneshot(request("/public", Some(&created.plaintext), "203.0.113.20"))
+        .await
+        .expect("first response");
+    assert_eq!(first.status(), StatusCode::OK);
+    assert_rate_limit_headers(first.headers(), "1");
+
+    let limited = app
+        .oneshot(request("/public", Some(&created.plaintext), "203.0.113.21"))
+        .await
+        .expect("limited response");
+    assert_eq!(limited.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_rate_limit_headers(limited.headers(), "1");
+    assert!(
+        limited.headers().get(header::RETRY_AFTER).is_some(),
+        "key limit should return Retry-After"
+    );
+}
+
+fn public_router(state: AppState) -> Router {
+    router_with(
+        Router::<AppState>::new().route("/public", get(|| async { "ok" })),
+        state,
+    )
+    .expect("router")
+}
+
+fn request(uri: &str, api_key: Option<&str>, ip: &str) -> Request<Body> {
+    let mut builder = Request::builder().uri(uri).header("x-forwarded-for", ip);
+    if let Some(api_key) = api_key {
+        builder = builder.header("x-api-key", api_key);
+    }
+    builder.body(Body::empty()).expect("request")
+}
+
+fn assert_rate_limit_headers(headers: &axum::http::HeaderMap, expected_limit: &str) {
+    assert_eq!(
+        headers.get("x-ratelimit-limit").expect("limit header"),
+        expected_limit
+    );
+    assert!(
+        headers.get("x-ratelimit-remaining").is_some(),
+        "remaining header is required"
+    );
+    assert!(
+        headers.get("x-ratelimit-reset").is_some(),
+        "reset header is required"
+    );
+}
+
+fn test_state(db: PgPool, cache: Arc<CacheClient>, config: AppConfig) -> AppState {
+    AppState::new(
+        db,
+        cache,
+        Arc::new(config),
+        Arc::new(Telemetry::disabled()),
+        CancellationToken::new(),
+    )
+}
+
+fn test_config_with_limits(rate_limits: RateLimitConfig) -> AppConfig {
+    AppConfig {
+        http: HttpConfig {
+            bind: "127.0.0.1:0".into(),
+            cors_allowed_origins: Vec::new(),
+            shutdown_grace_period_secs: 30,
+        },
+        database: DatabaseConfig {
+            url: "postgres://postgres:postgres@localhost/au_kpis".into(),
+        },
+        cache: CacheConfig {
+            url: "redis://127.0.0.1:6379".into(),
+        },
+        telemetry: TelemetryConfig {
+            service_name: "au-kpis-test".into(),
+            log_format: LogFormat::Json,
+            log_level: "info".into(),
+            otlp_endpoint: None,
+        },
+        rate_limits,
+    }
+}
+
+fn lazy_pool() -> PgPool {
+    PgPoolOptions::new()
+        .max_connections(1)
+        .connect_lazy("postgres://postgres:postgres@127.0.0.1/au_kpis_unreachable")
+        .expect("lazy postgres pool")
+}
+
+fn docker_available() -> bool {
+    std::env::var_os("DOCKER_HOST").is_some()
+        || std::path::Path::new("/var/run/docker.sock").exists()
+}

--- a/crates/au-kpis-api-http/tests/routes.rs
+++ b/crates/au-kpis-api-http/tests/routes.rs
@@ -2,7 +2,9 @@ use std::{sync::Arc, time::Duration};
 
 use au_kpis_api_http::{ApiError, AppState, ProblemDetails, router, router_with};
 use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
-use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_config::{
+    AppConfig, DatabaseConfig, HttpConfig, LogFormat, RateLimitConfig, TelemetryConfig,
+};
 use au_kpis_telemetry::Telemetry;
 use axum::{
     Router,
@@ -76,6 +78,7 @@ fn test_state_with_origins(cors_allowed_origins: Vec<String>) -> AppState {
             log_level: "info".into(),
             otlp_endpoint: None,
         },
+        rate_limits: RateLimitConfig::default(),
     };
 
     AppState::new(

--- a/crates/au-kpis-api-http/tests/search.rs
+++ b/crates/au-kpis-api-http/tests/search.rs
@@ -6,7 +6,9 @@ use std::{
 
 use au_kpis_api_http::{AppState, router};
 use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
-use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_config::{
+    AppConfig, DatabaseConfig, HttpConfig, LogFormat, RateLimitConfig, TelemetryConfig,
+};
 use au_kpis_telemetry::Telemetry;
 use axum::{
     body::{Body, to_bytes},
@@ -302,6 +304,7 @@ fn test_state(db: PgPool, cache: Arc<CacheClient>) -> AppState {
                 log_level: "info".into(),
                 otlp_endpoint: None,
             },
+            rate_limits: RateLimitConfig::default(),
         }),
         Arc::new(Telemetry::disabled()),
         CancellationToken::new(),

--- a/crates/au-kpis-api-http/tests/series.rs
+++ b/crates/au-kpis-api-http/tests/series.rs
@@ -2,7 +2,9 @@ use std::{collections::BTreeMap, sync::Arc, time::Duration};
 
 use au_kpis_api_http::{AppState, router};
 use au_kpis_cache::{CacheBackend, CacheClient, CacheError, RateLimitDecision, TokenBucketConfig};
-use au_kpis_config::{AppConfig, DatabaseConfig, HttpConfig, LogFormat, TelemetryConfig};
+use au_kpis_config::{
+    AppConfig, DatabaseConfig, HttpConfig, LogFormat, RateLimitConfig, TelemetryConfig,
+};
 use au_kpis_domain::ids::{ArtifactId, DataflowId, SeriesKey};
 use au_kpis_telemetry::Telemetry;
 use axum::{
@@ -132,6 +134,7 @@ fn test_state(db: PgPool) -> AppState {
                 log_level: "info".into(),
                 otlp_endpoint: None,
             },
+            rate_limits: RateLimitConfig::default(),
         }),
         Arc::new(Telemetry::disabled()),
         CancellationToken::new(),

--- a/crates/au-kpis-config/src/lib.rs
+++ b/crates/au-kpis-config/src/lib.rs
@@ -31,7 +31,7 @@
 #![forbid(unsafe_code)]
 #![deny(missing_docs, missing_debug_implementations)]
 
-use std::path::Path;
+use std::{collections::BTreeMap, path::Path};
 
 use au_kpis_error::{Classify, CoreError, ErrorClass};
 use figment::{
@@ -90,6 +90,8 @@ pub struct AppConfig {
     pub cache: CacheConfig,
     /// Telemetry configuration — consumed by `au-kpis-telemetry`.
     pub telemetry: TelemetryConfig,
+    /// API rate-limit tiers and anonymous request quota.
+    pub rate_limits: RateLimitConfig,
 }
 
 /// Config consumed by the ingestion worker binary.
@@ -168,6 +170,64 @@ impl Default for TelemetryConfig {
     }
 }
 
+/// API rate-limit configuration.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RateLimitConfig {
+    /// Tier name used when an API key references an unknown tier.
+    pub default_tier: String,
+    /// Named API-key rate-limit tiers.
+    pub tiers: BTreeMap<String, RateLimitTierConfig>,
+    /// Anonymous no-key per-IP quota.
+    pub anonymous: RateLimitQuotaConfig,
+}
+
+impl Default for RateLimitConfig {
+    fn default() -> Self {
+        let free = RateLimitTierConfig {
+            per_key: RateLimitQuotaConfig {
+                per_second: 60,
+                per_hour: 1_000,
+                burst_multiplier: 2,
+            },
+            per_ip: RateLimitQuotaConfig {
+                per_second: 10,
+                per_hour: 100,
+                burst_multiplier: 2,
+            },
+        };
+
+        Self {
+            default_tier: "free".into(),
+            tiers: BTreeMap::from([("free".into(), free)]),
+            anonymous: RateLimitQuotaConfig {
+                per_second: 10,
+                per_hour: 100,
+                burst_multiplier: 2,
+            },
+        }
+    }
+}
+
+/// API-key tier quota, enforced by both key and client IP.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct RateLimitTierConfig {
+    /// Per-key quota.
+    pub per_key: RateLimitQuotaConfig,
+    /// Per-IP quota for requests carrying a key in this tier.
+    pub per_ip: RateLimitQuotaConfig,
+}
+
+/// Token-bucket quota shape.
+#[derive(Debug, Clone, Copy, Deserialize, Serialize)]
+pub struct RateLimitQuotaConfig {
+    /// Refill rate for the one-second bucket.
+    pub per_second: u32,
+    /// Refill rate for the one-hour bucket.
+    pub per_hour: u32,
+    /// Bucket capacity multiplier over the refill rate.
+    pub burst_multiplier: u32,
+}
+
 /// Log output format.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(rename_all = "kebab-case")]
@@ -187,6 +247,7 @@ pub enum LogFormat {
 struct Defaults {
     http: HttpConfig,
     telemetry: TelemetryConfig,
+    rate_limits: RateLimitConfig,
 }
 
 /// Load [`AppConfig`] using the standard **defaults → TOML → env** precedence.
@@ -301,6 +362,77 @@ mod tests {
                     "http://localhost:4173".to_string(),
                 ]
             );
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn default_rate_limits_match_free_tier_spec() {
+        Jail::expect_with(|jail| {
+            jail.set_env("AU_KPIS_DATABASE__URL", "postgres://env/db");
+            jail.set_env("AU_KPIS_CACHE__URL", "redis://env:6379");
+
+            let cfg = load(None).expect("env supplies required fields");
+            let free = cfg
+                .rate_limits
+                .tiers
+                .get("free")
+                .expect("free tier configured");
+
+            assert_eq!(free.per_key.per_second, 60);
+            assert_eq!(free.per_key.per_hour, 1_000);
+            assert_eq!(free.per_key.burst_multiplier, 2);
+            assert_eq!(cfg.rate_limits.anonymous.per_second, 10);
+            assert_eq!(cfg.rate_limits.anonymous.per_hour, 100);
+            assert_eq!(cfg.rate_limits.anonymous.burst_multiplier, 2);
+            Ok(())
+        });
+    }
+
+    #[test]
+    fn env_can_override_rate_limit_tiers() {
+        Jail::expect_with(|jail| {
+            jail.set_env("AU_KPIS_DATABASE__URL", "postgres://env/db");
+            jail.set_env("AU_KPIS_CACHE__URL", "redis://env:6379");
+            jail.set_env("AU_KPIS_RATE_LIMITS__DEFAULT_TIER", "internal");
+            jail.set_env(
+                "AU_KPIS_RATE_LIMITS__TIERS__internal__PER_KEY__PER_SECOND",
+                "120",
+            );
+            jail.set_env(
+                "AU_KPIS_RATE_LIMITS__TIERS__internal__PER_KEY__PER_HOUR",
+                "5000",
+            );
+            jail.set_env(
+                "AU_KPIS_RATE_LIMITS__TIERS__internal__PER_KEY__BURST_MULTIPLIER",
+                "3",
+            );
+            jail.set_env(
+                "AU_KPIS_RATE_LIMITS__TIERS__internal__PER_IP__PER_SECOND",
+                "20",
+            );
+            jail.set_env(
+                "AU_KPIS_RATE_LIMITS__TIERS__internal__PER_IP__PER_HOUR",
+                "500",
+            );
+            jail.set_env(
+                "AU_KPIS_RATE_LIMITS__TIERS__internal__PER_IP__BURST_MULTIPLIER",
+                "2",
+            );
+
+            let cfg = load(None).expect("env supplies rate-limit tiers");
+            let internal = cfg
+                .rate_limits
+                .tiers
+                .get("internal")
+                .expect("internal tier configured");
+
+            assert_eq!(cfg.rate_limits.default_tier, "internal");
+            assert_eq!(internal.per_key.per_second, 120);
+            assert_eq!(internal.per_key.per_hour, 5_000);
+            assert_eq!(internal.per_key.burst_multiplier, 3);
+            assert_eq!(internal.per_ip.per_second, 20);
+            assert_eq!(internal.per_ip.per_hour, 500);
             Ok(())
         });
     }

--- a/docs/security.md
+++ b/docs/security.md
@@ -31,3 +31,19 @@ the create command and is never stored.
 
 5. Watch for any remaining requests using the revoked key. Issuance and
    revocation events are retained in `api_key_audit_log` for one year.
+
+## Rate Limit Tiers
+
+The default `free` tier follows the public spec: 60 requests per second and
+1,000 requests per hour per key, plus 10 requests per second and 100 requests
+per hour per IP for anonymous traffic. Bucket capacity is the configured quota
+times `burst_multiplier`, which defaults to `2`.
+
+Tier values can be overridden through config or environment variables, for
+example:
+
+```bash
+AU_KPIS_RATE_LIMITS__TIERS__free__PER_KEY__PER_SECOND=120
+AU_KPIS_RATE_LIMITS__TIERS__free__PER_KEY__PER_HOUR=5000
+AU_KPIS_RATE_LIMITS__TIERS__free__PER_KEY__BURST_MULTIPLIER=2
+```


### PR DESCRIPTION
Closes #46

## Summary

- Adds Redis token-bucket rate-limit middleware to the shared HTTP router.
- Enforces anonymous per-IP buckets and authenticated per-key plus per-IP buckets.
- Adds configurable rate-limit tiers with free-tier defaults matching the spec.
- Emits `Retry-After` and `X-RateLimit-*` headers for 429 responses, and `X-RateLimit-*` headers on allowed responses.
- Documents rate-limit tier override environment variables.

## Pass requirements

- [x] Free-tier defaults per spec (60 rps / 1000/h per key; 10 rps / 100/h per IP)
- [x] Per-key + per-IP buckets
- [x] Returns 429 with `Retry-After` + `X-RateLimit-*` headers
- [x] Integration test: burst saturates bucket, recovers after window
- [x] Tier overrides via env/config

## Test plan

- `cargo fmt --all --check`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo check --workspace --locked`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo nextest run --workspace --profile ci -j 1 --retries 0`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo run -p au-kpis-openapi --locked > target/openapi/issue46-openapi.json`
- `/Users/os/go/bin/oasdiff breaking openapi.json target/openapi/issue46-openapi.json`
- `git diff --check`
- `gitleaks protect --staged`

## Spec impact

No Spec changes required.
