### PR TITLE
test(api): add Parquet stream benchmark (#50)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -536,6 +536,9 @@ jobs:
             if [ -f crates/au-kpis-api-http/benches/observations_handler.rs ]; then
               cargo bench -p au-kpis-api-http --bench observations_handler --locked -- --save-baseline "${baseline}"
             fi
+            if [ -f crates/au-kpis-api-http/benches/parquet_stream.rs ]; then
+              cargo bench -p au-kpis-api-http --bench parquet_stream --locked -- --save-baseline "${baseline}"
+            fi
           }
           run_benchmarks main
           git checkout --detach "${pr_sha}"
@@ -549,6 +552,7 @@ jobs:
             cargo bench -p au-kpis-adapter-abs --bench sdmx_parse --locked -- --save-baseline "${baseline}"
             cargo bench -p au-kpis-loader --bench copy_upsert --locked -- --save-baseline "${baseline}"
             cargo bench -p au-kpis-api-http --bench observations_handler --locked -- --save-baseline "${baseline}"
+            cargo bench -p au-kpis-api-http --bench parquet_stream --locked -- --save-baseline "${baseline}"
           }
           run_benchmarks pr
           set +e
@@ -637,6 +641,11 @@ jobs:
           cargo test -p au-kpis-adapter-abs \
             --features dhat-heap \
             --test parse_memory \
+            -- --ignored --nocapture
+          cargo test -p au-kpis-api-http \
+            --release \
+            --features dhat-heap \
+            --test parquet_memory \
             -- --ignored --nocapture
 
   coverage:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -470,6 +470,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "criterion",
+ "dhat",
  "futures",
  "http",
  "jsonschema",

--- a/benches/baselines/issue-50.md
+++ b/benches/baselines/issue-50.md
@@ -1,0 +1,49 @@
+# Issue #50 Parquet 1M-Row Baseline
+
+Captured: 2026-05-27 on the local Codex workstation.
+
+## Parquet 1M-row stream
+
+Command:
+
+```bash
+cargo bench -p au-kpis-api-http --bench parquet_stream --locked -- --save-baseline issue50
+```
+
+Budget: <30 s for 1M streamed rows.
+
+Measured:
+
+```text
+api_parquet_stream/parquet_stream_1m_rows_under_30s
+time:  [1.2867 s 1.3070 s 1.3402 s]
+thrpt: [746.15 Kelem/s 765.10 Kelem/s 777.17 Kelem/s]
+```
+
+## dhat memory profile
+
+Command:
+
+```bash
+cargo test -p au-kpis-api-http --release --features dhat-heap --test parquet_memory -- --ignored --nocapture
+```
+
+Budget: <100 MB peak heap for 1M streamed rows.
+
+Measured:
+
+```text
+dhat parquet stream: rows=1000000 bytes=5471814 chunks=41 elapsed_ms=92999 max_bytes=6950516 total_bytes=2957548799
+```
+
+Peak heap was 6,950,516 bytes. DHAT instrumentation distorts wall-clock
+timing, so the Criterion benchmark is the authoritative <30 s timing check.
+
+## CI regression gate
+
+The PR workflow runs the Parquet Criterion target with the rest of the committed
+benchmarks and keeps the blocking merge-queue threshold at:
+
+```bash
+critcmp main pr --threshold 5
+```

--- a/crates/au-kpis-api-http/Cargo.toml
+++ b/crates/au-kpis-api-http/Cargo.toml
@@ -7,6 +7,9 @@ license.workspace = true
 repository.workspace = true
 description = "axum routes + handlers (library)."
 
+[features]
+dhat-heap = ["dep:dhat"]
+
 [dependencies]
 arrow-array = "58.3.0" # build RecordBatch values for streamed Parquet responses
 arrow-schema = "58.3.0" # define the Arrow schema exported by the Parquet endpoint
@@ -19,6 +22,7 @@ au-kpis-telemetry = { workspace = true }
 axum = { version = "0.7", features = ["macros"] }
 base64 = "0.22" # opaque cursor encoding; std has no base64 codec
 chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+dhat = { version = "0.3", optional = true }
 futures = "0.3" # TryStreamExt over sqlx row streams
 http = "1"
 parquet = { version = "58.3.0", default-features = false, features = ["arrow", "async", "zstd"] } # encode streamed Parquet responses with zstd and without unused codecs
@@ -47,6 +51,10 @@ tower = { version = "0.5", features = ["util"] }
 
 [[bench]]
 name = "observations_handler"
