### PR TITLE
ci(merge): add merge queue workflow contract (#15)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Required review owner for all repository changes.
+* @ponderingdemocritus

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,18 @@
+name: Merge Queue
+
+on:
+  merge_group:
+    types:
+      - checks_requested
+
+concurrency:
+  group: merge-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  merge-queue:
+    name: Merge Queue Checks
+    uses: ./.github/workflows/pr.yml
+    with:
+      merge_queue: true
+    secrets: inherit

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,9 +7,13 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-  merge_group:
-    types:
-      - checks_requested
+  workflow_call:
+    inputs:
+      merge_queue:
+        description: Run merge-queue-specific gate behavior.
+        required: false
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('merge-{0}', github.sha) }}
@@ -456,14 +460,14 @@ jobs:
           fi
 
       - name: Configure local smoke target
-        if: github.event_name != 'merge_group'
+        if: ${{ inputs.merge_queue != true }}
         run: |
           set -euo pipefail
           echo "AU_KPIS_BASE_URL=http://127.0.0.1:3000" >> "$GITHUB_ENV"
           echo "K6_ENVIRONMENT=pr-compose" >> "$GITHUB_ENV"
 
       - name: Configure staging smoke target
-        if: github.event_name == 'merge_group'
+        if: ${{ inputs.merge_queue == true }}
         env:
           AU_KPIS_STAGING_BASE_URL: ${{ vars.AU_KPIS_STAGING_BASE_URL }}
         run: |
@@ -476,15 +480,15 @@ jobs:
           echo "K6_ENVIRONMENT=staging" >> "$GITHUB_ENV"
 
       - name: Start compose smoke stack
-        if: github.event_name != 'merge_group'
+        if: ${{ inputs.merge_queue != true }}
         run: docker compose -f infra/compose/docker-compose.yml up -d --build api influxdb
 
       - name: Start merge-queue metrics store
-        if: github.event_name == 'merge_group'
+        if: ${{ inputs.merge_queue == true }}
         run: docker compose -f infra/compose/docker-compose.yml up -d influxdb
 
       - name: Apply migrations
-        if: github.event_name != 'merge_group'
+        if: ${{ inputs.merge_queue != true }}
         run: |
           set -euo pipefail
           for _ in $(seq 1 60); do
@@ -499,14 +503,14 @@ jobs:
                 psql -v ON_ERROR_STOP=1 -U au_kpis -d au_kpis
 
       - name: Seed smoke fixture data
-        if: github.event_name != 'merge_group'
+        if: ${{ inputs.merge_queue != true }}
         run: |
           docker compose -f infra/compose/docker-compose.yml exec -T postgres \
             psql -v ON_ERROR_STOP=1 -U au_kpis -d au_kpis \
             < apps/web/e2e/fixtures/explorer.sql
 
       - name: Wait for local API readiness
-        if: github.event_name != 'merge_group'
+        if: ${{ inputs.merge_queue != true }}
         run: |
           set -euo pipefail
           for _ in $(seq 1 120); do
@@ -606,6 +610,9 @@ jobs:
           critcmp_status=$?
           set -e
           printf '%s\n' "${critcmp_output}"
+          if [ "${critcmp_status}" -ne 0 ]; then
+            printf 'critcmp reported threshold crossings; checking confidence bounds before failing.\n'
+          fi
           critcmp --export main > target/criterion-main.json
           critcmp --export pr > target/criterion-pr.json
           python3 <<'PY'
@@ -886,6 +893,7 @@ jobs:
 
   codex-review:
     name: Codex Structured Review
+    if: ${{ inputs.merge_queue != true }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/crates/au-kpis-api-http/src/search.rs
+++ b/crates/au-kpis-api-http/src/search.rs
@@ -133,6 +133,11 @@ fn parse_search_query(raw: Option<&str>) -> Result<SearchQuery, ApiError> {
             "search query `q` must not be blank".into(),
         ));
     }
