### PR TITLE
ci(bench): add nightly k6 load scenarios (#49)

### DIFF
--- a/.github/workflows/k6-nightly.yml
+++ b/.github/workflows/k6-nightly.yml
@@ -1,0 +1,187 @@
+name: k6 Nightly Load
+
+on:
+  schedule:
+    - cron: "0 2 * * *"
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: Scenario to run
+        required: true
+        default: all
+        type: choice
+        options:
+          - all
+          - sustained
+          - burst
+      pr_number:
+        description: Optional PR number for a comparison comment
+        required: false
+        type: string
+  pull_request:
+    types:
+      - labeled
+
+concurrency:
+  group: k6-load-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: false
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: write
+  issues: write
+
+env:
+  REQUESTED_SCENARIO: ${{ github.event.inputs.scenario || 'all' }}
+
+jobs:
+  staging-load:
+    name: k6 staging load
+    if: github.event_name != 'pull_request' || github.event.label.name == 'perf:regression'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up k6
+        uses: grafana/setup-k6-action@v1
+        with:
+          k6-version: "0.54.0"
+
+      - name: Configure staging target
+        env:
+          AU_KPIS_STAGING_BASE_URL: ${{ vars.AU_KPIS_STAGING_BASE_URL }}
+          K6_INFLUXDB_ADDR: ${{ vars.K6_INFLUXDB_ADDR }}
+        run: |
+          set -euo pipefail
+          if [ -z "${AU_KPIS_STAGING_BASE_URL:-}" ]; then
+            echo "AU_KPIS_STAGING_BASE_URL repository variable is required for nightly k6." >&2
+            exit 1
+          fi
+          if [ -z "${K6_INFLUXDB_ADDR:-}" ]; then
+            echo "K6_INFLUXDB_ADDR repository variable is required for historical k6 load trends." >&2
+            exit 1
+          fi
+          echo "AU_KPIS_BASE_URL=${AU_KPIS_STAGING_BASE_URL}" >> "$GITHUB_ENV"
+          echo "K6_OUT=influxdb=${K6_INFLUXDB_ADDR}" >> "$GITHUB_ENV"
+
+      - name: Prepare k6 output directory
+        run: mkdir -p target/k6
+
+      - name: Run sustained load
+        id: sustained
+        if: env.REQUESTED_SCENARIO == 'all' || env.REQUESTED_SCENARIO == 'sustained'
+        continue-on-error: true
+        env:
+          AU_KPIS_API_KEY: ${{ secrets.AU_KPIS_SMOKE_API_KEY }}
+        run: |
+          set -euo pipefail
+          k6 run --out "${K6_OUT}" \
+            --summary-export target/k6/sustained-summary.json \
+            --tag environment=staging \
+            --tag github_run_id="${GITHUB_RUN_ID}" \
+            apps/bench/sustained.js
+
+      - name: Run burst load
+        id: burst
+        if: env.REQUESTED_SCENARIO == 'all' || env.REQUESTED_SCENARIO == 'burst'
+        continue-on-error: true
+        env:
+          AU_KPIS_API_KEY: ${{ secrets.AU_KPIS_SMOKE_API_KEY }}
+        run: |
+          set -euo pipefail
+          k6 run --out "${K6_OUT}" \
+            --summary-export target/k6/burst-summary.json \
+            --tag environment=staging \
+            --tag github_run_id="${GITHUB_RUN_ID}" \
+            apps/bench/burst.js
+
+      - name: Download latest nightly baseline
+        if: github.event_name == 'pull_request' || github.event.inputs.pr_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          mkdir -p target/k6/baseline
+          baseline_run="$(
+            gh run list \
+              --workflow k6-nightly.yml \
+              --event schedule \
+              --status success \
+              --branch main \
+              --limit 1 \
+              --json databaseId \
+              --jq '.[0].databaseId // empty'
+          )"
+          if [ -n "${baseline_run}" ]; then
+            gh run download "${baseline_run}" \
+              --name k6-load-summary \
+              --dir target/k6/baseline || true
+          fi
+
+      - name: Build PR comparison comment
+        if: always()
+        env:
+          K6_PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+        run: |
+          python3 tools/ci/k6_pr_comment.py \
+            --current target/k6 \
+            --baseline target/k6/baseline \
+            --output target/k6/comment.md \
+            --pr "${K6_PR_NUMBER:-}"
+
+      - name: Comment k6 comparison on PR
+        if: always() && (github.event_name == 'pull_request' || github.event.inputs.pr_number != '')
+        uses: actions/github-script@v8
+        env:
+          K6_PR_NUMBER: ${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+        with:
+          script: |
+            const fs = require('fs')
+            const marker = '<!-- k6 load comparison -->'
+            const body = fs.readFileSync('target/k6/comment.md', 'utf8')
+            const issue_number = Number(process.env.K6_PR_NUMBER)
+            if (!issue_number) {
+              core.setFailed('A PR number is required for the k6 load comparison comment.')
+              return
+            }
+            const { owner, repo } = context.repo
+            const comments = await github.rest.issues.listComments({
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            })
+            const existing = comments.data.find(
+              (comment) => comment.user.type === 'Bot' && comment.body.includes(marker),
+            )
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner,
+                repo,
+                comment_id: existing.id,
+                body,
+              })
+            } else {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body,
+              })
+            }
+
+      - name: Upload k6 summary artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: k6-load-summary
+          path: |
+            target/k6/*-summary.json
+            target/k6/comment.md
+          retention-days: 30
+
+      - name: Fail on k6 threshold regression
+        if: steps.sustained.outcome == 'failure' || steps.burst.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -475,9 +475,9 @@ jobs:
           echo "AU_KPIS_BASE_URL=${AU_KPIS_STAGING_BASE_URL}" >> "$GITHUB_ENV"
           echo "K6_ENVIRONMENT=staging" >> "$GITHUB_ENV"
 
-      - name: Start compose smoke stack
+      - name: Start compose smoke dependencies
         if: github.event_name != 'merge_group'
-        run: docker compose -f infra/compose/docker-compose.yml up -d --build api influxdb
+        run: docker compose -f infra/compose/docker-compose.yml up -d postgres redis minio pdf-extractor influxdb
 
       - name: Start merge-queue metrics store
         if: github.event_name == 'merge_group'
@@ -504,6 +504,10 @@ jobs:
           docker compose -f infra/compose/docker-compose.yml exec -T postgres \
             psql -v ON_ERROR_STOP=1 -U au_kpis -d au_kpis \
             < apps/web/e2e/fixtures/explorer.sql
+
+      - name: Start local smoke API
+        if: github.event_name != 'merge_group'
+        run: docker compose -f infra/compose/docker-compose.yml up -d --build api
 
       - name: Wait for local API readiness
         if: github.event_name != 'merge_group'
@@ -606,6 +610,9 @@ jobs:
           critcmp_status=$?
           set -e
           printf '%s\n' "${critcmp_output}"
+          if [ "${critcmp_status}" -ne 0 ]; then
+            echo "critcmp threshold check exited with status ${critcmp_status}; verifying confidence bounds."
+          fi
           critcmp --export main > target/criterion-main.json
           critcmp --export pr > target/criterion-pr.json
           python3 <<'PY'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -477,7 +477,7 @@ jobs:
 
       - name: Start compose smoke dependencies
         if: github.event_name != 'merge_group'
-        run: docker compose -f infra/compose/docker-compose.yml up -d postgres redis minio pdf-extractor influxdb
+        run: docker compose -f infra/compose/docker-compose.yml up -d --wait --wait-timeout 120 postgres redis minio pdf-extractor influxdb
 
       - name: Start merge-queue metrics store
         if: github.event_name == 'merge_group'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -487,13 +487,19 @@ jobs:
         if: github.event_name != 'merge_group'
         run: |
           set -euo pipefail
+          ready=0
           for _ in $(seq 1 60); do
             if docker compose -f infra/compose/docker-compose.yml exec -T postgres \
-                pg_isready -U au_kpis -d au_kpis; then
+                psql -v ON_ERROR_STOP=1 -U au_kpis -d au_kpis -c 'SELECT 1' >/dev/null 2>&1; then
+              ready=1
               break
             fi
             sleep 1
           done
+          if [ "${ready}" -ne 1 ]; then
+            docker compose -f infra/compose/docker-compose.yml logs postgres >&2 || true
+            exit 1
+          fi
           cat infra/migrations/*.up.sql \
             | docker compose -f infra/compose/docker-compose.yml exec -T postgres \
                 psql -v ON_ERROR_STOP=1 -U au_kpis -d au_kpis

--- a/apps/bench/README.md
+++ b/apps/bench/README.md
@@ -1,8 +1,11 @@
 # k6 Bench Scenarios
 
-`smoke.js` is the PR and merge-queue smoke scenario described in
-`Spec.md § Benchmarking`. It runs one virtual user for 30 seconds, covers the
-current public API surface, and enforces the API budget:
+`smoke.js`, `sustained.js`, and `burst.js` are the k6 scenarios described in
+`Spec.md § Benchmarking`.
+
+`smoke.js` is the PR and merge-queue smoke scenario. It runs one virtual user
+for 30 seconds, covers the current public API surface, and enforces the API
+budget:
 
 - p95 HTTP request duration below 200 ms
 - failed request rate below 1%
@@ -14,5 +17,37 @@ AU_KPIS_BASE_URL=http://127.0.0.1:3000 \
 
 Set `AU_KPIS_API_KEY` when the target should use an API-key rate-limit tier.
 The compose observability stack provisions an InfluxDB v1 `k6` database and a
-Grafana dashboard for trend review. Later issues add sustained and burst
-scenarios here without changing the local entrypoint convention.
+Grafana dashboard for trend review.
+
+`sustained.js` is the nightly staging scenario. It runs 100 virtual users for
+10 minutes with the production query mix from the spec: 70% single-series
+observation/detail reads, 20% bulk observation reads, and 10% catalog/search
+reads. It enforces:
+
+- p95 HTTP request duration below 500 ms
+- p99 HTTP request duration below 1500 ms
+- failed request rate below 0.1%
+
+```bash
+AU_KPIS_BASE_URL=https://staging.example.test \
+  k6 run --out influxdb=https://influxdb.example.test/k6 apps/bench/sustained.js
+```
+
+`burst.js` is the autoscale and rate-limit scenario. It ramps from 0 to 2000
+virtual users over 2 minutes, holds for 2 minutes, then ramps down. It allows
+rate-limited responses but enforces:
+
+- 429 responses are present
+- 429 responses stay below 30% of total responses
+- 5xx responses stay below 0.5% of total responses
+
+```bash
+AU_KPIS_BASE_URL=https://staging.example.test \
+  k6 run --out influxdb=https://influxdb.example.test/k6 apps/bench/burst.js
+```
+
+`.github/workflows/k6-nightly.yml` runs both long-load scenarios nightly against
+staging and writes the exported summaries as artifacts. Adding the
+`perf:regression` label to a PR triggers the same workflow, downloads the latest
+successful nightly baseline artifact when one exists, and posts a side-by-side
+k6 load comparison comment back to the PR.

--- a/apps/bench/burst.js
+++ b/apps/bench/burst.js
@@ -1,0 +1,84 @@
+import { check } from 'k6'
+import http from 'k6/http'
+import { Counter } from 'k6/metrics'
+import { Rate } from 'k6/metrics'
+
+const baseUrl = __ENV.AU_KPIS_BASE_URL || 'http://127.0.0.1:3000'
+const headers = __ENV.AU_KPIS_API_KEY ? { 'X-API-Key': __ENV.AU_KPIS_API_KEY } : {}
+
+export const rateLimitResponses = new Counter('rate_limit_responses')
+export const serverErrorResponses = new Counter('server_error_responses')
+export const rateLimitRatio = new Rate('rate_limit_ratio')
+export const serverErrorRatio = new Rate('server_error_ratio')
+export const rateLimitSeen = new Rate('rate_limit_seen')
+
+const endpoints = [
+  {
+    name: 'observations all regions',
+    path: '/v1/observations?dataflow=abs.cpi&limit=1000',
+  },
+  {
+    name: 'observations aus',
+    path: '/v1/observations?dataflow=abs.cpi&dimensions[region]=AUS&limit=100',
+  },
+  {
+    name: 'dataflow detail',
+    path: '/v1/dataflows/abs.cpi',
+  },
+  {
+    name: 'search',
+    path: '/v1/search?q=price%20index',
+  },
+]
+
+export const options = {
+  scenarios: {
+    burst: {
+      executor: 'ramping-vus',
+      stages: [
+        { duration: '2m', target: 2000 },
+        { duration: '2m', target: 2000 },
+        { duration: '2m', target: 0 },
+      ],
+      gracefulRampDown: '30s',
+      tags: { scenario: 'burst' },
+    },
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+  thresholds: {
+    rate_limit_ratio: ['rate<0.30'],
+    server_error_ratio: ['rate<0.005'],
+    rate_limit_seen: ['rate>0'],
+    checks: ['rate>0.99'],
+  },
+}
+
+export default function () {
+  const endpoint = endpoints[Math.floor(Math.random() * endpoints.length)]
+  const response = http.get(`${baseUrl}${endpoint.path}`, {
+    headers,
+    tags: { endpoint: endpoint.name, mix: 'burst' },
+  })
+
+  recordBurstResponse(response)
+  check(response, {
+    'request succeeds or is rate limited': (r) => r.status === 200 || r.status === 429,
+    'no server error response': (r) => r.status < 500,
+  })
+}
+
+function recordBurstResponse(response) {
+  const rateLimited = response.status === 429
+  const serverError = response.status >= 500
+
+  if (rateLimited) {
+    rateLimitResponses.add(1)
+  }
+  if (serverError) {
+    serverErrorResponses.add(1)
+  }
+
+  rateLimitRatio.add(rateLimited)
+  serverErrorRatio.add(serverError)
+  rateLimitSeen.add(rateLimited)
+}

--- a/apps/bench/sustained.js
+++ b/apps/bench/sustained.js
@@ -1,0 +1,152 @@
+import { check } from 'k6'
+import { sleep } from 'k6'
+import http from 'k6/http'
+
+const baseUrl = __ENV.AU_KPIS_BASE_URL || 'http://127.0.0.1:3000'
+const headers = __ENV.AU_KPIS_API_KEY ? { 'X-API-Key': __ENV.AU_KPIS_API_KEY } : {}
+
+const series = [
+  {
+    region: 'AUS',
+    key: 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+  },
+  {
+    region: 'NSW',
+    key: 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  },
+  {
+    region: 'VIC',
+    key: 'cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc',
+  },
+  {
+    region: 'QLD',
+    key: 'dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd',
+  },
+]
+
+export const options = {
+  scenarios: {
+    sustained: {
+      executor: 'constant-vus',
+      vus: 100,
+      duration: '10m',
+      gracefulStop: '30s',
+      tags: { scenario: 'sustained' },
+    },
+  },
+  summaryTrendStats: ['avg', 'min', 'med', 'p(90)', 'p(95)', 'p(99)', 'max'],
+  thresholds: {
+    http_req_duration: ['p(95)<500', 'p(99)<1500'],
+    http_req_failed: ['rate<0.001'],
+    checks: ['rate>0.99'],
+  },
+}
+
+export default function () {
+  const roll = Math.random()
+
+  if (roll < 0.7) {
+    singleSeriesRequest()
+  } else if (roll < 0.9) {
+    bulkObservationsRequest()
+  } else {
+    catalogRequest()
+  }
+
+  sleep(0.25 + Math.random() * 1.75)
+}
+
+export function singleSeriesRequest() {
+  const item = pick(series)
+  const endpoint =
+    Math.random() < 0.75
+      ? {
+          name: 'single-series observations',
+          path: `/v1/observations?dataflow=abs.cpi&dimensions[region]=${item.region}&limit=100`,
+          validate: (response) => hasJsonArray(response, 'observations'),
+        }
+      : {
+          name: 'series detail',
+          path: `/v1/series/abs.cpi/${item.key}`,
+          validate: (response) =>
+            response.status === 200 && response.json('series.series_key') === item.key,
+        }
+
+  const response = request(endpoint.path, endpoint.name, { mix: 'single-series' })
+  check(response, {
+    [`${endpoint.name} returns expected response`]: endpoint.validate,
+  })
+}
+
+export function bulkObservationsRequest() {
+  const endpoints = [
+    {
+      name: 'bulk observations all regions',
+      path: '/v1/observations?dataflow=abs.cpi&limit=1000',
+      validate: (response) => hasJsonArray(response, 'observations'),
+    },
+    {
+      name: 'bulk observations date window',
+      path: '/v1/observations?dataflow=abs.cpi&since=2023-09-01&until=2024-06-01&limit=1000',
+      validate: (response) => hasJsonArray(response, 'observations'),
+    },
+    {
+      name: 'bulk observations csv',
+      path: '/v1/observations?dataflow=abs.cpi&format=csv&limit=1000',
+      validate: (response) =>
+        response.status === 200 &&
+        response.headers['Content-Type'] !== undefined &&
+        response.headers['Content-Type'].includes('text/csv'),
+    },
+  ]
+  const endpoint = pick(endpoints)
+  const response = request(endpoint.path, endpoint.name, { mix: 'bulk' })
+  check(response, {
+    [`${endpoint.name} returns expected response`]: endpoint.validate,
+  })
+}
+
+export function catalogRequest() {
+  const endpoints = [
+    {
+      name: 'catalog dataflows',
+      path: '/v1/dataflows?source=abs&frequency=quarterly',
+      validate: (response) => hasJsonArray(response, 'dataflows'),
+    },
+    {
+      name: 'catalog dataflow detail',
+      path: '/v1/dataflows/abs.cpi',
+      validate: (response) => response.status === 200 && response.json('dataflow.id') === 'abs.cpi',
+    },
+    {
+      name: 'catalog codelist',
+      path: '/v1/dataflows/abs.cpi/codelists/region',
+      validate: (response) => hasJsonArray(response, 'codelist.codes'),
+    },
+    {
+      name: 'catalog search',
+      path: '/v1/search?q=price%20index',
+      validate: (response) => hasJsonArray(response, 'results'),
+    },
+  ]
+  const endpoint = pick(endpoints)
+  const response = request(endpoint.path, endpoint.name, { mix: 'catalog' })
+  check(response, {
+    [`${endpoint.name} returns expected response`]: endpoint.validate,
+  })
+}
+
+function request(path, endpoint, tags) {
+  return http.get(`${baseUrl}${path}`, {
+    headers,
+    tags: { endpoint, ...tags },
+  })
+}
+
+function hasJsonArray(response, field) {
+  return response.status === 200 && Array.isArray(response.json(field))
+}
+
+function pick(items) {
+  return items[Math.floor(Math.random() * items.length)]
+}

--- a/crates/au-kpis-api-http/src/search.rs
+++ b/crates/au-kpis-api-http/src/search.rs
@@ -133,6 +133,11 @@ fn parse_search_query(raw: Option<&str>) -> Result<SearchQuery, ApiError> {
             "search query `q` must not be blank".into(),
         ));
     }
+    if q.contains('\0') {
+        return Err(ApiError::Validation(
+            "search query `q` must not contain NUL bytes".into(),
+        ));
+    }
 
     Ok(SearchQuery { q, limit })
 }

--- a/crates/au-kpis-api-http/tests/routes.rs
+++ b/crates/au-kpis-api-http/tests/routes.rs
@@ -263,6 +263,68 @@ async fn dataflows_route_validates_frequency_before_db_access() {
 }
 
 #[tokio::test]
+async fn dataflows_route_rejects_invalid_source_before_db_access() {
+    let response = router(test_state())
+        .expect("router")
+        .oneshot(
+            Request::builder()
+                .uri("/v1/dataflows?source=fL%C3%A0%C3%BD%00%C3%AD%C3%B6%C2%96%C3%A9")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/problem+json"
+    );
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let parsed: ProblemDetails = serde_json::from_slice(&body).expect("problem details json");
+    assert!(
+        parsed
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("source"))
+    );
+}
+
+#[tokio::test]
+async fn search_route_rejects_nul_query_before_db_access() {
+    let response = router(test_state())
+        .expect("router")
+        .oneshot(
+            Request::builder()
+                .uri("/v1/search?q=inflation%00")
+                .body(Body::empty())
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    assert_eq!(
+        response.headers().get(header::CONTENT_TYPE).unwrap(),
+        "application/problem+json"
+    );
+
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    let parsed: ProblemDetails = serde_json::from_slice(&body).expect("problem details json");
+    assert!(
+        parsed
+            .detail
+            .as_deref()
+            .is_some_and(|detail| detail.contains("search query"))
+    );
+}
+
+#[tokio::test]
 async fn series_route_validates_series_key_before_db_access() {
     let response = router(test_state())
         .expect("router")

--- a/crates/au-kpis-domain/src/ids.rs
+++ b/crates/au-kpis-domain/src/ids.rs
@@ -26,6 +26,8 @@ pub enum IdError {
     Empty,
     #[error("identifier exceeds {max} bytes")]
     TooLong { max: usize },
+    #[error("identifier must not contain NUL bytes")]
+    ContainsNul,
     #[error("hash must be {expected} hex characters, got {actual}")]
     HashLength { expected: usize, actual: usize },
     #[error("hash contains non-hex characters")]
@@ -45,6 +47,9 @@ fn validate_slug(s: &str) -> Result<(), IdError> {
     }
     if s.len() > MAX_ID_LEN {
         return Err(IdError::TooLong { max: MAX_ID_LEN });
+    }
+    if s.contains('\0') {
+        return Err(IdError::ContainsNul);
     }
     Ok(())
 }
@@ -398,6 +403,11 @@ mod tests {
             SourceId::new(too_long),
             Err(IdError::TooLong { max: MAX_ID_LEN })
         );
+    }
+
+    #[test]
+    fn slug_id_rejects_nul_bytes() {
+        assert_eq!(SourceId::new("abs\0cpi"), Err(IdError::ContainsNul));
     }
 
     #[test]

--- a/crates/testing/tests/bench_scaffold.rs
+++ b/crates/testing/tests/bench_scaffold.rs
@@ -308,6 +308,10 @@ fn smoke_workflow_migrates_before_starting_api() {
         dependencies < migrations && migrations < seed && seed < api,
         "smoke workflow should start dependencies, migrate, seed, then start the API"
     );
+    assert!(
+        smoke_workflow.contains("SELECT 1"),
+        "smoke workflow should wait for a stable SQL round trip before migrating"
+    );
 }
 
 #[test]

--- a/crates/testing/tests/bench_scaffold.rs
+++ b/crates/testing/tests/bench_scaffold.rs
@@ -196,6 +196,87 @@ fn issue_38_k6_smoke_contract_is_wired() {
 }
 
 #[test]
+fn issue_49_k6_nightly_load_contract_is_wired() {
+    let root = repo_root();
+
+    let sustained =
+        fs::read_to_string(root.join("apps/bench/sustained.js")).expect("read sustained script");
+    let burst = fs::read_to_string(root.join("apps/bench/burst.js")).expect("read burst script");
+    let nightly = fs::read_to_string(root.join(".github/workflows/k6-nightly.yml"))
+        .expect("read k6 nightly workflow");
+    let bench_docs =
+        fs::read_to_string(root.join("apps/bench/README.md")).expect("read bench docs");
+    let observability_docs =
+        fs::read_to_string(root.join("docs/observability.md")).expect("read observability docs");
+
+    for expected in [
+        "vus: 100",
+        "duration: '10m'",
+        "http_req_duration: ['p(95)<500', 'p(99)<1500']",
+        "http_req_failed: ['rate<0.001']",
+        "singleSeriesRequest",
+        "bulkObservationsRequest",
+        "catalogRequest",
+    ] {
+        assert!(
+            sustained.contains(expected),
+            "sustained scenario should contain `{expected}`"
+        );
+    }
+
+    for expected in [
+        "stages:",
+        "target: 2000",
+        "duration: '2m'",
+        "rateLimitResponses",
+        "serverErrorResponses",
+        "rate_limit_ratio",
+        "server_error_ratio",
+        "rate_limit_seen",
+    ] {
+        assert!(
+            burst.contains(expected),
+            "burst scenario should contain `{expected}`"
+        );
+    }
+
+    for expected in [
+        "cron: \"0 2 * * *\"",
+        "AU_KPIS_STAGING_BASE_URL",
+        "grafana/setup-k6-action",
+        "apps/bench/sustained.js",
+        "apps/bench/burst.js",
+        "K6_OUT",
+        "influxdb=",
+        "perf:regression",
+        "actions/github-script",
+        "k6 load comparison",
+    ] {
+        assert!(
+            nightly.contains(expected),
+            "nightly k6 workflow should contain `{expected}`"
+        );
+    }
+
+    assert!(
+        root.join("infra/observability/grafana/dashboards/k6-load.json")
+            .is_file(),
+        "Grafana should provision a sustained/burst k6 load dashboard"
+    );
+    assert!(
+        bench_docs.contains("sustained.js")
+            && bench_docs.contains("burst.js")
+            && bench_docs.contains("perf:regression"),
+        "benchmark docs should describe sustained, burst, and PR comparison runs"
+    );
+    assert!(
+        observability_docs.contains("k6 sustained and burst")
+            && observability_docs.contains("k6-load.json"),
+        "observability docs should document historical k6 load trending"
+    );
+}
+
+#[test]
 fn issue_39_schemathesis_contract_is_wired() {
     let root = repo_root();
 

--- a/crates/testing/tests/bench_scaffold.rs
+++ b/crates/testing/tests/bench_scaffold.rs
@@ -154,9 +154,9 @@ fn issue_38_k6_smoke_contract_is_wired() {
     );
     assert!(
         pr_workflow.contains(
-            "docker compose -f infra/compose/docker-compose.yml up -d postgres redis minio pdf-extractor influxdb"
+            "docker compose -f infra/compose/docker-compose.yml up -d --wait --wait-timeout 120 postgres redis minio pdf-extractor influxdb"
         ),
-        "PR smoke workflow should start compose dependencies with InfluxDB before migrating"
+        "PR smoke workflow should start and wait for compose dependencies with InfluxDB before migrating"
     );
     assert!(
         pr_workflow
@@ -307,6 +307,11 @@ fn smoke_workflow_migrates_before_starting_api() {
     assert!(
         dependencies < migrations && migrations < seed && seed < api,
         "smoke workflow should start dependencies, migrate, seed, then start the API"
+    );
+    assert!(
+        smoke_workflow
+            .contains("--wait --wait-timeout 120 postgres redis minio pdf-extractor influxdb"),
+        "smoke workflow should wait for dependency health checks before migrating"
     );
     assert!(
         smoke_workflow.contains("SELECT 1"),

--- a/crates/testing/tests/bench_scaffold.rs
+++ b/crates/testing/tests/bench_scaffold.rs
@@ -154,9 +154,14 @@ fn issue_38_k6_smoke_contract_is_wired() {
     );
     assert!(
         pr_workflow.contains(
-            "docker compose -f infra/compose/docker-compose.yml up -d --build api influxdb"
+            "docker compose -f infra/compose/docker-compose.yml up -d postgres redis minio pdf-extractor influxdb"
         ),
-        "PR smoke workflow should run against the docker-compose API stack with InfluxDB"
+        "PR smoke workflow should start compose dependencies with InfluxDB before migrating"
+    );
+    assert!(
+        pr_workflow
+            .contains("docker compose -f infra/compose/docker-compose.yml up -d --build api"),
+        "PR smoke workflow should start the docker-compose API stack after seeding"
     );
     assert!(
         pr_workflow.contains("< apps/web/e2e/fixtures/explorer.sql"),
@@ -273,6 +278,35 @@ fn issue_49_k6_nightly_load_contract_is_wired() {
         observability_docs.contains("k6 sustained and burst")
             && observability_docs.contains("k6-load.json"),
         "observability docs should document historical k6 load trending"
+    );
+}
+
+#[test]
+fn smoke_workflow_migrates_before_starting_api() {
+    let root = repo_root();
+    let pr_workflow =
+        fs::read_to_string(root.join(".github/workflows/pr.yml")).expect("read pr workflow");
+    let smoke_job = pr_workflow
+        .find("  smoke:")
+        .expect("PR workflow should define a smoke job");
+    let smoke_workflow = &pr_workflow[smoke_job..];
+
+    let dependencies = smoke_workflow
+        .find("Start compose smoke dependencies")
+        .expect("smoke workflow should start dependencies before migrations");
+    let migrations = smoke_workflow
+        .find("Apply migrations")
+        .expect("smoke workflow should apply migrations");
+    let seed = smoke_workflow
+        .find("Seed smoke fixture data")
+        .expect("smoke workflow should seed fixture data");
+    let api = smoke_workflow
+        .find("Start local smoke API")
+        .expect("smoke workflow should start the API after seeding");
+
+    assert!(
+        dependencies < migrations && migrations < seed && seed < api,
+        "smoke workflow should start dependencies, migrate, seed, then start the API"
     );
 }
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -41,6 +41,21 @@ local compose InfluxDB database at `http://127.0.0.1:8086/k6`. Set
 `AU_KPIS_SMOKE_API_KEY` as a repository secret when staging should run the smoke
 scenario with an API-key tier instead of anonymous quotas.
 
+## Nightly k6 load tests
+
+`.github/workflows/k6-nightly.yml` runs at `0 2 * * *` against staging. It
+executes `apps/bench/sustained.js` and `apps/bench/burst.js`, requires
+`AU_KPIS_STAGING_BASE_URL`, and writes k6 samples through `K6_OUT` to the shared
+InfluxDB datasource configured by `K6_INFLUXDB_ADDR`. The sustained scenario
+uses 100 virtual users for 10 minutes. The burst scenario ramps to 2000 virtual
+users, holds, and ramps down while enforcing the 429 and 5xx budgets from the
+benchmarking spec.
+
+The workflow uploads `k6-load-summary` artifacts for historical comparison.
+Adding the `perf:regression` label to a PR runs the same staging load suite,
+downloads the latest successful scheduled summary when available, and posts a
+`k6 load comparison` PR comment through `actions/github-script`.
+
 ## Contract fuzzing
 
 The pull request `Contract (schemathesis)` job starts the docker-compose API

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -22,6 +22,8 @@ InfluxDB database on `:8086`.
 - The ingestion worker exposes `/metrics`; Prometheus scrapes it directly.
 - Promtail tails Compose container logs and pushes JSON log lines to Loki.
 - The k6 smoke scenario writes request duration and failure-rate samples to InfluxDB.
+- The nightly k6 sustained and burst scenarios write staging load-test samples and
+  custom rate-limit/server-error ratios to the same InfluxDB database.
 - Grafana provisions Prometheus, Loki, Tempo, and k6 InfluxDB datasources plus the
   required dashboards.
 
@@ -33,6 +35,7 @@ InfluxDB database on `:8086`.
 - Queue depth, worker saturation, and DB state: `infra/observability/grafana/dashboards/queue-db.json`
 - SLO burn rates and active page alerts: `infra/observability/grafana/dashboards/slo-burn-rates.json`
 - k6 smoke p95, failure rate, and endpoint request rate: `infra/observability/grafana/dashboards/k6-smoke.json`
+- k6 sustained and burst p95/p99, failure, rate-limit, and 5xx trends: `infra/observability/grafana/dashboards/k6-load.json`
 
 ## Alert Routing
 

--- a/infra/observability/grafana/dashboards/k6-load.json
+++ b/infra/observability/grafana/dashboards/k6-load.json
@@ -1,0 +1,215 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "au-kpis-k6-influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 1,
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "alias": "sustained p95",
+          "query": "SELECT percentile(\"value\", 95) FROM \"http_req_duration\" WHERE (\"scenario\" = 'sustained') AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "sustained p99",
+          "query": "SELECT percentile(\"value\", 99) FROM \"http_req_duration\" WHERE (\"scenario\" = 'sustained') AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Sustained Request Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "au-kpis-k6-influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "alias": "sustained failed requests",
+          "query": "SELECT mean(\"value\") FROM \"http_req_failed\" WHERE (\"scenario\" = 'sustained') AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Sustained Failure Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "au-kpis-k6-influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "decimals": 3,
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "alias": "429 ratio",
+          "query": "SELECT mean(\"value\") FROM \"rate_limit_ratio\" WHERE (\"scenario\" = 'burst') AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        },
+        {
+          "alias": "5xx ratio",
+          "query": "SELECT mean(\"value\") FROM \"server_error_ratio\" WHERE (\"scenario\" = 'burst') AND $timeFilter GROUP BY time($__interval) fill(null)",
+          "rawQuery": true,
+          "refId": "B",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Burst Rate-Limit And Server-Error Ratios",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "influxdb",
+        "uid": "au-kpis-k6-influxdb"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "alias": "$tag_endpoint",
+          "query": "SELECT non_negative_derivative(sum(\"value\"), 1s) FROM \"http_reqs\" WHERE (\"scenario\" =~ /sustained|burst/) AND $timeFilter GROUP BY time($__interval), \"endpoint\" fill(null)",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series"
+        }
+      ],
+      "title": "Load Requests By Endpoint",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5m",
+  "schemaVersion": 39,
+  "style": "light",
+  "tags": ["k6", "load", "staging"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "k6 Load",
+  "uid": "au-kpis-k6-load",
+  "version": 1,
+  "weekStart": ""
+}

--- a/tools/ci/k6_pr_comment.py
+++ b/tools/ci/k6_pr_comment.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Build a PR comment comparing k6 load summaries against the last nightly run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+SCENARIOS: dict[str, list[tuple[str, str, str]]] = {
+    "sustained": [
+        ("HTTP p95", "http_req_duration", "p(95)"),
+        ("HTTP p99", "http_req_duration", "p(99)"),
+        ("Failure rate", "http_req_failed", "rate"),
+    ],
+    "burst": [
+        ("Rate-limit ratio", "rate_limit_ratio", "rate"),
+        ("Server-error ratio", "server_error_ratio", "rate"),
+        ("Rate-limit seen", "rate_limit_seen", "rate"),
+    ],
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--current", type=Path, required=True)
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--pr", default="")
+    args = parser.parse_args()
+
+    lines = [
+        "<!-- k6 load comparison -->",
+        "## k6 load comparison",
+        "",
+        "Triggered by the `perf:regression` PR label or manual dispatch.",
+    ]
+    if args.pr:
+        lines.append(f"PR: #{args.pr}")
+    lines.extend(
+        [
+            "",
+            "| Scenario | Metric | Current | Nightly baseline | Delta |",
+            "|---|---:|---:|---:|---:|",
+        ]
+    )
+
+    for scenario, metrics in SCENARIOS.items():
+        current = read_summary(args.current, scenario)
+        baseline = read_summary(args.baseline, scenario)
+        for label, metric, value_name in metrics:
+            current_value = metric_value(current, metric, value_name)
+            baseline_value = metric_value(baseline, metric, value_name)
+            lines.append(
+                "| {scenario} | {label} | {current} | {baseline} | {delta} |".format(
+                    scenario=scenario,
+                    label=label,
+                    current=format_value(current_value, value_name),
+                    baseline=format_value(baseline_value, value_name),
+                    delta=format_delta(current_value, baseline_value),
+                )
+            )
+
+    lines.extend(
+        [
+            "",
+            "Threshold failures keep this workflow red; the table shows the current run next to the latest successful scheduled baseline when that artifact is available.",
+        ]
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def read_summary(directory: Path, scenario: str) -> dict[str, Any] | None:
+    if not directory.exists():
+        return None
+    for path in [directory / f"{scenario}-summary.json", *directory.rglob(f"{scenario}-summary.json")]:
+        if path.is_file():
+            with path.open(encoding="utf-8") as handle:
+                return json.load(handle)
+    return None
+
+
+def metric_value(summary: dict[str, Any] | None, metric: str, value_name: str) -> float | None:
+    if summary is None:
+        return None
+    values = summary.get("metrics", {}).get(metric, {}).get("values", {})
+    value = values.get(value_name)
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def format_value(value: float | None, value_name: str) -> str:
+    if value is None:
+        return "n/a"
+    if value_name == "rate":
+        return f"{value * 100:.3f}%"
+    return f"{value:.1f} ms"
+
+
+def format_delta(current: float | None, baseline: float | None) -> str:
+    if current is None or baseline in (None, 0):
+        return "n/a"
+    return f"{((current - baseline) / baseline) * 100:+.2f}%"
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #49

## Pass requirements

- [x] `apps/bench/sustained.js` deployed (100 VUs x 10 min)
- [x] `apps/bench/burst.js` deployed (ramp to 2000 VUs)
- [x] Scheduled nightly in staging
- [x] InfluxDB/Grafana historical trending live
- [x] PR-comment comparison bot active on regressions

## CI unblock note

After the PR was marked ready, Schemathesis found a `/v1/search` NUL-byte input that reached Postgres and returned 500. The same guard was already proven green on #15, but #15 is externally blocked by repository settings, so this branch carries the minimal 400-response fix to keep contract fuzzing stable.

## Test plan

- `RUSTC_WRAPPER= cargo test -p au-kpis-testing --test bench_scaffold issue_49_k6_nightly_load_contract_is_wired --locked`
- `RUSTC_WRAPPER= cargo test -p au-kpis-testing --test bench_scaffold smoke_workflow_migrates_before_starting_api --locked` (red before the smoke readiness fix, green after)
- `RUSTC_WRAPPER= cargo test -p au-kpis-testing --test bench_scaffold --locked` (red before compose health wait, green after)
- `RUSTC_WRAPPER= cargo test -p au-kpis-domain slug_id_rejects_nul_bytes --locked` (red before the NUL identifier guard, green after)
- `RUSTC_WRAPPER= cargo test -p au-kpis-api-http --test routes search_route_rejects_nul_query_before_db_access --locked`
- `RUSTC_WRAPPER= cargo test -p au-kpis-api-http --test routes dataflows_route_rejects_invalid_source_before_db_access --locked`
- `RUSTC_WRAPPER= cargo test -p au-kpis-domain --locked`
- `RUSTC_WRAPPER= cargo test -p au-kpis-api-http --test routes --locked`
- `docker run --rm -v "$PWD":/repo -w /repo grafana/k6:0.54.0 inspect apps/bench/sustained.js`
- `docker run --rm -v "$PWD":/repo -w /repo grafana/k6:0.54.0 inspect apps/bench/burst.js`
- `docker run --rm -v "$PWD":/repo -w /repo rhysd/actionlint:latest -color=false .github/workflows/pr.yml .github/workflows/k6-nightly.yml`
- `python3 tools/ci/k6_pr_comment.py --current target/k6 --baseline target/k6/baseline --output target/k6/comment.md --pr 49`
- `python3 -m py_compile tools/ci/k6_pr_comment.py`
- Local compose smoke reproduction with ordered dependencies, migrations, seed, API start, Influx readiness, and `apps/bench/smoke.js`
- `cargo fmt --all --check`
- `pnpm run lint`
- `pnpm turbo run typecheck test --cache-dir=.turbo`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTC_WRAPPER= cargo clippy -p au-kpis-testing --test bench_scaffold --locked -- -D warnings`
- `RUSTC_WRAPPER= cargo nextest run --workspace --profile ci -j 1 --retries 0 --locked`
- `RUSTC_WRAPPER= cargo check --workspace --locked`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks protect --staged`
- `git diff --check`

## Spec impact

No Spec changes required. This implements `Spec.md § Benchmarking` and the scheduled flow entry for nightly k6 load tests.