+harness = false
+
+[[bench]]
+name = "parquet_stream"
 harness = false
 
 [lints]

--- a/crates/au-kpis-api-http/benches/parquet_stream.rs
+++ b/crates/au-kpis-api-http/benches/parquet_stream.rs
@@ -1,0 +1,53 @@
+use std::time::{Duration, Instant};
+
+use au_kpis_api_http::observations::benchmark_support::{
+    PARQUET_STREAM_BENCHMARK_BUDGET, PARQUET_STREAM_BENCHMARK_ROWS, drain_synthetic_parquet_stream,
+};
+use criterion::{Criterion, SamplingMode, Throughput, black_box, criterion_group, criterion_main};
+
+fn bench_parquet_stream(c: &mut Criterion) {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .expect("tokio runtime");
+
+    let mut group = c.benchmark_group("api_parquet_stream");
+    group.throughput(Throughput::Elements(PARQUET_STREAM_BENCHMARK_ROWS as u64));
+    group.sampling_mode(SamplingMode::Flat);
+    group.sample_size(10);
+    group.bench_function("parquet_stream_1m_rows_under_30s", |b| {
+        b.iter_custom(|iterations| {
+            let mut elapsed = Duration::ZERO;
+            for _ in 0..iterations {
+                let started = Instant::now();
+                let stats = runtime
+                    .block_on(drain_synthetic_parquet_stream(
+                        PARQUET_STREAM_BENCHMARK_ROWS,
+                    ))
+                    .expect("drain synthetic parquet stream");
+                let iteration_elapsed = started.elapsed();
+                assert_eq!(stats.rows, PARQUET_STREAM_BENCHMARK_ROWS);
+                assert!(stats.bytes > 0, "parquet stream should emit bytes");
+                assert!(stats.chunks > 0, "parquet stream should emit chunks");
+                assert!(
+                    iteration_elapsed < PARQUET_STREAM_BENCHMARK_BUDGET,
+                    "1M-row parquet stream took {iteration_elapsed:?}, exceeding {PARQUET_STREAM_BENCHMARK_BUDGET:?}"
+                );
+                black_box(stats);
+                elapsed += iteration_elapsed;
+            }
+            elapsed
+        });
+    });
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(10))
+        .sample_size(10);
+    targets = bench_parquet_stream
+}
+criterion_main!(benches);

--- a/crates/au-kpis-api-http/src/observations.rs
+++ b/crates/au-kpis-api-http/src/observations.rs
@@ -806,6 +806,117 @@ fn parquet_to_api_error(err: ParquetError) -> ApiError {
     ApiError::Internal
 }
 