+    if q.contains('\0') {
+        return Err(ApiError::Validation(
+            "search query `q` must not contain NUL bytes".into(),
+        ));
+    }
 
     Ok(SearchQuery { q, limit })
 }

--- a/crates/au-kpis-api-http/tests/routes.rs
+++ b/crates/au-kpis-api-http/tests/routes.rs
@@ -263,6 +263,68 @@ async fn dataflows_route_validates_frequency_before_db_access() {
 }
 
 #[tokio::test]
+async fn dataflows_route_rejects_invalid_source_before_db_access() {
+    let response = router(test_state())
+        .expect("router")
+        .oneshot(
+            Request::builder()
+                .uri("/v1/dataflows?source=fL%C3%A0%C3%BD%00%C3%AD%C3%B6%C2%96%C3%A9")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/problem+json"
+    );
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let parsed: ProblemDetails = serde_json::from_slice(&body).expect("problem details json");
+    assert!(
+        parsed
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("source"))
+    );
+}
+
+#[tokio::test]
+async fn search_route_rejects_nul_query_before_db_access() {
+    let response = router(test_state())
+        .expect("router")
+        .oneshot(
+            Request::builder()
+                .uri("/v1/search?q=inflation%00")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/problem+json"
+    );
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let parsed: ProblemDetails = serde_json::from_slice(&body).expect("problem details json");
+    assert!(
+        parsed
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("search query"))
+    );
+}
+
+#[tokio::test]
 async fn series_route_validates_series_key_before_db_access() {
     let response = router(test_state())
         .expect("router")

--- a/crates/au-kpis-domain/src/ids.rs
+++ b/crates/au-kpis-domain/src/ids.rs
@@ -26,6 +26,8 @@ pub enum IdError {
     Empty,
     #[error("identifier exceeds {max} bytes")]
     TooLong { max: usize },
+    #[error("identifier must not contain NUL bytes")]
+    ContainsNul,
     #[error("hash must be {expected} hex characters, got {actual}")]
     HashLength { expected: usize, actual: usize },
     #[error("hash contains non-hex characters")]
@@ -45,6 +47,9 @@ fn validate_slug(s: &str) -> Result<(), IdError> {
     }
     if s.len() > MAX_ID_LEN {
         return Err(IdError::TooLong { max: MAX_ID_LEN });
+    }
+    if s.contains('\0') {
+        return Err(IdError::ContainsNul);
     }
     Ok(())
 }
@@ -398,6 +403,11 @@ mod tests {
             SourceId::new(too_long),
             Err(IdError::TooLong { max: MAX_ID_LEN })
         );
+    }
+
+    #[test]
+    fn slug_id_rejects_nul_bytes() {
+        assert_eq!(SourceId::new("abs\0cpi"), Err(IdError::ContainsNul));
     }
 
     #[test]

