### PR TITLE
ci(bench): run k6 smoke in CI (#38)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -429,74 +429,120 @@ jobs:
           format: table
 
   smoke:
-    name: Smoke
+    name: Smoke (k6)
     runs-on: ubuntu-latest
     permissions:
       contents: read
     env:
-      AU_KPIS_CONTRACT_ADDR: 127.0.0.1:38081
+      LOCAL_K6_OUT: influxdb=http://127.0.0.1:8086/k6
     steps:
       - name: Checkout
         uses: actions/checkout@v5
 
-      - name: Set up Rust
-        uses: ./.github/actions/setup-rust
+      - name: Set up k6
+        uses: grafana/setup-k6-action@v1
+        with:
+          k6-version: "0.54.0"
 
-      - name: Set up Node.js
-        uses: ./.github/actions/setup-node
-
-      - name: Build SDK packages
-        run: pnpm turbo run build --cache-dir=.turbo
-
-      - name: Build smoke server
-        run: cargo build -p au-kpis-api-http --example contract_server --locked
-
-      - name: Start smoke server
+      - name: Configure k6 output
+        env:
+          K6_INFLUXDB_ADDR: ${{ vars.K6_INFLUXDB_ADDR }}
         run: |
           set -euo pipefail
-          mkdir -p target/smoke
-          ./target/debug/examples/contract_server > target/smoke/server.log 2>&1 &
-          echo $! > target/smoke/server.pid
+          if [ -n "${K6_INFLUXDB_ADDR:-}" ]; then
+            echo "K6_OUT=influxdb=${K6_INFLUXDB_ADDR}" >> "$GITHUB_ENV"
+          else
+            echo "K6_OUT=${LOCAL_K6_OUT}" >> "$GITHUB_ENV"
+          fi
 
-      - name: Wait for API readiness
+      - name: Configure local smoke target
+        if: github.event_name != 'merge_group'
+        run: |
+          set -euo pipefail
+          echo "AU_KPIS_BASE_URL=http://127.0.0.1:3000" >> "$GITHUB_ENV"
+          echo "K6_ENVIRONMENT=pr-compose" >> "$GITHUB_ENV"
+
+      - name: Configure staging smoke target
+        if: github.event_name == 'merge_group'
+        env:
+          AU_KPIS_STAGING_BASE_URL: ${{ vars.AU_KPIS_STAGING_BASE_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AU_KPIS_STAGING_BASE_URL:-}" ]; then
+            echo "AU_KPIS_STAGING_BASE_URL repository variable is required for merge queue smoke." >&2
+            exit 1
+          fi
+          echo "AU_KPIS_BASE_URL=${AU_KPIS_STAGING_BASE_URL}" >> "$GITHUB_ENV"
+          echo "K6_ENVIRONMENT=staging" >> "$GITHUB_ENV"
+
+      - name: Start compose smoke stack
+        if: github.event_name != 'merge_group'
+        run: docker compose -f infra/compose/docker-compose.yml up -d --build api influxdb
+
+      - name: Start merge-queue metrics store
+        if: github.event_name == 'merge_group'
+        run: docker compose -f infra/compose/docker-compose.yml up -d influxdb
+
+      - name: Apply migrations
+        if: github.event_name != 'merge_group'
+        run: |
+          set -euo pipefail
+          for _ in $(seq 1 60); do
+            if docker compose -f infra/compose/docker-compose.yml exec -T postgres \
+                pg_isready -U au_kpis -d au_kpis; then
+              break
+            fi
+            sleep 1
+          done
+          cat infra/migrations/*.up.sql \
+            | docker compose -f infra/compose/docker-compose.yml exec -T postgres \
+                psql -v ON_ERROR_STOP=1 -U au_kpis -d au_kpis
+
+      - name: Seed smoke fixture data
+        if: github.event_name != 'merge_group'
+        run: |
+          docker compose -f infra/compose/docker-compose.yml exec -T postgres \
+            psql -v ON_ERROR_STOP=1 -U au_kpis -d au_kpis \
+            < apps/web/e2e/fixtures/explorer.sql
+
+      - name: Wait for local API readiness
+        if: github.event_name != 'merge_group'
         run: |
           set -euo pipefail
           for _ in $(seq 1 120); do
-            if curl -fsS "http://${AU_KPIS_CONTRACT_ADDR}/v1/health" >/dev/null; then
+            if curl -fsS "http://127.0.0.1:3000/v1/health" >/dev/null; then
               exit 0
             fi
             sleep 1
           done
-          echo "Smoke server did not become ready" >&2
-          cat target/smoke/server.log >&2 || true
+          docker compose -f infra/compose/docker-compose.yml logs api >&2 || true
           exit 1
 
-      - name: Run curl smoke checks
+      - name: Wait for k6 metrics store
         run: |
           set -euo pipefail
-          curl -fsS "http://${AU_KPIS_CONTRACT_ADDR}/v1/health" | jq -e '.status == "ok"'
-          curl -fsS "http://${AU_KPIS_CONTRACT_ADDR}/v1/openapi.json" | jq -e '.openapi'
+          for _ in $(seq 1 60); do
+            if curl -fsS "http://127.0.0.1:8086/ping" >/dev/null; then
+              exit 0
+            fi
+            sleep 1
+          done
+          docker compose -f infra/compose/docker-compose.yml logs influxdb >&2 || true
+          exit 1
 
-      - name: Run SDK smoke check
+      - name: Run k6 smoke scenario
+        env:
+          AU_KPIS_API_KEY: ${{ secrets.AU_KPIS_SMOKE_API_KEY }}
         run: |
-          node --input-type=module <<'JS'
-          import { createClient } from './packages/sdk/dist/client.js'
+          set -euo pipefail
+          k6 run --out "${K6_OUT}" \
+            --tag environment="${K6_ENVIRONMENT}" \
+            --tag github_run_id="${GITHUB_RUN_ID}" \
+            apps/bench/smoke.js
 
-          const client = createClient({ baseUrl: `http://${process.env.AU_KPIS_CONTRACT_ADDR}` })
-          const health = await client.health()
-          if (health.status !== 'ok') {
-            throw new Error(`unexpected health status: ${health.status}`)
-          }
-          await client.openapi()
-          JS
-
-      - name: Stop smoke server
+      - name: Stop compose smoke stack
         if: always()
-        run: |
-          set -euo pipefail
-          if [ -f target/smoke/server.pid ]; then
-            kill "$(cat target/smoke/server.pid)" || true
-          fi
+        run: docker compose -f infra/compose/docker-compose.yml --profile observability down -v
 
   bench:
     name: Bench Regression

--- a/apps/bench/README.md
+++ b/apps/bench/README.md
@@ -1,12 +1,18 @@
-# k6 Bench Scaffolds
+# k6 Bench Scenarios
 
-`smoke.js` is the Phase 1 placeholder for the PR smoke scenario described in
-`Spec.md § Benchmarking`. It targets a locally running API and keeps thresholds
-close to the production budget while the endpoint set is still small.
+`smoke.js` is the PR and merge-queue smoke scenario described in
+`Spec.md § Benchmarking`. It runs one virtual user for 30 seconds, covers the
+current public API surface, and enforces the API budget:
+
+- p95 HTTP request duration below 200 ms
+- failed request rate below 1%
 
 ```bash
-AU_KPIS_BASE_URL=http://127.0.0.1:3000 k6 run apps/bench/smoke.js
+AU_KPIS_BASE_URL=http://127.0.0.1:3000 \
+  k6 run --out influxdb=http://127.0.0.1:8086/k6 apps/bench/smoke.js
 ```
 
-Later issues add sustained and burst scenarios here without changing the local
-entrypoint convention.
+Set `AU_KPIS_API_KEY` when the target should use an API-key rate-limit tier.
+The compose observability stack provisions an InfluxDB v1 `k6` database and a
+Grafana dashboard for trend review. Later issues add sustained and burst
+scenarios here without changing the local entrypoint convention.

--- a/apps/bench/smoke.js
+++ b/apps/bench/smoke.js
@@ -1,7 +1,54 @@
 import { check } from 'k6'
+import { sleep } from 'k6'
 import http from 'k6/http'
 
 const baseUrl = __ENV.AU_KPIS_BASE_URL || 'http://127.0.0.1:3000'
+const headers = __ENV.AU_KPIS_API_KEY ? { 'X-API-Key': __ENV.AU_KPIS_API_KEY } : {}
+const fixtureSeriesKey = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+
+const endpoints = [
+  {
+    name: 'health',
+    path: '/v1/health',
+    check: (response) => response.status === 200 && response.json('status') === 'ok',
+  },
+  {
+    name: 'openapi',
+    path: '/v1/openapi.json',
+    check: (response) => response.status === 200 && response.json('openapi') !== undefined,
+  },
+  {
+    name: 'dataflows list',
+    path: '/v1/dataflows?source=abs&frequency=quarterly',
+    check: (response) => response.status === 200 && Array.isArray(response.json('dataflows')),
+  },
+  {
+    name: 'dataflow detail',
+    path: '/v1/dataflows/abs.cpi',
+    check: (response) => response.status === 200 && response.json('dataflow.id') === 'abs.cpi',
+  },
+  {
+    name: 'dataflow codelist',
+    path: '/v1/dataflows/abs.cpi/codelists/region',
+    check: (response) => response.status === 200 && Array.isArray(response.json('codelist.codes')),
+  },
+  {
+    name: 'observations',
+    path: '/v1/observations?dataflow=abs.cpi&dimensions[region]=AUS&limit=5',
+    check: (response) => response.status === 200 && Array.isArray(response.json('observations')),
+  },
+  {
+    name: 'series detail',
+    path: '/v1/series/abs.cpi/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    check: (response) =>
+      response.status === 200 && response.json('series.series_key') === fixtureSeriesKey,
+  },
+  {
+    name: 'search',
+    path: '/v1/search?q=price%20index',
+    check: (response) => response.status === 200 && Array.isArray(response.json('results')),
+  },
+]
 
 export const options = {
   vus: 1,
@@ -13,13 +60,14 @@ export const options = {
 }
 
 export default function () {
-  const health = http.get(`${baseUrl}/v1/health`)
-  check(health, {
-    'health returns 200': (response) => response.status === 200,
-  })
-
-  const openapi = http.get(`${baseUrl}/v1/openapi.json`)
-  check(openapi, {
-    'openapi returns 200': (response) => response.status === 200,
-  })
+  for (const endpoint of endpoints) {
+    const response = http.get(`${baseUrl}${endpoint.path}`, {
+      headers,
+      tags: { endpoint: endpoint.name },
+    })
+    check(response, {
+      [`${endpoint.name} returns expected response`]: endpoint.check,
+    })
+  }
+  sleep(2)
 }

--- a/crates/testing/tests/bench_scaffold.rs
+++ b/crates/testing/tests/bench_scaffold.rs
@@ -117,19 +117,77 @@ fn issue_37_benchmark_contract_is_wired() {
 }
 
 #[test]
-fn smoke_workflow_builds_server_before_readiness_polling() {
+fn issue_38_k6_smoke_contract_is_wired() {
     let root = repo_root();
+    let smoke_script =
+        fs::read_to_string(root.join("apps/bench/smoke.js")).expect("read k6 smoke script");
     let pr_workflow =
         fs::read_to_string(root.join(".github/workflows/pr.yml")).expect("read pr workflow");
 
+    for expected in [
+        "duration: '30s'",
+        "http_req_duration: ['p(95)<200']",
+        "http_req_failed: ['rate<0.01']",
+        "/v1/health",
+        "/v1/openapi.json",
+        "/v1/dataflows?source=abs&frequency=quarterly",
+        "/v1/dataflows/abs.cpi",
+        "/v1/dataflows/abs.cpi/codelists/region",
+        "/v1/observations?dataflow=abs.cpi&dimensions[region]=AUS&limit=5",
+        "/v1/series/abs.cpi/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "/v1/search?q=price%20index",
+        "sleep(2)",
+    ] {
+        assert!(
+            smoke_script.contains(expected),
+            "k6 smoke script should cover `{expected}`"
+        );
+    }
+
     assert!(
-        pr_workflow.contains("cargo build -p au-kpis-api-http --example contract_server --locked"),
-        "smoke workflow should build the contract server before starting it"
+        pr_workflow.contains("name: Smoke (k6)"),
+        "smoke workflow should be the k6 PR and merge-queue gate"
     );
     assert!(
-        pr_workflow
-            .contains("./target/debug/examples/contract_server > target/smoke/server.log 2>&1 &"),
-        "smoke workflow should start the prebuilt contract server binary"
+        pr_workflow.contains(
+            "docker compose -f infra/compose/docker-compose.yml up -d --build api influxdb"
+        ),
+        "PR smoke workflow should run against the docker-compose API stack with InfluxDB"
+    );
+    assert!(
+        pr_workflow.contains("< apps/web/e2e/fixtures/explorer.sql"),
+        "PR smoke workflow should seed real endpoint data before k6 runs"
+    );
+    assert!(
+        pr_workflow.contains("grafana/setup-k6-action"),
+        "smoke workflow should install k6 explicitly"
+    );
+    assert!(
+        pr_workflow.contains("k6 run --out \"${K6_OUT}\"")
+            && pr_workflow.contains("influxdb=http://127.0.0.1:8086/k6"),
+        "smoke workflow should publish k6 results to InfluxDB for Grafana trending"
+    );
+    assert!(
+        pr_workflow.contains("AU_KPIS_STAGING_BASE_URL")
+            && pr_workflow.contains("github.event_name == 'merge_group'"),
+        "merge-queue smoke flow should target the configured staging API"
+    );
+
+    let compose = fs::read_to_string(root.join("infra/compose/docker-compose.yml"))
+        .expect("read compose file");
+    assert!(
+        compose.contains("influxdb:") && compose.contains("INFLUXDB_DB: k6"),
+        "compose stack should include an InfluxDB v1 database for k6 metrics"
+    );
+    assert!(
+        root.join("infra/observability/grafana/provisioning/datasources/k6-influxdb.yml")
+            .is_file(),
+        "Grafana should provision a k6 InfluxDB datasource"
+    );
+    assert!(
+        root.join("infra/observability/grafana/dashboards/k6-smoke.json")
+            .is_file(),
+        "Grafana should provision a k6 smoke trend dashboard"
     );
 }
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -19,12 +19,27 @@ the single `CI OK` status check.
 - Supply-chain and secret scans: `cargo deny`, `cargo audit`,
   `pnpm audit --audit-level critical`, and gitleaks over full history
 - API container build plus Trivy HIGH/CRITICAL image scan
-- Curl and SDK smoke checks against the local contract server
+- k6 smoke checks against the docker-compose stack on pull requests and the
+  configured staging API in merge queue
 - Advisory Criterion bench comparison through `critcmp`
 - Advisory Codex structured review when repository secrets allow it
 
 Rust jobs install `sccache` and use the GitHub Actions backend. TypeScript jobs
 restore the pnpm store and `.turbo` cache before running Turborepo tasks.
+
+## k6 smoke gate
+
+The smoke job starts the compose API stack and an InfluxDB v1 metrics store for
+pull requests, applies migrations, seeds `apps/web/e2e/fixtures/explorer.sql`,
+and runs `apps/bench/smoke.js`. Merge-queue runs use
+`AU_KPIS_STAGING_BASE_URL` from repository variables as the API target and still
+publish k6 samples through the configured InfluxDB output.
+
+Set `K6_INFLUXDB_ADDR` as a repository variable when CI should post trend data
+to a shared InfluxDB/Grafana environment. If it is not set, the job posts to the
+local compose InfluxDB database at `http://127.0.0.1:8086/k6`. Set
+`AU_KPIS_SMOKE_API_KEY` as a repository secret when staging should run the smoke
+scenario with an API-key tier instead of anonymous quotas.
 
 ## Dependency and secret policy
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -12,7 +12,8 @@ docker compose -f infra/compose/docker-compose.yml --profile observability up -d
 
 Grafana is available at `http://127.0.0.1:3002` with local defaults `admin` / `admin`.
 The stack also exposes Prometheus on `:9090`, Alertmanager on `:9093`, Loki on `:3100`,
-Tempo on `:3200`, OTLP on `:4317`/`:4318`, and Pushgateway on `:9091`.
+Tempo on `:3200`, OTLP on `:4317`/`:4318`, Pushgateway on `:9091`, and the k6
+InfluxDB database on `:8086`.
 
 ## Signal Flow
 
@@ -20,7 +21,9 @@ Tempo on `:3200`, OTLP on `:4317`/`:4318`, and Pushgateway on `:9091`.
 - `otel-collector` writes traces to Tempo and exposes OTLP metrics for Prometheus.
 - The ingestion worker exposes `/metrics`; Prometheus scrapes it directly.
 - Promtail tails Compose container logs and pushes JSON log lines to Loki.
-- Grafana provisions Prometheus, Loki, and Tempo datasources plus the required dashboards.
+- The k6 smoke scenario writes request duration and failure-rate samples to InfluxDB.
+- Grafana provisions Prometheus, Loki, Tempo, and k6 InfluxDB datasources plus the
+  required dashboards.
 
 ## Dashboards
 
@@ -29,6 +32,7 @@ Tempo on `:3200`, OTLP on `:4317`/`:4318`, and Pushgateway on `:9091`.
 - API latency p50/p95/p99: `infra/observability/grafana/dashboards/api-latency.json`
 - Queue depth, worker saturation, and DB state: `infra/observability/grafana/dashboards/queue-db.json`
 - SLO burn rates and active page alerts: `infra/observability/grafana/dashboards/slo-burn-rates.json`
+- k6 smoke p95, failure rate, and endpoint request rate: `infra/observability/grafana/dashboards/k6-smoke.json`
 
 ## Alert Routing
 

--- a/infra/compose/docker-compose.yml
+++ b/infra/compose/docker-compose.yml
@@ -199,6 +199,17 @@ services:
     ports:
       - "127.0.0.1:9091:9091"
 
+  influxdb:
+    profiles: ["observability"]
+    image: influxdb:1.8
+    environment:
+      INFLUXDB_DB: k6
+      INFLUXDB_HTTP_AUTH_ENABLED: "false"
+    ports:
+      - "127.0.0.1:8086:8086"
+    volumes:
+      - influxdb-data:/var/lib/influxdb
+
   tempo:
     profiles: ["observability"]
     image: grafana/tempo:2.7.0
@@ -269,6 +280,8 @@ services:
     depends_on:
       prometheus:
         condition: service_started
+      influxdb:
+        condition: service_started
       tempo:
         condition: service_started
       loki:
@@ -279,6 +292,7 @@ volumes:
   redis-data:
   minio-data:
   prometheus-data:
+  influxdb-data:
   tempo-data:
   loki-data:
   grafana-data:

--- a/infra/observability/grafana/dashboards/k6-smoke.json
+++ b/infra/observability/grafana/dashboards/k6-smoke.json
@@ -1,0 +1,158 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "au-kpis-k6-influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "p95 request duration",
+          "query": "SELECT percentile(\"value\", 95) FROM \"http_req_duration\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "HTTP p95",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "au-kpis-k6-influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "failed requests",
+          "query": "SELECT mean(\"value\") FROM \"http_req_failed\" WHERE $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Failure Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "au-kpis-k6-influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_endpoint",
+          "query": "SELECT non_negative_derivative(sum(\"value\"), 1s) FROM \"http_reqs\" WHERE $timeFilter GROUP BY time($__interval), \"endpoint\" fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Requests By Endpoint",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "1m",
+  "schemaVersion": 39,
+  "style": "light",
+  "tags": ["k6", "smoke", "ci"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "k6 Smoke",
+  "uid": "au-kpis-k6-smoke",
+  "version": 1,
+  "weekStart": ""
+}

--- a/infra/observability/grafana/provisioning/datasources/k6-influxdb.yml
+++ b/infra/observability/grafana/provisioning/datasources/k6-influxdb.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+datasources:
+  - name: k6 InfluxDB
+    uid: au-kpis-k6-influxdb
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    database: k6
+    editable: false
+    jsonData:
+      httpMode: GET


### PR DESCRIPTION
Closes #38

## Pass requirements

- [x] `apps/bench/smoke.js` with thresholds from spec (p95 <200 ms, error <1%)
- [x] Runs against `docker-compose` stack in PR CI
- [x] Runs against staging in merge-queue flow
- [x] Results posted to InfluxDB/Grafana for trending

## Test plan

- `cargo fmt --all --check`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo check --workspace --locked`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo nextest run --workspace --profile ci -j 1 --retries 0`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `docker compose -f infra/compose/docker-compose.yml --profile observability config --quiet`
- `jq -e . infra/observability/grafana/dashboards/k6-smoke.json`
- Local Docker k6 smoke against compose API + InfluxDB: 120/120 checks, p95 ~6 ms, 0% failed requests
- `RUSTC_WRAPPER= cargo run -p au-kpis-openapi > target/openapi/openapi.json` plus normalized diff against committed `openapi.json`
- `gitleaks protect --staged`

## Spec impact

No Spec changes required. This implements the existing `Spec.md § Benchmarking` and CI/CD smoke requirements.