+/// Helpers used by the dedicated Parquet streaming benchmark and DHAT profile.
+#[doc(hidden)]
+pub mod benchmark_support {
+    use std::time::Duration;
+
+    use futures::Stream;
+
+    use super::*;
+
+    /// The Phase 3 Parquet benchmark row count.
+    pub const PARQUET_STREAM_BENCHMARK_ROWS: usize = 1_000_000;
+    /// The Phase 3 Parquet benchmark wall-clock budget.
+    pub const PARQUET_STREAM_BENCHMARK_BUDGET: Duration = Duration::from_secs(30);
+    /// The Phase 3 Parquet benchmark peak heap budget.
+    pub const PARQUET_STREAM_DHAT_HEAP_BUDGET_BYTES: usize = 100 * 1024 * 1024;
+
+    /// Summary of a drained synthetic Parquet stream.
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    pub struct ParquetStreamBenchmarkStats {
+        /// Number of synthetic rows requested from the writer.
+        pub rows: usize,
+        /// Number of Parquet bytes emitted by the stream.
+        pub bytes: usize,
+        /// Number of chunks emitted through the response channel.
+        pub chunks: usize,
+    }
+
+    /// Stream one million production-shaped rows through the Parquet writer and
+    /// drain the response channel without retaining emitted bytes.
+    pub async fn drain_synthetic_parquet_stream(
+        row_count: usize,
+    ) -> Result<ParquetStreamBenchmarkStats, ApiError> {
+        let (tx, mut rx) = mpsc::channel(8);
+        let rows = synthetic_observation_rows(row_count);
+        let writer = tokio::spawn(write_parquet_rows(
+            rows,
+            benchmark_metadata(),
+            row_count,
+            tx,
+            PARQUET_ROW_GROUP_TARGET_BYTES,
+        ));
+
+        let mut bytes = 0_usize;
+        let mut chunks = 0_usize;
+        while let Some(chunk) = rx.recv().await {
+            let chunk = chunk?;
+            bytes += chunk.len();
+            chunks += 1;
+        }
+
+        writer.await.map_err(|err| {
+            tracing::error!(error = %err, "parquet benchmark writer task failed");
+            ApiError::Internal
+        })??;
+
+        Ok(ParquetStreamBenchmarkStats {
+            rows: row_count,
+            bytes,
+            chunks,
+        })
+    }
+
+    fn benchmark_metadata() -> ObservationsMetadata {
+        ObservationsMetadata {
+            dataflow: DataflowId::new("abs.cpi").expect("benchmark dataflow id is valid"),
+            attribution: "Source: Australian Bureau of Statistics".to_string(),
+            license: "CC-BY-4.0".to_string(),
+            source_url: "https://www.abs.gov.au/statistics/economy/price-indexes-and-inflation/consumer-price-index-australia".to_string(),
+        }
+    }
+
+    fn synthetic_observation_rows(
+        row_count: usize,
+    ) -> impl Stream<Item = Result<ObservationsRow, ApiError>> + Send + 'static {
+        async_stream::try_stream! {
+            let dataflow = DataflowId::new("abs.cpi").expect("benchmark dataflow id is valid");
+            let artifact = ArtifactId::of_content(b"parquet 1m benchmark artifact");
+            let ingested_at = DateTime::from_timestamp(1_714_000_000, 0)
+                .expect("benchmark ingested timestamp is valid");
+            let observed_at = DateTime::from_timestamp(1_577_836_800, 0)
+                .expect("benchmark observation timestamp is valid");
+            let regions = ["AUS", "NSW", "VIC", "QLD", "WA"];
+
+            for idx in 0..row_count {
+                let region = regions[idx % regions.len()];
+                let dimensions: BTreeMap<String, String> =
+                    [("region".to_string(), region.to_string())].into_iter().collect();
+                let series_key = SeriesKey::derive(&dataflow, [("region", region)]);
+                yield ObservationsRow {
+                    series_key,
+                    time: observed_at + chrono::Duration::seconds(idx as i64),
+                    time_precision: TimePrecision::Day,
+                    value: Some(100.0 + (idx as f64 / 10.0)),
+                    status: ObservationStatus::Normal,
+                    revision_no: 0,
+                    attributes: BTreeMap::new(),
+                    ingested_at,
+                    source_artifact_id: artifact,
+                    dimensions,
+                    measure_id: "index".to_string(),
+                    unit: "index".to_string(),
+                };
+
+                if idx % PARQUET_BATCH_ROWS == 0 {
+                    tokio::task::yield_now().await;
+                }
+            }
+        }
+    }
+}
+
 fn fetch_observation_rows(
     pool: PgPool,
     query: ParsedObservationsQuery,

--- a/crates/au-kpis-api-http/tests/parquet_memory.rs
+++ b/crates/au-kpis-api-http/tests/parquet_memory.rs
@@ -1,0 +1,44 @@
+#![cfg(feature = "dhat-heap")]
+
+use std::time::Instant;
+
+use au_kpis_api_http::observations::benchmark_support::{
+    PARQUET_STREAM_BENCHMARK_ROWS, PARQUET_STREAM_DHAT_HEAP_BUDGET_BYTES,
+    drain_synthetic_parquet_stream,
+};
+
+#[global_allocator]
+static ALLOC: dhat::Alloc = dhat::Alloc;
+
+#[tokio::test(flavor = "current_thread")]
+#[ignore = "1M-row DHAT memory profile for issue #50"]
+async fn parquet_stream_1m_rows_stays_below_100mb_peak_heap_under_dhat() {
+    let profiler = dhat::Profiler::builder().testing().build();
+    let started = Instant::now();
+    let stats = drain_synthetic_parquet_stream(PARQUET_STREAM_BENCHMARK_ROWS)
+        .await
+        .expect("drain synthetic parquet stream");
+    let elapsed = started.elapsed();
+    let heap = dhat::HeapStats::get();
+    println!(
+        "dhat parquet stream: rows={} bytes={} chunks={} elapsed_ms={} max_bytes={} total_bytes={}",
+        stats.rows,
+        stats.bytes,
+        stats.chunks,
+        elapsed.as_millis(),
+        heap.max_bytes,
+        heap.total_bytes
+    );
+
+    assert_eq!(stats.rows, PARQUET_STREAM_BENCHMARK_ROWS);
+    assert!(stats.bytes > 0, "parquet stream should emit bytes");
+    // DHAT instrumentation distorts wall-clock timing; the Criterion bench
+    // enforces the uninstrumented 30-second budget for this same path.
+    assert!(
+        heap.max_bytes < PARQUET_STREAM_DHAT_HEAP_BUDGET_BYTES,
+        "peak heap {} bytes exceeded {} byte budget",
+        heap.max_bytes,
+        PARQUET_STREAM_DHAT_HEAP_BUDGET_BYTES
+    );
+    drop(profiler);
+}

--- a/crates/testing/tests/bench_scaffold.rs
+++ b/crates/testing/tests/bench_scaffold.rs
@@ -171,3 +171,58 @@ fn bench_workflow_runs_workspace_baselines_without_first_bench_skip() {
         "bench workflow should not skip regression comparison now that benchmarks are blocking"
     );
 }