--- a/crates/testing/tests/bench_scaffold.rs
+++ b/crates/testing/tests/bench_scaffold.rs
@@ -90,8 +90,11 @@ fn issue_37_benchmark_contract_is_wired() {
 
     let pr_workflow =
         fs::read_to_string(root.join(".github/workflows/pr.yml")).expect("read pr workflow");
+    let merge_workflow = fs::read_to_string(root.join(".github/workflows/merge.yml"))
+        .expect("read merge queue workflow");
     assert!(
-        pr_workflow.contains("merge_group:"),
+        merge_workflow.contains("merge_group:")
+            && merge_workflow.contains("uses: ./.github/workflows/pr.yml"),
         "benchmark regression gate should run for merge queue batches"
     );
     assert!(
@@ -173,7 +176,7 @@ fn issue_38_k6_smoke_contract_is_wired() {
     );
     assert!(
         pr_workflow.contains("AU_KPIS_STAGING_BASE_URL")
-            && pr_workflow.contains("github.event_name == 'merge_group'"),
+            && pr_workflow.contains("inputs.merge_queue == true"),
         "merge-queue smoke flow should target the configured staging API"
     );
 
@@ -201,6 +204,8 @@ fn issue_39_schemathesis_contract_is_wired() {
 
     let pr_workflow =
         fs::read_to_string(root.join(".github/workflows/pr.yml")).expect("read pr workflow");
+    let merge_workflow = fs::read_to_string(root.join(".github/workflows/merge.yml"))
+        .expect("read merge queue workflow");
     let contract_config = fs::read_to_string(root.join("tests/contract/schemathesis.toml"))
         .expect("read schemathesis PR config");
     let deep_config = fs::read_to_string(root.join("tests/contract/schemathesis.deep.toml"))
@@ -228,7 +233,9 @@ fn issue_39_schemathesis_contract_is_wired() {
         "PR contract workflow should emit a JUnit report artifact"
     );
     assert!(
-        pr_workflow.contains("merge_group:") && pr_workflow.contains("- contract"),
+        merge_workflow.contains("merge_group:")
+            && merge_workflow.contains("uses: ./.github/workflows/pr.yml")
+            && pr_workflow.contains("- contract"),
         "contract checks should remain blocking in merge queue batches through CI OK"
     );
 
@@ -303,6 +310,75 @@ fn issue_39_schemathesis_contract_is_wired() {
             && testing_docs.contains("schemathesis.deep.toml"),
         "CI and testing docs should document PR and nightly contract fuzzing"
     );
+}
+
+#[test]
+fn issue_15_merge_queue_contract_is_wired() {
+    let root = repo_root();
+
+    let pr_workflow =
+        fs::read_to_string(root.join(".github/workflows/pr.yml")).expect("read pr workflow");
+    let merge_workflow = fs::read_to_string(root.join(".github/workflows/merge.yml"))
+        .expect("read merge queue workflow");
+    let codeowners = fs::read_to_string(root.join(".github/CODEOWNERS")).expect("read CODEOWNERS");
+    let ci_docs = fs::read_to_string(root.join("docs/ci.md")).expect("read CI docs");
+
+    assert!(
+        pr_workflow.contains("workflow_call:")
+            && pr_workflow.contains("merge_queue:")
+            && pr_workflow.contains("type: boolean"),
+        "PR workflow should be reusable by the merge-queue workflow"
+    );
+    assert!(
+        !pr_workflow.contains("  merge_group:"),
+        "merge_group should be owned by the dedicated merge queue workflow"
+    );
+
+    for expected in [
+        "name: Merge Queue",
+        "merge_group:",
+        "checks_requested",
+        "uses: ./.github/workflows/pr.yml",
+        "merge_queue: true",
+        "secrets: inherit",
+    ] {
+        assert!(
+            merge_workflow.contains(expected),
+            "merge queue workflow should contain `{expected}`"
+        );
+    }
+
+    for expected in [
+        "name: Smoke (k6)",
+        "name: Bench Regression",
+        "name: Contract (schemathesis)",
+        "CI OK",
+        "inputs.merge_queue == true",
+    ] {
+        assert!(
+            pr_workflow.contains(expected),
+            "merge queue should reuse the blocking PR gate `{expected}`"
+        );
+    }
+
+    assert!(
+        codeowners.contains("* @ponderingdemocritus"),
+        "CODEOWNERS should define a default owner for required review"
+    );
+
+    for expected in [
+        "GitHub merge queue cannot be enabled",
+        "personal account",
+        "add a `merge_queue` rule to `main`",
+        "Required CODEOWNERS review is enforced on `main`",
+        "Signed commits are required on `main`",
+        "A failing merge group fails `CI OK`",
+    ] {
+        assert!(
+            ci_docs.contains(expected),
+            "CI docs should document branch protection setting `{expected}`"
+        );
+    }
 }
 
 #[test]

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,7 +2,8 @@
 
 `Spec.md` is the source of truth for required gates. The pull request workflow
 groups those gates into parallel GitHub Actions jobs and aggregates them through
-the single `CI OK` status check.
+the single `CI OK` status check. The merge-queue workflow reuses that full gate
+set with merge-queue staging behavior enabled.
 
 ## Pull request workflow
 
@@ -21,11 +22,43 @@ the single `CI OK` status check.
 - API container build plus Trivy HIGH/CRITICAL image scan
 - k6 smoke checks against the docker-compose stack on pull requests and the
   configured staging API in merge queue
-- Advisory Criterion bench comparison through `critcmp`
+- Blocking Criterion bench comparison through `critcmp`
 - Advisory Codex structured review when repository secrets allow it
 
 Rust jobs install `sccache` and use the GitHub Actions backend. TypeScript jobs
 restore the pnpm store and `.turbo` cache before running Turborepo tasks.
+
+## Merge queue and branch protection
+
+`.github/workflows/merge.yml` is the only workflow that listens for
+`merge_group` events. It calls `.github/workflows/pr.yml` with
+`merge_queue: true`, so every merge group runs the full pull-request flow plus
+the merge-queue-specific k6 staging smoke target. Branch protection should use
+the single aggregate status instead of individual jobs, because `CI OK` fails
+when any required upstream job fails or is cancelled.
+
+Currently enforceable repository settings for `main`:
+
+- Required status check is `CI OK`.
+- Required CODEOWNERS review is enforced on `main` through `.github/CODEOWNERS`.
+- Signed commits are required on `main`.
+
+GitHub merge queue cannot be enabled while this repository is owned by a
+personal account. GitHub only supports pull request merge queues for public
+repositories owned by an organization, or private repositories owned by
+organizations using Enterprise Cloud. After transferring the repository to an
+organization, add a `merge_queue` rule to `main` in the existing `merge`
+ruleset with these parameters. A failing merge group fails `CI OK`, which
+ejects the whole batch instead of partially landing any pull request from that
+group.
+
+- `grouping_strategy`: `ALLGREEN`
+- `merge_method`: `MERGE`
+- `min_entries_to_merge`: `1`
+- `max_entries_to_merge`: `5`
+- `max_entries_to_build`: `5`
+- `min_entries_to_merge_wait_minutes`: `5`
+- `check_response_timeout_minutes`: `60`
 
 ## k6 smoke gate
 


### PR DESCRIPTION
## Context

Refs #15. This wires the dedicated merge-queue workflow entry point and applies the branch-protection settings GitHub allows on the current repository. The remaining merge-queue ruleset switch is blocked because the repository is owned by a personal account; GitHub documents pull request merge queues for organization-owned repositories.

## Pass requirements

- [x] `merge.yml` runs the merge-queue-only gate by calling the full PR flow with merge-queue behavior enabled: k6 staging smoke, schemathesis, bench regression, current Playwright suite, and `CI OK` aggregation.
- [ ] GitHub merge queue is enabled on `main`.
  - Blocked: GitHub returned `422 Invalid rule 'merge_queue'` for the repository ruleset. The repo is currently owned by `ponderingdemocritus` as a personal account, and GitHub merge queue requires organization ownership. `docs/ci.md` records the exact post-transfer ruleset parameters.
- [x] Required CODEOWNERS review is enforced on `main`.
- [x] Signed commits are required on `main`.
- [x] Failed merge-queue batch behavior is documented as failing `CI OK` and ejecting the batch once GitHub merge queue is available.
- [x] Repository settings or ops notes document exact branch-protection and merge-queue configuration.

## Test plan

- `docker run --rm -v "/Users/os/.codex/worktrees/c479/australian-kpis":/repo -w /repo rhysd/actionlint:latest -color=false .github/workflows/pr.yml .github/workflows/merge.yml`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo fmt --all --check`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `CARGO_INCREMENTAL=0 CARGO_BUILD_JOBS=1 RUSTC_WRAPPER= cargo nextest run --workspace --profile ci -j 1 --retries 0 --locked` (371 passed)
- `pnpm run lint`
- `pnpm turbo run typecheck test --cache-dir=.turbo`
- `RUSTC_WRAPPER= cargo deny check`
- `RUSTC_WRAPPER= cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks protect --staged`

## Spec impact

No `Spec.md` change. `docs/ci.md` now records the operational limitation and exact settings to apply after moving the repository under an organization.