+
+#[test]
+fn issue_50_parquet_stream_benchmark_contract_is_wired() {
+    let root = repo_root();
+
+    assert!(
+        root.join("crates/au-kpis-api-http/benches/parquet_stream.rs")
+            .is_file(),
+        "issue #50 should provide a dedicated 1M-row Parquet Criterion bench"
+    );
+    assert!(
+        root.join("crates/au-kpis-api-http/tests/parquet_memory.rs")
+            .is_file(),
+        "issue #50 should provide a DHAT memory-budget test"
+    );
+
+    let api_manifest = fs::read_to_string(root.join("crates/au-kpis-api-http/Cargo.toml"))
+        .expect("read api-http manifest");
+    assert!(
+        api_manifest.contains("dhat-heap = [\"dep:dhat\"]"),
+        "api-http should expose a dhat-heap feature for the memory profile"
+    );
+    assert!(
+        api_manifest.contains("name = \"parquet_stream\""),
+        "api-http manifest should register the parquet_stream Criterion bench"
+    );
+
+    let pr_workflow =
+        fs::read_to_string(root.join(".github/workflows/pr.yml")).expect("read pr workflow");
+    assert!(
+        pr_workflow.contains(
+            "cargo bench -p au-kpis-api-http --bench parquet_stream --locked -- --save-baseline"
+        ),
+        "benchmark workflow should run the 1M-row Parquet Criterion bench"
+    );
+    assert!(
+        pr_workflow.contains("cargo test -p au-kpis-api-http")
+            && pr_workflow.contains("--features dhat-heap")
+            && pr_workflow.contains("--test parquet_memory"),
+        "CI should enforce the 1M-row Parquet DHAT memory budget"
+    );
+    assert!(
+        pr_workflow.contains("critcmp main pr --threshold 5"),
+        "merge-queue benchmark regression threshold should remain 5%"
+    );
+
+    let baseline = fs::read_to_string(root.join("benches/baselines/issue-50.md"))
+        .expect("issue #50 benchmark baseline summary should be committed");
+    for expected in ["Parquet 1M-row stream", "<30 s", "<100 MB", "dhat"] {
+        assert!(
+            baseline.contains(expected),
+            "baseline summary should document `{expected}`"
+        );
+    }
+}


### PR DESCRIPTION
Closes #50

## Pass requirements

- [x] Criterion bench exists for a 1M-row Parquet stream
- [x] `dhat` verifies the 1M-row path stays under the Phase 3 memory budget of <100 MB peak memory
- [x] The 1M-row path completes within the Phase 3 target of <30 seconds
- [x] Result is attached to CI output or benchmark reporting
- [x] Regression threshold remains 5% in merge queue

## Test plan

- `cargo fmt --all --check`
- `RUSTC_WRAPPER= cargo test -p au-kpis-testing issue_50_parquet_stream_benchmark_contract_is_wired -- --exact`
- `RUSTC_WRAPPER= cargo check -p au-kpis-api-http --benches --tests --locked`
- `RUSTC_WRAPPER= cargo bench -p au-kpis-api-http --bench parquet_stream --locked -- --save-baseline issue50`
- `RUSTC_WRAPPER= cargo test -p au-kpis-api-http --release --features dhat-heap --test parquet_memory -- --ignored --nocapture`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo check --workspace --locked`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo nextest run --workspace --profile ci -j 1 --retries 0`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `RUSTC_WRAPPER= cargo run -p au-kpis-openapi --locked > target/openapi/issue50-openapi.json && /Users/os/go/bin/oasdiff breaking openapi.json target/openapi/issue50-openapi.json`
- `git diff --check`
- `gitleaks protect --staged`

## Spec impact

No Spec changes required; this implements the existing Phase 3 Parquet benchmark requirement.
