### PR TITLE
feat(treasury): add PDF budget adapter (#52)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,23 @@ version = "0.1.0"
 [[package]]
 name = "au-kpis-adapter-treasury"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "au-kpis-adapter",
+ "au-kpis-domain",
+ "au-kpis-error",
+ "au-kpis-pdf-client",
+ "au-kpis-storage",
+ "bytes",
+ "chrono",
+ "futures",
+ "insta",
+ "object_store",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "au-kpis-api"
@@ -605,6 +622,7 @@ dependencies = [
  "au-kpis-adapter-abs",
  "au-kpis-adapter-apra",
  "au-kpis-adapter-rba",
+ "au-kpis-adapter-treasury",
  "au-kpis-config",
  "au-kpis-db",
  "au-kpis-domain",

--- a/crates/adapters/treasury/Cargo.toml
+++ b/crates/adapters/treasury/Cargo.toml
@@ -8,3 +8,22 @@ repository.workspace = true
 description = "Treasury adapter (PDF via sidecar)."
 
 [dependencies]
+async-trait = "0.1"
+au-kpis-adapter = { workspace = true }
+au-kpis-domain = { workspace = true }
+au-kpis-error = { workspace = true }
+au-kpis-pdf-client = { workspace = true }
+au-kpis-storage = { workspace = true }
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+futures = "0.3"
+tokio = { version = "1", features = ["rt", "sync"] }
+tracing = "0.1"
+
+[dev-dependencies]
+async-trait = "0.1"
+bytes = "1"
+insta = { version = "1", features = ["json"] }
+object_store = "0.11"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }

--- a/crates/adapters/treasury/src/lib.rs
+++ b/crates/adapters/treasury/src/lib.rs
@@ -1,1 +1,1467 @@
-//! Treasury adapter (PDF via sidecar).
+//! Treasury Budget Paper PDF adapter.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::{collections::BTreeMap, io, time::Duration};
+
+use async_trait::async_trait;
+use au_kpis_adapter::{
+    AdapterError, AdapterManifest, ArtifactRef, DiscoveredJob, DiscoveryCtx, FetchCtx,
+    ObservationStream, ParseCtx, RateLimit, SourceAdapter, UpstreamRevision,
+    capture_response_headers, retry_after_delta,
+};
+use au_kpis_domain::{
+    Artifact, ArtifactId, CodeId, Dataflow, DataflowId, DimensionId, Frequency, License, MeasureId,
+    Observation, ObservationStatus, SeriesDescriptor, SeriesKey, SourceId, TimePrecision,
+};
+use au_kpis_error::{Classify, CoreError, ErrorClass};
+use au_kpis_pdf_client::{
+    BackendInfo, ExtractRequest, ExtractionBackendKind, ExtractionResponse, ExtractionStrategy,
+    PdfClient, PdfClientError, TableCandidate,
+};
+use au_kpis_storage::{BlobStore, StorageKey};
+use chrono::{DateTime, NaiveDate, TimeZone, Utc};
+use futures::{StreamExt, stream};
+
+const DEFAULT_BUDGET_URL: &str = "https://budget.gov.au/content/bp4/index.htm";
+const DEFAULT_PDF_BASE_URL: &str = "http://127.0.0.1:8010";
+const USER_AGENT: &str = concat!("au-kpis-adapter-treasury/", env!("CARGO_PKG_VERSION"));
+const DATAFLOW_ID: &str = "treasury.budget_papers";
+const ATTRIBUTION: &str = "Source: Australian Government, The Treasury";
+const LICENSE_NAME: &str = "CC-BY-4.0";
+const LICENSE_URL: &str = "https://creativecommons.org/licenses/by/4.0/";
+const SOURCE_NAME: &str = "Australian Government, The Treasury";
+const PAPER: &str = "Budget Paper No. 4";
+const PAPER_SLUG: &str = "bp4-agency-resourcing";
+const TARGET_TITLE: &str = "Agency resourcing table";
+const TARGET_FILENAME: &str = "bp4_05_agency_resourcing_tables.pdf";
+
+/// Treasury Budget Paper adapter that parses PDF tables via the sidecar.
+#[derive(Debug, Clone)]
+pub struct TreasuryAdapter {
+    manifest: AdapterManifest,
+    budget_url: String,
+    pdf_client: PdfClient,
+}
+
+impl Default for TreasuryAdapter {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
+impl TreasuryAdapter {
+    /// Start building a Treasury adapter.
+    #[must_use]
+    pub fn builder() -> TreasuryAdapterBuilder {
+        TreasuryAdapterBuilder::default()
+    }
+
+    /// Parse the Treasury Budget Paper 4 page into target PDF publications.
+    pub fn parse_budget_publications_page(
+        body: &str,
+    ) -> Result<Vec<TreasuryBudgetPublication>, AdapterError> {
+        parse_budget_publications_page_with_base(body, DEFAULT_BUDGET_URL)
+    }
+
+    /// Convert discovered publications into jobs for the supplied timestamp.
+    #[must_use]
+    pub fn current_jobs_with_started_at(
+        current: &[TreasuryBudgetPublication],
+        started_at: DateTime<Utc>,
+    ) -> Vec<DiscoveredJob> {
+        Self::discoverable_jobs_with_started_at(current, &BTreeMap::new(), started_at, None)
+    }
+
+    /// Diff current Treasury links against stored upstream revisions.
+    #[must_use]
+    pub fn discoverable_jobs_with_started_at(
+        current: &[TreasuryBudgetPublication],
+        known_revisions: &BTreeMap<String, UpstreamRevision>,
+        started_at: DateTime<Utc>,
+        trace_parent: Option<&str>,
+    ) -> Vec<DiscoveredJob> {
+        discoverable_jobs_with_budget_url(
+            current,
+            known_revisions,
+            started_at,
+            trace_parent,
+            DEFAULT_BUDGET_URL,
+        )
+    }
+
+    /// Static metadata for the Treasury budget papers dataflow.
+    #[must_use]
+    pub fn dataflow_metadata(&self) -> Vec<Dataflow> {
+        vec![Dataflow {
+            id: dataflow_id(),
+            source_id: source_id(),
+            name: "Treasury budget papers".into(),
+            description: Some(
+                "Annual Australian Government Budget Paper No. 4 agency resourcing tables parsed from PDFs."
+                    .into(),
+            ),
+            dimensions: vec![
+                DimensionId::new("budget_year").expect("static dimension id is valid"),
+                DimensionId::new("paper").expect("static dimension id is valid"),
+                DimensionId::new("table").expect("static dimension id is valid"),
+                DimensionId::new("line_item").expect("static dimension id is valid"),
+            ],
+            measures: vec![MeasureId::new("value").expect("static measure id is valid")],
+            frequency: Frequency::Annual,
+            license: License::CcBy40,
+            attribution: ATTRIBUTION.into(),
+            source_url: DEFAULT_BUDGET_URL.into(),
+        }]
+    }
+
+    fn budget_url(&self) -> &str {
+        &self.budget_url
+    }
+
+    fn validate_fetch_job(&self, job: &DiscoveredJob) -> Result<(), AdapterError> {
+        if job.source_id != self.manifest.source_id {
+            return Err(AdapterError::Validation(format!(
+                "Treasury fetch received job for source `{}`",
+                job.source_id.as_str()
+            )));
+        }
+        if !self
+            .manifest
+            .dataflows
+            .iter()
+            .any(|dataflow_id| dataflow_id == &job.dataflow_id)
+        {
+            return Err(AdapterError::Validation(format!(
+                "Treasury fetch received unsupported dataflow `{}`",
+                job.dataflow_id.as_str()
+            )));
+        }
+        budget_publication_provenance_for_fetch(&job.source_url, &job.metadata).ok_or_else(
+            || {
+                AdapterError::Validation(format!(
+                    "Treasury fetch URL `{}` is not a target budget PDF artifact",
+                    job.source_url
+                ))
+            },
+        )?;
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SourceAdapter for TreasuryAdapter {
+    fn id(&self) -> &'static str {
+        "treasury"
+    }
+
+    fn manifest(&self) -> &AdapterManifest {
+        &self.manifest
+    }
+
+    #[tracing::instrument(skip(self, ctx), fields(source = self.id()))]
+    async fn discover(&self, ctx: &DiscoveryCtx) -> Result<Vec<DiscoveredJob>, AdapterError> {
+        let response = ctx
+            .http
+            .execute(
+                ctx.http
+                    .raw()
+                    .get(self.budget_url())
+                    .header("user-agent", USER_AGENT)
+                    .header("accept", "text/html,application/xhtml+xml"),
+            )
+            .await?
+            .error_for_status()?;
+        let body = response.text().await?;
+        let publications = parse_budget_publications_page_with_base(&body, self.budget_url())?;
+        Ok(discoverable_jobs_with_budget_url(
+            &publications,
+            ctx.known_revisions(),
+            ctx.started_at,
+            ctx.trace_parent(),
+            self.budget_url(),
+        ))
+    }
+
+    #[tracing::instrument(skip(self, ctx), fields(source = self.id(), job_id = %job.id))]
+    async fn fetch(&self, job: DiscoveredJob, ctx: &FetchCtx) -> Result<ArtifactRef, AdapterError> {
+        self.validate_fetch_job(&job)?;
+        let response = ctx
+            .http
+            .execute(
+                ctx.http
+                    .raw_artifact()
+                    .get(&job.source_url)
+                    .header("user-agent", USER_AGENT)
+                    .header("accept", "application/pdf"),
+            )
+            .await?;
+        let response_headers = capture_response_headers(response.headers());
+        let status = response.status();
+        if !status.is_success() {
+            return Err(AdapterError::UpstreamStatus {
+                status,
+                retry_after: retry_after_delta(&response_headers),
+                response_headers,
+            });
+        }
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .map_or_else(|| "application/pdf".to_string(), str::to_string);
+
+        let staged = ctx
+            .blob_store
+            .stage_artifact_stream(response.bytes_stream().boxed())
+            .await?;
+        let id = staged.id();
+        let storage_key = StorageKey::canonical_for(&id).to_string();
+        let artifact = Artifact {
+            id,
+            source_id: job.source_id,
+            source_url: job.source_url,
+            content_type,
+            response_headers,
+            storage_key,
+            size_bytes: staged.size_bytes(),
+            fetched_at: Utc::now(),
+        };
+        ctx.blob_store.commit_staged_artifact(&staged).await?;
+        ctx.persist_artifact(artifact).await
+    }
+
+    fn parse<'a>(&'a self, artifact: ArtifactRef, ctx: &'a ParseCtx) -> ObservationStream<'a> {
+        parse_artifact_stream(self.pdf_client.clone(), artifact, ctx)
+    }
+}
+
+fn parse_artifact_stream(
+    pdf_client: PdfClient,
+    artifact: ArtifactRef,
+    ctx: &ParseCtx,
+) -> ObservationStream<'_> {
+    let provenance = match validate_parse_artifact(&artifact, ctx) {
+        Ok(provenance) => provenance,
+        Err(err) => return Box::pin(stream::once(async move { Err(err) })),
+    };
+
+    let blob_store = ctx.blob_store.clone();
+    let started_at = ctx.started_at;
+    let cancellation = ctx.cancellation().clone();
+    let (row_tx, row_rx) = tokio::sync::mpsc::channel(1024);
+
+    tokio::spawn(async move {
+        let key = StorageKey::from_persisted(artifact.storage_key.clone());
+        let identity = tokio::select! {
+            () = cancellation.cancelled() => Err(cancelled_parse_error()),
+            result = verify_parse_artifact_identity(&blob_store, &key, &artifact) => result,
+        };
+        if let Err(err) = identity {
+            let _ = row_tx.send(Err(err)).await;
+            return;
+        }
+
+        let result =
+            parse_pdf_artifact(pdf_client, artifact, provenance, started_at, row_tx.clone()).await;
+        if let Err(err) = result {
+            let _ = row_tx.send(Err(err)).await;
+        }
+    });
+
+    Box::pin(stream::unfold(row_rx, |mut row_rx| async {
+        row_rx.recv().await.map(|item| (item, row_rx))
+    }))
+}
+
+async fn parse_pdf_artifact(
+    pdf_client: PdfClient,
+    artifact: ArtifactRef,
+    provenance: TreasuryBudgetProvenance,
+    ingested_at: DateTime<Utc>,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+) -> Result<(), AdapterError> {
+    let mut request = ExtractRequest::new(artifact.storage_key.clone(), "treasury")
+        .strategy(ExtractionStrategy::Deterministic);
+    if let Some(artifact_date) = &provenance.artifact_date {
+        request = request.artifact_date(artifact_date.clone());
+    }
+    let response = pdf_client
+        .extract(request)
+        .await
+        .map_err(pdf_client_error)?;
+    if response.artifact_key != artifact.storage_key {
+        return Err(AdapterError::Validation(format!(
+            "Treasury sidecar returned artifact key `{}` for requested artifact `{}`",
+            response.artifact_key, artifact.storage_key
+        )));
+    }
+    if response.backend.kind != ExtractionBackendKind::Deterministic {
+        return Err(AdapterError::FormatDrift(format!(
+            "Treasury sidecar used unsupported backend `{}`",
+            response.backend.name
+        )));
+    }
+
+    let rows = parse_table_candidates(response, &artifact, &provenance, ingested_at)?;
+    for row in rows {
+        if tx.send(Ok(row)).await.is_err() {
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+fn parse_table_candidates(
+    response: ExtractionResponse,
+    artifact: &ArtifactRef,
+    provenance: &TreasuryBudgetProvenance,
+    ingested_at: DateTime<Utc>,
+) -> Result<Vec<(SeriesDescriptor, Observation)>, AdapterError> {
+    let backend = response.backend;
+    let mut parsed = Vec::new();
+    for (index, table) in response.tables.iter().enumerate() {
+        if let Some(rows) =
+            parse_budget_table(table, index, &backend, artifact, provenance, ingested_at)?
+        {
+            parsed.extend(rows);
+        }
+    }
+
+    if parsed.is_empty() {
+        return Err(AdapterError::FormatDrift(
+            "Treasury PDF sidecar returned no recognised budget tables".into(),
+        ));
+    }
+    Ok(parsed)
+}
+
+fn parse_budget_table(
+    table: &TableCandidate,
+    table_index: usize,
+    backend: &BackendInfo,
+    artifact: &ArtifactRef,
+    provenance: &TreasuryBudgetProvenance,
+    ingested_at: DateTime<Utc>,
+) -> Result<Option<Vec<(SeriesDescriptor, Observation)>>, AdapterError> {
+    let rows = table
+        .cells
+        .iter()
+        .map(|row| row.iter().map(|cell| clean_cell(cell)).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    let Some(periods) = find_budget_period_columns(&rows)? else {
+        return Ok(None);
+    };
+    let unit = unit_from_rows(&rows);
+    let table_title = table_title_for_candidate(&rows, periods.row_index, table.page, table_index);
+    let schema_hash = schema_hash_for_candidate(table, &rows);
+    let first_period_col = periods
+        .columns
+        .first()
+        .map(|period| period.column)
+        .expect("period finder returns at least one column");
+    let mut parsed = Vec::new();
+
+    for row in rows.iter().skip(periods.row_index + 1) {
+        let Some(line_item) = label_before(row, first_period_col) else {
+            continue;
+        };
+        let mut row_values = Vec::new();
+        let mut numeric_values = 0_usize;
+        let mut invalid_value = None;
+        for period in &periods.columns {
+            let cell = row.get(period.column).map_or("", String::as_str);
+            match parse_value(cell) {
+                Ok((value, status)) => {
+                    if value.is_some() {
+                        numeric_values += 1;
+                    }
+                    let status = if matches!(status, ObservationStatus::Normal) {
+                        period.status
+                    } else {
+                        status
+                    };
+                    row_values.push((period, value, status));
+                }
+                Err(err) => invalid_value = Some(err),
+            }
+        }
+        if numeric_values == 0 {
+            continue;
+        }
+        if let Some(err) = invalid_value {
+            return Err(err);
+        }
+        for (period, value, status) in row_values {
+            parsed.push(build_row(BuildRow {
+                provenance,
+                table_title: &table_title,
+                table_page: table.page,
+                line_item: &line_item,
+                period_label: &period.label,
+                unit: &unit,
+                time: period.time,
+                precision: TimePrecision::Year,
+                value,
+                status,
+                schema_hash: &schema_hash,
+                backend,
+                artifact,
+                ingested_at,
+            })?);
+        }
+    }
+
+    if parsed.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(parsed))
+    }
+}
+
+struct BuildRow<'a> {
+    provenance: &'a TreasuryBudgetProvenance,
+    table_title: &'a str,
+    table_page: u32,
+    line_item: &'a str,
+    period_label: &'a str,
+    unit: &'a str,
+    time: DateTime<Utc>,
+    precision: TimePrecision,
+    value: Option<f64>,
+    status: ObservationStatus,
+    schema_hash: &'a str,
+    backend: &'a BackendInfo,
+    artifact: &'a ArtifactRef,
+    ingested_at: DateTime<Utc>,
+}
+
+fn build_row(input: BuildRow<'_>) -> Result<(SeriesDescriptor, Observation), AdapterError> {
+    let dataflow_id = dataflow_id();
+    let dimensions = BTreeMap::from([
+        (
+            DimensionId::new("budget_year").expect("static dimension id is valid"),
+            treasury_code_id("budget_year", &input.provenance.budget_year)?,
+        ),
+        (
+            DimensionId::new("paper").expect("static dimension id is valid"),
+            treasury_code_id("paper", &input.provenance.paper_slug)?,
+        ),
+        (
+            DimensionId::new("table").expect("static dimension id is valid"),
+            treasury_code_id("table", &slugify_code(input.table_title))?,
+        ),
+        (
+            DimensionId::new("line_item").expect("static dimension id is valid"),
+            treasury_code_id("line_item", &slugify_code(input.line_item))?,
+        ),
+    ]);
+    let series_key = SeriesKey::derive(
+        &dataflow_id,
+        dimensions
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    );
+    let descriptor = SeriesDescriptor {
+        series_key,
+        dataflow_id,
+        measure_id: MeasureId::new("value").expect("static measure id is valid"),
+        dimensions,
+        unit: input.unit.to_string(),
+    };
+    let mut attributes = BTreeMap::from([
+        ("source".into(), SOURCE_NAME.into()),
+        ("source_url".into(), input.artifact.source_url.clone()),
+        ("license".into(), LICENSE_NAME.into()),
+        ("license_url".into(), LICENSE_URL.into()),
+        ("attribution".into(), ATTRIBUTION.into()),
+        ("budget_year".into(), input.provenance.budget_year.clone()),
+        ("paper".into(), input.provenance.paper.clone()),
+        ("paper_slug".into(), input.provenance.paper_slug.clone()),
+        ("publication_title".into(), input.provenance.title.clone()),
+        ("table_title".into(), input.table_title.to_string()),
+        ("table_page".into(), input.table_page.to_string()),
+        ("schema_hash".into(), input.schema_hash.to_string()),
+        ("treasury_line_item".into(), input.line_item.to_string()),
+        (
+            "treasury_period_label".into(),
+            input.period_label.to_string(),
+        ),
+        ("extraction_backend".into(), input.backend.name.clone()),
+        (
+            "extraction_backend_version".into(),
+            input.backend.version.clone(),
+        ),
+    ]);
+    if let Some(artifact_date) = &input.provenance.artifact_date {
+        attributes.insert("artifact_date".into(), artifact_date.clone());
+    }
+    if let Some(model_sha256) = &input.backend.model_sha256 {
+        attributes.insert("extraction_model_sha256".into(), model_sha256.clone());
+    }
+    let observation = Observation {
+        series_key,
+        time: input.time,
+        time_precision: input.precision,
+        value: input.value,
+        status: input.status,
+        revision_no: 0,
+        attributes,
+        ingested_at: input.ingested_at,
+        source_artifact_id: input.artifact.id,
+    };
+    Ok((descriptor, observation))
+}
+
+fn validate_parse_artifact(
+    artifact: &ArtifactRef,
+    ctx: &ParseCtx,
+) -> Result<TreasuryBudgetProvenance, AdapterError> {
+    if artifact.source_id.as_str() != "treasury" {
+        return Err(AdapterError::Validation(format!(
+            "Treasury parse received artifact for source `{}`",
+            artifact.source_id.as_str()
+        )));
+    }
+    if let Some(expected) = ctx.expected_dataflow_id() {
+        let actual = dataflow_id();
+        if expected != &actual {
+            return Err(AdapterError::Validation(format!(
+                "Treasury parse expected dataflow `{}` but adapter emits `{}`",
+                expected.as_str(),
+                actual.as_str()
+            )));
+        }
+    }
+    budget_publication_provenance_for_parse(&artifact.source_url, ctx.metadata()).ok_or_else(|| {
+        AdapterError::Validation(format!(
+            "Treasury parse artifact `{}` is missing budget-paper provenance",
+            artifact.source_url
+        ))
+    })
+}
+
+async fn verify_parse_artifact_identity(
+    blob_store: &BlobStore,
+    key: &StorageKey,
+    artifact: &ArtifactRef,
+) -> Result<(), AdapterError> {
+    let canonical_key = StorageKey::canonical_for(&artifact.id).to_string();
+    if artifact.storage_key == canonical_key {
+        return Ok(());
+    }
+
+    if artifact.storage_key.starts_with("artifacts/") {
+        return Err(AdapterError::Validation(format!(
+            "Treasury parse artifact storage key `{}` does not match artifact id `{}`",
+            artifact.storage_key, artifact.id
+        )));
+    }
+
+    if blob_store.matches_artifact_id(key, artifact.id).await? {
+        Ok(())
+    } else {
+        Err(AdapterError::Validation(format!(
+            "Treasury parse artifact storage key `{}` does not match artifact id `{}`",
+            artifact.storage_key, artifact.id
+        )))
+    }
+}
+
+fn parse_budget_publications_page_with_base(
+    body: &str,
+    base_url: &str,
+) -> Result<Vec<TreasuryBudgetPublication>, AdapterError> {
+    let page_budget_year = find_fiscal_year(&clean_html_text(body).unwrap_or_default());
+    let mut publications = Vec::new();
+    let mut rest = body;
+    while let Some(anchor_start) = rest.find("<a") {
+        rest = &rest[anchor_start..];
+        let Some(open_end) = rest.find('>') else {
+            break;
+        };
+        let attrs = &rest[..open_end + 1];
+        let Some(close_start) = rest[open_end + 1..].find("</a>") else {
+            break;
+        };
+        let text = &rest[open_end + 1..open_end + 1 + close_start];
+        rest = &rest[open_end + 1 + close_start + "</a>".len()..];
+        let Some(href) = attr_value(attrs, "href") else {
+            continue;
+        };
+        let source_url = resolve_url(base_url, &href)?;
+        let metadata = BTreeMap::from([
+            (
+                "budget_year".to_string(),
+                page_budget_year.clone().unwrap_or_default(),
+            ),
+            (
+                "artifact_date".to_string(),
+                attr_value(attrs, "data-updated").unwrap_or_default(),
+            ),
+        ]);
+        let Some(provenance) = budget_publication_provenance_for_fetch(&source_url, &metadata)
+        else {
+            continue;
+        };
+        let anchor_text = clean_html_text(text);
+        let title = anchor_text
+            .filter(|value| !looks_like_download_label(value))
+            .unwrap_or_else(|| provenance.title.clone());
+        publications.push(TreasuryBudgetPublication {
+            budget_year: provenance.budget_year,
+            paper: provenance.paper,
+            paper_slug: provenance.paper_slug,
+            title,
+            source_url,
+            last_updated: attr_value(attrs, "data-updated")
+                .or_else(|| attr_value(attrs, "datetime")),
+        });
+    }
+    publications.sort_by(|left, right| {
+        left.budget_year
+            .cmp(&right.budget_year)
+            .then(left.paper_slug.cmp(&right.paper_slug))
+            .then(left.source_url.cmp(&right.source_url))
+    });
+    publications.dedup_by(|left, right| left.source_url == right.source_url);
+    Ok(publications)
+}
+
+fn attr_value(attrs: &str, name: &str) -> Option<String> {
+    let bytes = attrs.as_bytes();
+    for (name_start, _) in attrs.match_indices(name) {
+        if name_start > 0 && is_attr_name_char(bytes[name_start - 1]) {
+            continue;
+        }
+        let mut cursor = name_start + name.len();
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        if bytes.get(cursor) != Some(&b'=') {
+            continue;
+        }
+        cursor += 1;
+        while bytes.get(cursor).is_some_and(u8::is_ascii_whitespace) {
+            cursor += 1;
+        }
+        let quote = attrs[cursor..].chars().next()?;
+        if quote != '"' && quote != '\'' {
+            return None;
+        }
+        let value_start = cursor + quote.len_utf8();
+        let value_end = attrs[value_start..].find(quote)? + value_start;
+        return Some(attrs[value_start..value_end].to_string());
+    }
+    None
+}
+
+fn is_attr_name_char(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b':')
+}
+
+fn clean_html_text(text: &str) -> Option<String> {
+    let mut out = String::with_capacity(text.len());
+    let mut in_tag = false;
+    for ch in text.chars() {
+        match ch {
+            '<' => in_tag = true,
+            '>' => in_tag = false,
+            _ if !in_tag => out.push(ch),
+            _ => {}
+        }
+    }
+    let cleaned = decode_url_component(&out)
+        .replace("&amp;", "&")
+        .replace("&nbsp;", " ")
+        .replace("&ndash;", "-")
+        .replace("&#8211;", "-")
+        .replace('\u{a0}', " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    (!cleaned.is_empty()).then_some(cleaned)
+}
+
+fn resolve_url(base_url: &str, href: &str) -> Result<String, AdapterError> {
+    if href.starts_with("https://") || href.starts_with("http://") {
+        return Ok(href.to_string());
+    }
+    if href.starts_with('/') {
+        let scheme_end = base_url.find("://").ok_or_else(|| {
+            AdapterError::Validation(format!("Treasury budget URL `{base_url}` is not absolute"))
+        })?;
+        let path_start = base_url[scheme_end + 3..]
+            .find('/')
+            .map_or(base_url.len(), |index| scheme_end + 3 + index);
+        return Ok(format!("{}{}", &base_url[..path_start], href));
+    }
+    let Some((prefix, _)) = base_url.rsplit_once('/') else {
+        return Err(AdapterError::Validation(format!(
+            "Treasury budget URL `{base_url}` has no path separator"
+        )));
+    };
+    Ok(format!("{prefix}/{href}"))
+}
+
+#[derive(Debug, Clone)]
+struct TreasuryBudgetProvenance {
+    budget_year: String,
+    paper: String,
+    paper_slug: String,
+    title: String,
+    artifact_date: Option<String>,
+}
+
+fn budget_publication_provenance_for_fetch(
+    source_url: &str,
+    metadata: &BTreeMap<String, String>,
+) -> Option<TreasuryBudgetProvenance> {
+    budget_publication_provenance(source_url, metadata, false)
+}
+
+fn budget_publication_provenance_for_parse(
+    source_url: &str,
+    metadata: &BTreeMap<String, String>,
+) -> Option<TreasuryBudgetProvenance> {
+    budget_publication_provenance(source_url, metadata, true)
+}
+
+fn budget_publication_provenance(
+    source_url: &str,
+    metadata: &BTreeMap<String, String>,
+    require_treasury_host: bool,
+) -> Option<TreasuryBudgetProvenance> {
+    let (_, after_scheme) = source_url.split_once("://")?;
+    let (host, path_with_suffix) = after_scheme.split_once('/')?;
+    if require_treasury_host
+        && !matches!(
+            host,
+            "budget.gov.au" | "www.budget.gov.au" | "archive.budget.gov.au"
+        )
+    {
+        return None;
+    }
+    let path = path_with_suffix
+        .split('?')
+        .next()
+        .unwrap_or(path_with_suffix)
+        .split('#')
+        .next()
+        .unwrap_or(path_with_suffix);
+    if !path.ends_with(TARGET_FILENAME) {
+        return None;
+    }
+    if !path.contains("bp4/download/") && !path.contains("content/bp4/download/") {
+        return None;
+    }
+    let budget_year = find_fiscal_year(source_url)
+        .or_else(|| {
+            metadata
+                .get("budget_year")
+                .filter(|value| !value.is_empty())
+                .cloned()
+        })
+        .unwrap_or_else(|| "unknown".into());
+    let artifact_date = metadata
+        .get("artifact_date")
+        .filter(|value| !value.is_empty())
+        .cloned();
+    Some(TreasuryBudgetProvenance {
+        budget_year,
+        paper: PAPER.into(),
+        paper_slug: PAPER_SLUG.into(),
+        title: TARGET_TITLE.into(),
+        artifact_date,
+    })
+}
+
+fn discoverable_jobs_with_budget_url(
+    current: &[TreasuryBudgetPublication],
+    known_revisions: &BTreeMap<String, UpstreamRevision>,
+    started_at: DateTime<Utc>,
+    trace_parent: Option<&str>,
+    budget_url: &str,
+) -> Vec<DiscoveredJob> {
+    current
+        .iter()
+        .filter_map(|publication| {
+            let revision = publication.revision(started_at);
+            known_revisions
+                .get(&publication.revision_key())
+                .is_none_or(|known| known != &revision)
+                .then(|| publication.to_discovered_job(started_at, trace_parent, budget_url))
+        })
+        .collect()
+}
+
+fn find_budget_period_columns(rows: &[Vec<String>]) -> Result<Option<BudgetPeriods>, AdapterError> {
+    for (row_index, row) in rows.iter().enumerate() {
+        let columns = row
+            .iter()
+            .enumerate()
+            .filter_map(|(column, cell)| {
+                parse_budget_period(cell)
+                    .transpose()
+                    .map(|result| result.map(|period| (column, period)))
+            })
+            .map(|result| {
+                result.map(|(column, mut period)| {
+                    period.column = column;
+                    period
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        if columns.len() >= 2 {
+            return Ok(Some(BudgetPeriods { row_index, columns }));
+        }
+    }
+    Ok(None)
+}
+
+#[derive(Debug, Clone)]
+struct BudgetPeriods {
+    row_index: usize,
+    columns: Vec<BudgetPeriod>,
+}
+
+#[derive(Debug, Clone)]
+struct BudgetPeriod {
+    column: usize,
+    label: String,
+    time: DateTime<Utc>,
+    status: ObservationStatus,
+}
+
+fn parse_budget_period(value: &str) -> Result<Option<BudgetPeriod>, AdapterError> {
+    let Some(label) = find_fiscal_year(value) else {
+        return Ok(None);
+    };
+    let Some((start_year, _)) = label.split_once('-') else {
+        return Ok(None);
+    };
+    let year = start_year.parse::<i32>().map_err(|_| {
+        AdapterError::FormatDrift(format!("invalid Treasury fiscal period `{value}`"))
+    })?;
+    let date = NaiveDate::from_ymd_opt(year, 7, 1).ok_or_else(|| {
+        AdapterError::FormatDrift(format!("invalid Treasury fiscal period `{value}`"))
+    })?;
+    let normalized = normalize_header(value);
+    let status = if normalized.contains("estimated actual") {
+        ObservationStatus::Estimated
+    } else if normalized.contains("estimate") || normalized.contains("budget") {
+        ObservationStatus::Forecast
+    } else {
+        ObservationStatus::Normal
+    };
+    Ok(Some(BudgetPeriod {
+        column: 0,
+        label,
+        time: utc_midnight(date),
+        status,
+    }))
+}
+
+fn find_fiscal_year(value: &str) -> Option<String> {
+    let bytes = value.as_bytes();
+    for index in 0..bytes.len().saturating_sub(6) {
+        if !(bytes[index].is_ascii_digit()
+            && bytes.get(index + 1).is_some_and(u8::is_ascii_digit)
+            && bytes.get(index + 2).is_some_and(u8::is_ascii_digit)
+            && bytes.get(index + 3).is_some_and(u8::is_ascii_digit))
+        {
+            continue;
+        }
+        let separator = *bytes.get(index + 4)?;
+        if separator != b'-' && separator != b'_' {
+            continue;
+        }
+        if bytes.get(index + 5).is_some_and(u8::is_ascii_digit)
+            && bytes.get(index + 6).is_some_and(u8::is_ascii_digit)
+        {
+            return Some(format!(
+                "{}-{}",
+                &value[index..index + 4],
+                &value[index + 5..index + 7]
+            ));
+        }
+    }
+    None
+}
+
+fn label_before(row: &[String], first_period_col: usize) -> Option<String> {
+    let label = row
+        .iter()
+        .take(first_period_col)
+        .map(|cell| cell.trim())
+        .filter(|cell| !cell.is_empty())
+        .collect::<Vec<_>>()
+        .join(" / ");
+    if label.is_empty() || normalize_header(&label) == "agency" {
+        None
+    } else {
+        Some(label)
+    }
+}
+
+fn table_title_for_candidate(
+    rows: &[Vec<String>],
+    header_index: usize,
+    page: u32,
+    table_index: usize,
+) -> String {
+    rows.iter()
+        .take(header_index)
+        .flat_map(|row| row.iter())
+        .find_map(|cell| {
+            let trimmed = cell.trim();
+            (!trimmed.is_empty()).then_some(trimmed.to_string())
+        })
+        .unwrap_or_else(|| format!("{PAPER} table page {page} #{}", table_index + 1))
+}
+
+fn schema_hash_for_candidate(table: &TableCandidate, rows: &[Vec<String>]) -> String {
+    let mut material = format!("page:{}\nbbox:{:?}\n", table.page, table.bbox);
+    for row in rows
+        .iter()
+        .filter(|row| row.iter().any(|cell| !cell.trim().is_empty()))
+        .take(12)
+    {
+        material.push_str(
+            &row.iter()
+                .map(|cell| cell.trim())
+                .collect::<Vec<_>>()
+                .join("\t"),
+        );
+        material.push('\n');
+    }
+    ArtifactId::of_content(material.as_bytes()).to_hex()
+}
+
+fn unit_from_rows(rows: &[Vec<String>]) -> String {
+    for cell in rows.iter().flat_map(|row| row.iter()) {
+        let lower = cell.to_ascii_lowercase();
+        if lower.contains("$ million") || lower.contains("$m") || lower.contains("($m)") {
+            return "$ million".into();
+        }
+        if lower.contains("per cent") || lower.contains("percent") || lower.contains('%') {
+            return "percent".into();
+        }
+        if lower.contains("number") {
+            return "number".into();
+        }
+    }
+    "unknown".into()
+}
+
+fn parse_value(value: &str) -> Result<(Option<f64>, ObservationStatus), AdapterError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty()
+        || matches!(
+            trimmed.to_ascii_lowercase().as_str(),
+            "-" | "*" | "**" | "na" | "n/a" | "nfp"
+        )
+    {
+        return Ok((None, ObservationStatus::Missing));
+    }
+    let mut normalized = trimmed.replace([',', ' ', '$'], "");
+    let negative = normalized.starts_with('(') && normalized.ends_with(')');
+    if negative {
+        normalized = normalized
+            .trim_start_matches('(')
+            .trim_end_matches(')')
+            .to_string();
+    }
+    normalized
+        .parse::<f64>()
+        .map(|value| {
+            (
+                Some(if negative { -value } else { value }),
+                ObservationStatus::Normal,
+            )
+        })
+        .map_err(|_| AdapterError::FormatDrift(format!("invalid Treasury numeric value `{value}`")))
+}
+
+fn clean_cell(value: &str) -> String {
+    value
+        .replace(['\n', '\u{a0}'], " ")
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn normalize_header(value: &str) -> String {
+    clean_cell(value).trim().to_ascii_lowercase()
+}
+
+fn decode_url_component(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut out = String::with_capacity(value.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        if bytes[index] == b'%' && index + 2 < bytes.len() {
+            let hex = &value[index + 1..index + 3];
+            if let Ok(byte) = u8::from_str_radix(hex, 16) {
+                out.push(byte as char);
+                index += 3;
+                continue;
+            }
+        }
+        out.push(bytes[index] as char);
+        index += 1;
+    }
+    out
+}
+
+fn slugify_code(value: &str) -> String {
+    let mut slug = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                '_'
+            }
+        })
+        .collect::<String>()
+        .split('_')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>()
+        .join("_");
+    if slug.is_empty() {
+        slug = "value".into();
+    }
+    if slug.len() > 128 {
+        slug.truncate(128);
+        slug = slug.trim_end_matches('_').to_string();
+    }
+    slug
+}
+
+fn treasury_code_id(field: &str, value: &str) -> Result<CodeId, AdapterError> {
+    CodeId::new(value.to_string()).map_err(|err| {
+        AdapterError::FormatDrift(format!("invalid Treasury {field} code `{value}`: {err}"))
+    })
+}
+
+fn utc_midnight(date: NaiveDate) -> DateTime<Utc> {
+    Utc.from_utc_datetime(&date.and_hms_opt(0, 0, 0).expect("midnight is valid"))
+}
+
+fn looks_like_download_label(value: &str) -> bool {
+    let normalized = normalize_header(value);
+    normalized.starts_with("pdf ") || normalized == "pdf" || normalized.ends_with(" mb")
+}
+
+fn source_id() -> SourceId {
+    SourceId::new("treasury").expect("static source id is valid")
+}
+
+fn dataflow_id() -> DataflowId {
+    DataflowId::new(DATAFLOW_ID).expect("static dataflow id is valid")
+}
+
+fn pdf_client_error(err: PdfClientError) -> AdapterError {
+    match err.class() {
+        ErrorClass::Validation => AdapterError::Validation(err.to_string()),
+        ErrorClass::Permanent => AdapterError::FormatDrift(err.to_string()),
+        ErrorClass::Transient => {
+            CoreError::Io(io::Error::other(format!("Treasury PDF sidecar: {err}"))).into()
+        }
+    }
+}
+
+fn cancelled_parse_error() -> AdapterError {
+    CoreError::Io(io::Error::new(
+        io::ErrorKind::Interrupted,
+        "Treasury parse cancelled",
+    ))
+    .into()
+}
+
+/// Builder for [`TreasuryAdapter`].
+#[derive(Debug, Clone)]
+pub struct TreasuryAdapterBuilder {
+    budget_url: String,
+    pdf_base_url: String,
+    pdf_client: Option<PdfClient>,
+}
+
+impl Default for TreasuryAdapterBuilder {
+    fn default() -> Self {
+        Self {
+            budget_url: DEFAULT_BUDGET_URL.into(),
+            pdf_base_url: DEFAULT_PDF_BASE_URL.into(),
+            pdf_client: None,
+        }
+    }
+}
+
+impl TreasuryAdapterBuilder {
+    /// Override the Budget Paper 4 publications URL, usually for fixture tests.
+    #[must_use]
+    pub fn budget_url(mut self, budget_url: impl Into<String>) -> Self {
+        self.budget_url = budget_url.into();
+        self
+    }
+
+    /// Override the PDF sidecar base URL.
+    #[must_use]
+    pub fn pdf_base_url(mut self, pdf_base_url: impl Into<String>) -> Self {
+        self.pdf_base_url = pdf_base_url.into();
+        self
+    }
+
+    /// Inject a prebuilt PDF client, usually for tests.
+    #[must_use]
+    pub fn pdf_client(mut self, pdf_client: PdfClient) -> Self {
+        self.pdf_client = Some(pdf_client);
+        self
+    }
+
+    /// Build the adapter, returning validation errors for invalid sidecar URLs.
+    pub fn try_build(self) -> Result<TreasuryAdapter, AdapterError> {
+        let pdf_client = match self.pdf_client {
+            Some(pdf_client) => pdf_client,
+            None => PdfClient::new(&self.pdf_base_url).map_err(pdf_client_error)?,
+        };
+        Ok(TreasuryAdapter {
+            manifest: AdapterManifest {
+                source_id: source_id(),
+                name: "Australian Government Treasury".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+                rate_limit: RateLimit::new(30, Duration::from_secs(60))
+                    .expect("static Treasury rate limit is valid"),
+                dataflows: vec![dataflow_id()],
+            },
+            budget_url: self.budget_url,
+            pdf_client,
+        })
+    }
+
+    /// Build the adapter.
+    #[must_use]
+    pub fn build(self) -> TreasuryAdapter {
+        self.try_build()
+            .expect("valid static Treasury adapter configuration")
+    }
+}
+
+/// Stored revision type for Treasury Budget Paper PDF links.
+pub type TreasuryBudgetRevision = UpstreamRevision;
+
+/// One Treasury Budget Paper PDF publication discovered from the budget page.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TreasuryBudgetPublication {
+    /// Fiscal year of the Budget publication, such as `2026-27`.
+    pub budget_year: String,
+    /// Human paper name.
+    pub paper: String,
+    /// Stable paper slug for metadata and series dimensions.
+    pub paper_slug: String,
+    /// Link text or target table title.
+    pub title: String,
+    /// Canonical artifact URL.
+    pub source_url: String,
+    /// Optional update marker scraped from the budget page.
+    pub last_updated: Option<String>,
+}
+
+impl TreasuryBudgetPublication {
+    fn revision_key(&self) -> String {
+        format!("TREASURY:{}:{}", self.paper_slug, self.budget_year)
+    }
+
+    fn revision(&self, _started_at: DateTime<Utc>) -> UpstreamRevision {
+        let version = self
+            .last_updated
+            .clone()
+            .unwrap_or_else(|| self.source_url.clone());
+        UpstreamRevision::new(version, self.last_updated.clone())
+    }
+
+    fn to_discovered_job(
+        &self,
+        started_at: DateTime<Utc>,
+        trace_parent: Option<&str>,
+        budget_url: &str,
+    ) -> DiscoveredJob {
+        let revision = self.revision(started_at);
+        let revision_version = revision.version().to_string();
+        let revision_key = self.revision_key();
+        let artifact_date = self
+            .last_updated
+            .clone()
+            .unwrap_or_else(|| self.budget_year.clone());
+        DiscoveredJob {
+            id: format!(
+                "treasury:{}:{}:{}",
+                self.paper_slug, self.budget_year, revision_version
+            ),
+            source_id: source_id(),
+            dataflow_id: dataflow_id(),
+            source_url: self.source_url.clone(),
+            trace_parent: trace_parent.map(str::to_owned),
+            metadata: BTreeMap::from([
+                ("adapter".into(), "treasury".into()),
+                ("artifact_date".into(), artifact_date),
+                ("artifact_format".into(), "pdf".into()),
+                ("attribution".into(), ATTRIBUTION.into()),
+                ("budget_year".into(), self.budget_year.clone()),
+                ("cadence".into(), "annual".into()),
+                ("dataflow_id".into(), DATAFLOW_ID.into()),
+                ("license".into(), LICENSE_NAME.into()),
+                ("license_url".into(), LICENSE_URL.into()),
+                ("paper".into(), self.paper.clone()),
+                ("paper_slug".into(), self.paper_slug.clone()),
+                ("revision_key".into(), revision_key),
+                ("revision_version".into(), revision_version),
+                (
+                    "schema_drift_policy".into(),
+                    "hash-pdf-table-candidates".into(),
+                ),
+                ("source_index_url".into(), budget_url.to_string()),
+                ("title".into(), self.title.clone()),
+            ]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeSet;
+
+    #[test]
+    fn fiscal_year_finder_handles_dash_and_underscore_forms() {
+        assert_eq!(find_fiscal_year("Budget 2026-27"), Some("2026-27".into()));
+        assert_eq!(find_fiscal_year("bp4_2026_27.pdf"), Some("2026-27".into()));
+    }
+
+    #[test]
+    fn parse_budget_period_marks_estimates() {
+        assert_eq!(
+            parse_budget_period("2025-26 Estimated actual")
+                .unwrap()
+                .unwrap()
+                .status,
+            ObservationStatus::Estimated
+        );
+        assert_eq!(
+            parse_budget_period("2026-27 Forward estimate")
+                .unwrap()
+                .unwrap()
+                .status,
+            ObservationStatus::Forecast
+        );
+    }
+
+    #[test]
+    fn duplicate_budget_periods_are_not_enough_for_a_table() {
+        let rows = vec![vec!["Agency".into(), "2026-27 Budget".into()]];
+        assert!(find_budget_period_columns(&rows).unwrap().is_none());
+    }
+
+    #[test]
+    fn candidate_schema_hash_is_stable() {
+        let table = TableCandidate {
+            page: 1,
+            bbox: [1.0, 2.0, 3.0, 4.0],
+            cells: vec![vec!["Agency".into(), "2026-27 Budget".into()]],
+            spans: vec![],
+            diagnostics: BTreeMap::new(),
+        };
+        let rows = table.cells.clone();
+        assert_eq!(
+            schema_hash_for_candidate(&table, &rows),
+            schema_hash_for_candidate(&table, &rows)
+        );
+    }
+
+    #[test]
+    fn no_duplicate_dimension_ids() {
+        let dataflows = TreasuryAdapter::default().dataflow_metadata();
+        let ids = dataflows[0]
+            .dimensions
+            .iter()
+            .map(DimensionId::as_str)
+            .collect::<BTreeSet<_>>();
+        assert_eq!(ids.len(), 4);
+    }
+
+    #[test]
+    fn fetch_job_validation_rejects_wrong_provenance() {
+        let adapter = TreasuryAdapter::default();
+        let mut job = fixture_job();
+
+        job.source_id = SourceId::new("abs").unwrap();
+        assert!(adapter.validate_fetch_job(&job).is_err());
+
+        let mut job = fixture_job();
+        job.dataflow_id = DataflowId::new("treasury.unsupported").unwrap();
+        assert!(adapter.validate_fetch_job(&job).is_err());
+
+        let mut job = fixture_job();
+        job.source_url = "https://budget.gov.au/content/bp4/download/not_the_target.pdf".into();
+        assert!(adapter.validate_fetch_job(&job).is_err());
+    }
+
+    #[test]
+    fn html_url_and_period_helpers_cover_edge_cases() {
+        assert_eq!(
+            attr_value("<a href='one.pdf'>", "href"),
+            Some("one.pdf".into())
+        );
+        assert_eq!(attr_value("<a href=one.pdf>", "href"), None);
+        assert_eq!(attr_value("<a data-href=\"one.pdf\">", "href"), None);
+
+        assert_eq!(
+            resolve_url(DEFAULT_BUDGET_URL, "download/table.pdf").unwrap(),
+            "https://budget.gov.au/content/bp4/download/table.pdf"
+        );
+        assert_eq!(
+            resolve_url(DEFAULT_BUDGET_URL, "/content/bp4/download/table.pdf").unwrap(),
+            "https://budget.gov.au/content/bp4/download/table.pdf"
+        );
+        assert_eq!(
+            resolve_url(
+                DEFAULT_BUDGET_URL,
+                "https://archive.budget.gov.au/table.pdf"
+            )
+            .unwrap(),
+            "https://archive.budget.gov.au/table.pdf"
+        );
+        assert!(resolve_url("budget.gov.au/content/bp4/index.htm", "/table.pdf").is_err());
+        assert!(resolve_url("budget.gov.au", "table.pdf").is_err());
+
+        assert_eq!(decode_url_component("Budget%20Paper%ZZ"), "Budget Paper%ZZ");
+        assert!(looks_like_download_label("PDF 2.4 MB"));
+        assert!(looks_like_download_label("PDF"));
+        assert!(!looks_like_download_label("Agency resourcing table"));
+
+        assert_eq!(
+            parse_budget_period("2024-25 Actual")
+                .unwrap()
+                .unwrap()
+                .status,
+            ObservationStatus::Normal
+        );
+        assert!(parse_budget_period("not a period").unwrap().is_none());
+        assert_eq!(find_fiscal_year("Budget 2026/27"), None);
+        assert_eq!(find_fiscal_year("Budget 2026-A7"), None);
+    }
+
+    #[test]
+    fn provenance_rejects_ambiguous_sources_and_uses_metadata_fallback() {
+        let metadata = BTreeMap::from([
+            ("budget_year".into(), "2026-27".into()),
+            ("artifact_date".into(), "2026-05-12".into()),
+        ]);
+
+        assert!(
+            budget_publication_provenance(
+                "https://example.com/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+                &metadata,
+                true,
+            )
+            .is_none()
+        );
+        assert!(
+            budget_publication_provenance(
+                "https://budget.gov.au/content/bp4/download/other.pdf",
+                &metadata,
+                true,
+            )
+            .is_none()
+        );
+        assert!(
+            budget_publication_provenance(
+                "https://budget.gov.au/content/other/download/bp4_05_agency_resourcing_tables.pdf",
+                &metadata,
+                true,
+            )
+            .is_none()
+        );
+
+        let provenance = budget_publication_provenance(
+            "https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+            &metadata,
+            true,
+        )
+        .expect("target Treasury publication");
+        assert_eq!(provenance.budget_year, "2026-27");
+        assert_eq!(provenance.artifact_date.as_deref(), Some("2026-05-12"));
+
+        let provenance = budget_publication_provenance(
+            "https://mirror.example/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+            &BTreeMap::new(),
+            false,
+        )
+        .expect("host check disabled for recorded fetch metadata");
+        assert_eq!(provenance.budget_year, "unknown");
+    }
+
+    #[test]
+    fn table_helpers_cover_units_values_labels_and_slugs() {
+        assert_eq!(unit_from_rows(&[vec!["Budget ($m)".into()]]), "$ million");
+        assert_eq!(unit_from_rows(&[vec!["Growth per cent".into()]]), "percent");
+        assert_eq!(unit_from_rows(&[vec!["Employee number".into()]]), "number");
+        assert_eq!(unit_from_rows(&[vec!["No unit marker".into()]]), "unknown");
+
+        assert_eq!(parse_value("").unwrap(), (None, ObservationStatus::Missing));
+        assert_eq!(
+            parse_value("n/a").unwrap(),
+            (None, ObservationStatus::Missing)
+        );
+        assert_eq!(
+            parse_value("(1,234.5)").unwrap(),
+            (Some(-1234.5), ObservationStatus::Normal)
+        );
+        assert!(parse_value("not numeric").is_err());
+
+        assert_eq!(label_before(&["Agency".into()], 1), None);
+        assert_eq!(label_before(&["".into(), " ".into()], 2), None);
+        assert_eq!(
+            label_before(
+                &["Department".into(), "Program".into(), "2026-27".into()],
+                2
+            ),
+            Some("Department / Program".into())
+        );
+
+        assert_eq!(
+            table_title_for_candidate(&[vec!["".into()], vec!["".into()]], 2, 7, 3),
+            "Budget Paper No. 4 table page 7 #4"
+        );
+        assert_eq!(
+            table_title_for_candidate(&[vec!["Table 1".into()]], 1, 7, 0),
+            "Table 1"
+        );
+
+        assert_eq!(slugify_code("!!!"), "value");
+        let long_slug = slugify_code(&"A".repeat(140));
+        assert_eq!(long_slug.len(), 128);
+        assert!(long_slug.chars().all(|ch| ch == 'a'));
+    }
+
+    fn fixture_job() -> DiscoveredJob {
+        let publication = TreasuryAdapter::parse_budget_publications_page(
+            r#"<title>Budget Paper No. 4 | Budget 2026-27</title>
+            <a href="https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf">
+            Agency resourcing table</a>"#,
+        )
+        .expect("fixture publication")
+        .into_iter()
+        .next()
+        .expect("fixture job");
+        TreasuryAdapter::current_jobs_with_started_at(
+            &[publication],
+            Utc.with_ymd_and_hms(2026, 5, 27, 0, 0, 0).unwrap(),
+        )
+        .into_iter()
+        .next()
+        .expect("job emitted")
+    }
+}

--- a/crates/adapters/treasury/tests/discover.rs
+++ b/crates/adapters/treasury/tests/discover.rs
@@ -1,0 +1,204 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use au_kpis_adapter::{AdapterHttpClient, DiscoveryCtx, SourceAdapter};
+use au_kpis_adapter_treasury::{TreasuryAdapter, TreasuryBudgetRevision};
+use chrono::{TimeZone, Utc};
+use serde_json::json;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+const TRACE_PARENT: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+const BUDGET_FIXTURE: &str = r#"
+<!doctype html>
+<html>
+  <head><title>Budget Paper No. 4 | Budget 2026&ndash;27</title></head>
+  <body>
+    <main>
+      <h1>Budget Paper No. 4</h1>
+      <table>
+        <tr>
+          <td id="agency-2026">Agency resourcing table</td>
+          <td><a href="/content/bp4/download/bp4_05_agency_resourcing_tables.pdf" data-updated="2026-05-12">PDF 1.97 MB</a></td>
+        </tr>
+        <tr>
+          <td id="agency-2025">Agency resourcing table</td>
+          <td><a href="https://archive.budget.gov.au/2025-26/bp4/download/bp4_05_agency_resourcing_tables.pdf" data-updated="2025-05-13">PDF 1.79 MB</a></td>
+        </tr>
+        <tr>
+          <td id="agency-2024">Agency resourcing table</td>
+          <td><a href="https://archive.budget.gov.au/2024-25/bp4/download/bp4_05_agency_resourcing_tables.pdf" data-updated="2024-05-14">PDF 1.37 MB</a></td>
+        </tr>
+        <tr>
+          <td>Preliminaries</td>
+          <td><a href="/content/bp4/download/bp4_01_prelims.pdf">PDF ignored</a></td>
+        </tr>
+        <tr>
+          <td>Agency resourcing table</td>
+          <td><a href="/content/bp4/download/bp4_05_agency_resourcing_tables.docx">DOCX ignored</a></td>
+        </tr>
+      </table>
+    </main>
+  </body>
+</html>
+"#;
+
+async fn serve_budget_page_once(body: &'static str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fixture server");
+    let addr = listener.local_addr().expect("fixture server address");
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).await.expect("read request");
+        let request = String::from_utf8_lossy(&request[..read]);
+        assert!(request.starts_with("GET /content/bp4/index.htm HTTP/1.1"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("user-agent: au-kpis-adapter-treasury/")
+        );
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/html\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response");
+    });
+
+    format!("http://{addr}/content/bp4/index.htm")
+}
+
+#[test]
+fn parse_budget_publications_page_discovers_budget_paper_pdf_artifacts() {
+    let publications = TreasuryAdapter::parse_budget_publications_page(BUDGET_FIXTURE)
+        .expect("parse Treasury budget page");
+
+    let snapshot = publications
+        .iter()
+        .map(|publication| {
+            json!({
+                "budget_year": publication.budget_year,
+                "paper": publication.paper,
+                "paper_slug": publication.paper_slug,
+                "title": publication.title,
+                "source_url": publication.source_url,
+                "last_updated": publication.last_updated,
+            })
+        })
+        .collect::<Vec<_>>();
+    insta::assert_json_snapshot!(snapshot);
+}
+
+#[test]
+fn discoverable_jobs_apply_annual_revision_and_source_metadata() {
+    let current = TreasuryAdapter::parse_budget_publications_page(BUDGET_FIXTURE)
+        .expect("parse Treasury budget page");
+    let known_revisions = BTreeMap::from([(
+        "TREASURY:bp4-agency-resourcing:2025-26".to_string(),
+        TreasuryBudgetRevision::new("2025-05-13", Some("2025-05-13")),
+    )]);
+    let jobs = TreasuryAdapter::discoverable_jobs_with_started_at(
+        &current,
+        &known_revisions,
+        Utc.with_ymd_and_hms(2026, 5, 27, 0, 0, 0).unwrap(),
+        Some(TRACE_PARENT),
+    );
+
+    assert_eq!(jobs.len(), 2);
+    assert!(jobs.iter().all(|job| job.source_id.as_str() == "treasury"));
+    assert!(
+        jobs.iter()
+            .all(|job| job.dataflow_id.as_str() == "treasury.budget_papers")
+    );
+    assert!(
+        jobs.iter()
+            .all(|job| job.trace_parent.as_deref() == Some(TRACE_PARENT))
+    );
+    assert!(
+        jobs.iter()
+            .all(|job| job.metadata["attribution"] == "Source: Australian Government, The Treasury")
+    );
+    assert!(
+        jobs.iter()
+            .all(|job| job.metadata["license"] == "CC-BY-4.0")
+    );
+    assert!(
+        jobs.iter()
+            .all(|job| job.metadata["schema_drift_policy"] == "hash-pdf-table-candidates")
+    );
+    assert_eq!(jobs[0].metadata["cadence"], "annual");
+    assert_eq!(
+        jobs[0].metadata["revision_key"],
+        "TREASURY:bp4-agency-resourcing:2024-25"
+    );
+    assert_eq!(
+        jobs[1].metadata["revision_key"],
+        "TREASURY:bp4-agency-resourcing:2026-27"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn discover_scrapes_treasury_budget_publications_page_over_http() {
+    let budget_url = serve_budget_page_once(BUDGET_FIXTURE).await;
+    let adapter = TreasuryAdapter::builder().budget_url(&budget_url).build();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = DiscoveryCtx::new(http, Utc.with_ymd_and_hms(2026, 5, 27, 0, 0, 0).unwrap())
+        .with_trace_parent(TRACE_PARENT);
+
+    let jobs = adapter
+        .discover(&ctx)
+        .await
+        .expect("discover Treasury PDFs");
+
+    assert_eq!(jobs.len(), 3);
+    let origin = budget_url
+        .trim_end_matches("/content/bp4/index.htm")
+        .to_string();
+    assert_eq!(
+        jobs[0].source_url,
+        "https://archive.budget.gov.au/2024-25/bp4/download/bp4_05_agency_resourcing_tables.pdf"
+    );
+    assert_eq!(
+        jobs[2].source_url,
+        format!("{origin}/content/bp4/download/bp4_05_agency_resourcing_tables.pdf")
+    );
+    assert_eq!(jobs[2].metadata["budget_year"], "2026-27");
+    assert_eq!(jobs[2].metadata["artifact_format"], "pdf");
+}
+
+#[test]
+fn manifest_declares_treasury_rate_limit_and_dataflow_metadata() {
+    let adapter = TreasuryAdapter::default();
+    let manifest = adapter.manifest();
+
+    assert_eq!(manifest.source_id.as_str(), "treasury");
+    assert_eq!(manifest.rate_limit.max_requests, 30);
+    assert_eq!(manifest.rate_limit.per, Duration::from_secs(60));
+    assert_eq!(
+        manifest.dataflows,
+        vec![au_kpis_domain::DataflowId::new("treasury.budget_papers").unwrap()]
+    );
+
+    let dataflows = adapter.dataflow_metadata();
+    assert_eq!(dataflows.len(), 1);
+    assert_eq!(dataflows[0].id.as_str(), "treasury.budget_papers");
+    assert_eq!(dataflows[0].frequency, au_kpis_domain::Frequency::Annual);
+    assert_eq!(dataflows[0].license, au_kpis_domain::License::CcBy40);
+    assert_eq!(
+        dataflows[0].attribution,
+        "Source: Australian Government, The Treasury"
+    );
+    assert_eq!(
+        dataflows[0].source_url,
+        "https://budget.gov.au/content/bp4/index.htm"
+    );
+}

--- a/crates/adapters/treasury/tests/fetch.rs
+++ b/crates/adapters/treasury/tests/fetch.rs
@@ -1,0 +1,147 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use au_kpis_adapter::{AdapterError, AdapterHttpClient, ArtifactRecorder, FetchCtx, SourceAdapter};
+use au_kpis_adapter_treasury::TreasuryAdapter;
+use au_kpis_domain::{Artifact, ArtifactId};
+use au_kpis_storage::{BlobStore, StorageKey};
+use bytes::Bytes;
+use chrono::{TimeZone, Utc};
+use object_store::{ObjectStore, memory::InMemory, path::Path as ObjectPath};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+const PDF_FIXTURE: &[u8] = b"%PDF-1.7\n% treasury budget fixture\n%%EOF\n";
+
+#[derive(Debug, Default)]
+struct RecordingArtifactRecorder {
+    artifacts: tokio::sync::Mutex<Vec<Artifact>>,
+}
+
+#[async_trait]
+impl ArtifactRecorder for RecordingArtifactRecorder {
+    async fn get(&self, id: ArtifactId) -> Result<Option<Artifact>, AdapterError> {
+        Ok(self
+            .artifacts
+            .lock()
+            .await
+            .iter()
+            .find(|artifact| artifact.id == id)
+            .cloned())
+    }
+
+    async fn record(&self, artifact: &Artifact) -> Result<Artifact, AdapterError> {
+        self.artifacts.lock().await.push(artifact.clone());
+        Ok(artifact.clone())
+    }
+
+    async fn repair_storage_key(
+        &self,
+        artifact: &Artifact,
+        _observed_storage_key: &str,
+    ) -> Result<Artifact, AdapterError> {
+        Ok(artifact.clone())
+    }
+}
+
+fn recording_recorder() -> Arc<RecordingArtifactRecorder> {
+    Arc::new(RecordingArtifactRecorder::default())
+}
+
+async fn serve_artifact_once(body: &'static [u8]) -> (String, String) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fixture server");
+    let addr = listener.local_addr().expect("fixture server address");
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).await.expect("read request");
+        let request = String::from_utf8_lossy(&request[..read]);
+        assert!(
+            request.starts_with(
+                "GET /content/bp4/download/bp4_05_agency_resourcing_tables.pdf HTTP/1.1"
+            ),
+            "{request}"
+        );
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("user-agent: au-kpis-adapter-treasury/")
+        );
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/pdf\r\nx-treasury-fixture: bp4\r\ncontent-length: {}\r\n\r\n",
+            body.len(),
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response headers");
+        stream.write_all(body).await.expect("write response body");
+    });
+
+    let budget_url = format!("http://{addr}/content/bp4/index.htm");
+    let source_url =
+        format!("http://{addr}/content/bp4/download/bp4_05_agency_resourcing_tables.pdf");
+    (budget_url, source_url)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fetch_persists_raw_treasury_budget_pdf_with_response_headers() {
+    let (budget_url, source_url) = serve_artifact_once(PDF_FIXTURE).await;
+    let adapter = TreasuryAdapter::builder().budget_url(budget_url).build();
+    let publication = TreasuryAdapter::parse_budget_publications_page(&format!(
+        r#"<title>Budget Paper No. 4 | Budget 2026&ndash;27</title><a href="{source_url}" data-updated="2026-05-12">Agency resourcing table</a>"#
+    ))
+    .expect("parse budget publication link")
+    .into_iter()
+    .next()
+    .expect("publication discovered");
+    let job = TreasuryAdapter::current_jobs_with_started_at(
+        &[publication],
+        Utc.with_ymd_and_hms(2026, 5, 27, 0, 0, 0).unwrap(),
+    )
+    .into_iter()
+    .next()
+    .expect("job emitted");
+    let recorder = recording_recorder();
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let blob_store = BlobStore::from_arc(object_store.clone());
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = FetchCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 27, 1, 0, 0).unwrap(),
+        recorder.clone(),
+    );
+
+    let artifact = adapter
+        .fetch(job.clone(), &ctx)
+        .await
+        .expect("fetch Treasury PDF");
+
+    assert_eq!(artifact.source_id.as_str(), "treasury");
+    assert_eq!(artifact.source_url, job.source_url);
+    assert_eq!(artifact.content_type, "application/pdf");
+    assert_eq!(artifact.response_headers["x-treasury-fixture"], vec!["bp4"]);
+    assert_eq!(artifact.size_bytes, PDF_FIXTURE.len() as u64);
+    assert_eq!(artifact.id, ArtifactId::of_content(PDF_FIXTURE));
+    assert_eq!(
+        artifact.storage_key,
+        StorageKey::canonical_for(&artifact.id).to_string()
+    );
+
+    let stored = object_store
+        .get(&ObjectPath::from(artifact.storage_key.clone()))
+        .await
+        .expect("stored artifact")
+        .bytes()
+        .await
+        .expect("artifact bytes");
+    assert_eq!(stored, Bytes::from_static(PDF_FIXTURE));
+    assert_eq!(recorder.artifacts.lock().await.len(), 1);
+}

--- a/crates/adapters/treasury/tests/parse.rs
+++ b/crates/adapters/treasury/tests/parse.rs
@@ -1,0 +1,412 @@
+use std::{collections::BTreeMap, str};
+
+use au_kpis_adapter::{AdapterHttpClient, ArtifactRef, ParseCtx, SourceAdapter};
+use au_kpis_adapter_treasury::TreasuryAdapter;
+use au_kpis_domain::{ArtifactId, DataflowId, SourceId};
+use au_kpis_storage::{BlobStore, StorageKey};
+use bytes::Bytes;
+use chrono::{TimeZone, Utc};
+use futures::StreamExt;
+use object_store::memory::InMemory;
+use serde::Serialize;
+use serde_json::{Value, json};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+const BP4_2026_27: &[u8] = b"%PDF-1.7\n% treasury budget fixture 2026-27\n%%EOF\n";
+const BP4_2025_26: &[u8] = b"%PDF-1.7\n% treasury budget fixture 2025-26\n%%EOF\n";
+const BP4_2024_25: &[u8] = b"%PDF-1.7\n% treasury budget fixture 2024-25\n%%EOF\n";
+
+#[derive(Debug, Serialize)]
+struct FixtureSnapshot {
+    observation_count: usize,
+    series_count: usize,
+    first_rows: Vec<SnapshotRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct SnapshotRow {
+    dataflow_id: String,
+    measure_id: String,
+    dimensions: BTreeMap<String, String>,
+    unit: String,
+    time: String,
+    time_precision: String,
+    value: Option<f64>,
+    status: String,
+    attributes: BTreeMap<String, String>,
+    source_artifact_id: String,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct FixtureCase {
+    name: &'static str,
+    bytes: &'static [u8],
+    source_url: &'static str,
+    budget_year: &'static str,
+    artifact_date: &'static str,
+    cells: &'static [&'static [&'static str]],
+}
+
+async fn artifact_for(
+    blob_store: &BlobStore,
+    bytes: &'static [u8],
+    source_url: &str,
+) -> ArtifactRef {
+    let id = blob_store
+        .put_artifact(Bytes::from_static(bytes))
+        .await
+        .expect("store fixture artifact");
+    ArtifactRef {
+        id,
+        source_id: SourceId::new("treasury").unwrap(),
+        source_url: source_url.into(),
+        content_type: "application/pdf".into(),
+        response_headers: BTreeMap::new(),
+        storage_key: StorageKey::canonical_for(&id).to_string(),
+        size_bytes: bytes.len() as u64,
+        fetched_at: Utc.with_ymd_and_hms(2026, 5, 27, 0, 0, 0).unwrap(),
+    }
+}
+
+async fn serve_sidecar_once(
+    expected_storage_key: String,
+    expected_artifact_date: &'static str,
+    response_body: String,
+) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind sidecar fixture server");
+    let addr = listener.local_addr().expect("fixture server address");
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let request = read_http_request(&mut stream).await;
+        assert!(request.starts_with("POST /extract HTTP/1.1"), "{request}");
+        let body = request.split("\r\n\r\n").nth(1).expect("request body");
+        let json: Value = serde_json::from_str(body).expect("extract request json");
+        assert_eq!(json["s3_key"], expected_storage_key);
+        assert_eq!(json["source_id"], "treasury");
+        assert_eq!(json["artifact_date"], expected_artifact_date);
+        assert_eq!(json["strategy"], "deterministic");
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/json\r\ncontent-length: {}\r\n\r\n{}",
+            response_body.len(),
+            response_body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write sidecar response");
+    });
+
+    format!("http://{addr}")
+}
+
+async fn read_http_request(stream: &mut tokio::net::TcpStream) -> String {
+    let mut buffer = Vec::new();
+    loop {
+        let mut chunk = [0_u8; 1024];
+        let read = stream.read(&mut chunk).await.expect("read request");
+        assert_ne!(read, 0, "connection closed before request completed");
+        buffer.extend_from_slice(&chunk[..read]);
+        if let Some(header_end) = find_header_end(&buffer) {
+            let headers = str::from_utf8(&buffer[..header_end]).expect("utf8 headers");
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().expect("content length"))
+                })
+                .unwrap_or(0);
+            if buffer.len() >= header_end + 4 + content_length {
+                return String::from_utf8(buffer).expect("utf8 request");
+            }
+        }
+    }
+}
+
+fn find_header_end(buffer: &[u8]) -> Option<usize> {
+    buffer.windows(4).position(|window| window == b"\r\n\r\n")
+}
+
+fn sidecar_response(storage_key: &str, cells: &[&[&str]]) -> String {
+    let rows = cells
+        .iter()
+        .map(|row| row.iter().map(|cell| cell.to_string()).collect::<Vec<_>>())
+        .collect::<Vec<_>>();
+    json!({
+        "artifact_key": storage_key,
+        "backend": {
+            "kind": "deterministic",
+            "name": "fixture-pdfplumber",
+            "version": "2026.1",
+            "model_sha256": null
+        },
+        "tables": [{
+            "page": 12,
+            "bbox": [10.0, 20.0, 500.0, 700.0],
+            "cells": rows,
+            "spans": [],
+            "diagnostics": {"fixture": "treasury-budget"}
+        }]
+    })
+    .to_string()
+}
+
+async fn snapshot_fixture(case: FixtureCase, blob_store: BlobStore) -> FixtureSnapshot {
+    let artifact = artifact_for(&blob_store, case.bytes, case.source_url).await;
+    let sidecar_url = serve_sidecar_once(
+        artifact.storage_key.clone(),
+        case.artifact_date,
+        sidecar_response(&artifact.storage_key, case.cells),
+    )
+    .await;
+    let adapter = TreasuryAdapter::builder().pdf_base_url(sidecar_url).build();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 27, 1, 0, 0).unwrap(),
+    )
+    .with_expected_dataflow(
+        DataflowId::new("treasury.budget_papers").unwrap(),
+        BTreeMap::from([
+            ("budget_year".into(), case.budget_year.into()),
+            ("artifact_date".into(), case.artifact_date.into()),
+            ("paper".into(), "Budget Paper No. 4".into()),
+            ("paper_slug".into(), "bp4-agency-resourcing".into()),
+            ("title".into(), "Agency resourcing table".into()),
+        ]),
+    );
+    let rows = adapter
+        .parse(artifact, &ctx)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("parse Treasury fixture through sidecar");
+
+    let observation_count = rows.len();
+    let series_count = rows
+        .iter()
+        .map(|(series, _)| series.series_key)
+        .collect::<std::collections::BTreeSet<_>>()
+        .len();
+    let first_rows: Vec<SnapshotRow> = rows
+        .into_iter()
+        .take(8)
+        .map(|(series, observation)| SnapshotRow {
+            dataflow_id: series.dataflow_id.as_str().to_string(),
+            measure_id: series.measure_id.as_str().to_string(),
+            dimensions: series
+                .dimensions
+                .into_iter()
+                .map(|(key, value)| (key.as_str().to_string(), value.as_str().to_string()))
+                .collect(),
+            unit: series.unit,
+            time: observation.time.to_rfc3339(),
+            time_precision: format!("{:?}", observation.time_precision),
+            value: observation.value,
+            status: format!("{:?}", observation.status),
+            attributes: observation.attributes,
+            source_artifact_id: observation.source_artifact_id.to_hex(),
+        })
+        .collect();
+
+    FixtureSnapshot {
+        observation_count,
+        series_count,
+        first_rows,
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parses_treasury_budget_pdf_fixtures_through_sidecar_contract() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let fixtures = [
+        FixtureCase {
+            name: "bp4_agency_resourcing_2026_27",
+            bytes: BP4_2026_27,
+            source_url: "https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+            budget_year: "2026-27",
+            artifact_date: "2026-05-12",
+            cells: &[
+                &["Table 1: Agency resourcing by portfolio ($m)", "", "", ""],
+                &[
+                    "Agency",
+                    "2024-25 Actual",
+                    "2025-26 Budget",
+                    "2026-27 Forward estimate",
+                ],
+                &["Department of the Treasury", "310.0", "325.5", "341.0"],
+                &["Department of Finance", "420.0", "438.5", "456.0"],
+            ],
+        },
+        FixtureCase {
+            name: "bp4_agency_resourcing_2025_26",
+            bytes: BP4_2025_26,
+            source_url: "https://archive.budget.gov.au/2025-26/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+            budget_year: "2025-26",
+            artifact_date: "2025-05-13",
+            cells: &[
+                &["Table 1: Agency resourcing by portfolio ($m)", "", "", ""],
+                &[
+                    "Agency",
+                    "2023-24 Actual",
+                    "2024-25 Estimated actual",
+                    "2025-26 Budget",
+                ],
+                &["Department of the Treasury", "292.0", "305.5", "320.0"],
+                &["Department of Finance", "398.0", "411.0", "429.5"],
+            ],
+        },
+        FixtureCase {
+            name: "bp4_agency_resourcing_2024_25",
+            bytes: BP4_2024_25,
+            source_url: "https://archive.budget.gov.au/2024-25/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+            budget_year: "2024-25",
+            artifact_date: "2024-05-14",
+            cells: &[
+                &["Table 1: Agency resourcing by portfolio ($m)", "", "", ""],
+                &[
+                    "Agency",
+                    "2022-23 Actual",
+                    "2023-24 Estimated actual",
+                    "2024-25 Budget",
+                ],
+                &["Department of the Treasury", "275.0", "288.5", "301.0"],
+                &["Department of Finance", "377.0", "389.0", "404.5"],
+            ],
+        },
+    ];
+
+    for case in fixtures {
+        let snapshot = snapshot_fixture(case, blob_store.clone()).await;
+        assert!(snapshot.observation_count > 0);
+        insta::assert_json_snapshot!(case.name, snapshot);
+    }
+}
+
+#[tokio::test]
+async fn parse_rejects_ambiguous_treasury_provenance() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let mut artifact = artifact_for(
+        &blob_store,
+        BP4_2026_27,
+        "https://mirror.example.invalid/bp4_05_agency_resourcing_tables.pdf",
+    )
+    .await;
+    artifact.source_id = SourceId::new("abs").unwrap();
+
+    let adapter = TreasuryAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 27, 1, 0, 0).unwrap(),
+    );
+    let err = adapter
+        .parse(artifact, &ctx)
+        .next()
+        .await
+        .expect("one parse result")
+        .expect_err("invalid provenance should fail");
+
+    assert!(
+        err.to_string()
+            .contains("Treasury parse received artifact for source")
+    );
+}
+
+#[tokio::test]
+async fn parse_rejects_artifact_id_storage_key_mismatch() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let actual_id = blob_store
+        .put_artifact(Bytes::from_static(BP4_2026_27))
+        .await
+        .expect("store fixture artifact");
+    let wrong_id = ArtifactId::of_content(b"different Treasury artifact");
+    assert_ne!(actual_id, wrong_id);
+
+    let artifact = ArtifactRef {
+        id: wrong_id,
+        source_id: SourceId::new("treasury").unwrap(),
+        source_url:
+            "https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf".into(),
+        content_type: "application/pdf".into(),
+        response_headers: BTreeMap::new(),
+        storage_key: StorageKey::canonical_for(&actual_id).to_string(),
+        size_bytes: BP4_2026_27.len() as u64,
+        fetched_at: Utc.with_ymd_and_hms(2026, 5, 27, 0, 0, 0).unwrap(),
+    };
+    let adapter = TreasuryAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 27, 1, 0, 0).unwrap(),
+    );
+
+    let err = adapter
+        .parse(artifact, &ctx)
+        .next()
+        .await
+        .expect("one parse result")
+        .expect_err("mismatched storage key should fail");
+
+    assert!(
+        err.to_string().contains("does not match artifact id"),
+        "{err}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn parse_rejects_sidecar_artifact_key_mismatch() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let artifact = artifact_for(
+        &blob_store,
+        BP4_2026_27,
+        "https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+    )
+    .await;
+    let response = sidecar_response(
+        "artifacts/not-the-requested-artifact",
+        &[
+            &["Agency", "2026-27 Budget"],
+            &["Department of the Treasury", "1.0"],
+        ],
+    );
+    let sidecar_url =
+        serve_sidecar_once(artifact.storage_key.clone(), "2026-05-12", response).await;
+    let adapter = TreasuryAdapter::builder().pdf_base_url(sidecar_url).build();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 27, 1, 0, 0).unwrap(),
+    )
+    .with_expected_dataflow(
+        DataflowId::new("treasury.budget_papers").unwrap(),
+        BTreeMap::from([
+            ("budget_year".into(), "2026-27".into()),
+            ("artifact_date".into(), "2026-05-12".into()),
+        ]),
+    );
+
+    let err = adapter
+        .parse(artifact, &ctx)
+        .next()
+        .await
+        .expect("one parse result")
+        .expect_err("sidecar mismatch should fail");
+
+    assert!(
+        err.to_string().contains("sidecar returned artifact key"),
+        "{err}"
+    );
+}

--- a/crates/adapters/treasury/tests/snapshots/discover__parse_budget_publications_page_discovers_budget_paper_pdf_artifacts.snap
+++ b/crates/adapters/treasury/tests/snapshots/discover__parse_budget_publications_page_discovers_budget_paper_pdf_artifacts.snap
@@ -1,0 +1,30 @@
+---
+source: crates/adapters/treasury/tests/discover.rs
+expression: snapshot
+---
+[
+  {
+    "budget_year": "2024-25",
+    "last_updated": "2024-05-14",
+    "paper": "Budget Paper No. 4",
+    "paper_slug": "bp4-agency-resourcing",
+    "source_url": "https://archive.budget.gov.au/2024-25/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+    "title": "Agency resourcing table"
+  },
+  {
+    "budget_year": "2025-26",
+    "last_updated": "2025-05-13",
+    "paper": "Budget Paper No. 4",
+    "paper_slug": "bp4-agency-resourcing",
+    "source_url": "https://archive.budget.gov.au/2025-26/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+    "title": "Agency resourcing table"
+  },
+  {
+    "budget_year": "2026-27",
+    "last_updated": "2026-05-12",
+    "paper": "Budget Paper No. 4",
+    "paper_slug": "bp4-agency-resourcing",
+    "source_url": "https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+    "title": "Agency resourcing table"
+  }
+]

--- a/crates/adapters/treasury/tests/snapshots/parse__bp4_agency_resourcing_2024_25.snap
+++ b/crates/adapters/treasury/tests/snapshots/parse__bp4_agency_resourcing_2024_25.snap
@@ -1,0 +1,220 @@
+---
+source: crates/adapters/treasury/tests/parse.rs
+expression: snapshot
+---
+{
+  "observation_count": 6,
+  "series_count": 2,
+  "first_rows": [
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2024-25",
+        "line_item": "department_of_the_treasury",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2022-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 275.0,
+      "status": "Normal",
+      "attributes": {
+        "artifact_date": "2024-05-14",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2024-25",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "d1a529ef09ad69e5f3c0a2e6da36dcf4449ace0fad82c2a7f2af82ca1a5e281a",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2024-25/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of the Treasury",
+        "treasury_period_label": "2022-23"
+      },
+      "source_artifact_id": "13ae98bc66404753efd5770ec5a3b12ebb3c610c6046e6a5934f8f262e747c7a"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2024-25",
+        "line_item": "department_of_the_treasury",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2023-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 288.5,
+      "status": "Estimated",
+      "attributes": {
+        "artifact_date": "2024-05-14",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2024-25",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "d1a529ef09ad69e5f3c0a2e6da36dcf4449ace0fad82c2a7f2af82ca1a5e281a",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2024-25/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of the Treasury",
+        "treasury_period_label": "2023-24"
+      },
+      "source_artifact_id": "13ae98bc66404753efd5770ec5a3b12ebb3c610c6046e6a5934f8f262e747c7a"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2024-25",
+        "line_item": "department_of_the_treasury",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2024-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 301.0,
+      "status": "Forecast",
+      "attributes": {
+        "artifact_date": "2024-05-14",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2024-25",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "d1a529ef09ad69e5f3c0a2e6da36dcf4449ace0fad82c2a7f2af82ca1a5e281a",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2024-25/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of the Treasury",
+        "treasury_period_label": "2024-25"
+      },
+      "source_artifact_id": "13ae98bc66404753efd5770ec5a3b12ebb3c610c6046e6a5934f8f262e747c7a"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2024-25",
+        "line_item": "department_of_finance",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2022-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 377.0,
+      "status": "Normal",
+      "attributes": {
+        "artifact_date": "2024-05-14",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2024-25",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "d1a529ef09ad69e5f3c0a2e6da36dcf4449ace0fad82c2a7f2af82ca1a5e281a",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2024-25/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of Finance",
+        "treasury_period_label": "2022-23"
+      },
+      "source_artifact_id": "13ae98bc66404753efd5770ec5a3b12ebb3c610c6046e6a5934f8f262e747c7a"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2024-25",
+        "line_item": "department_of_finance",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2023-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 389.0,
+      "status": "Estimated",
+      "attributes": {
+        "artifact_date": "2024-05-14",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2024-25",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "d1a529ef09ad69e5f3c0a2e6da36dcf4449ace0fad82c2a7f2af82ca1a5e281a",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2024-25/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of Finance",
+        "treasury_period_label": "2023-24"
+      },
+      "source_artifact_id": "13ae98bc66404753efd5770ec5a3b12ebb3c610c6046e6a5934f8f262e747c7a"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2024-25",
+        "line_item": "department_of_finance",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2024-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 404.5,
+      "status": "Forecast",
+      "attributes": {
+        "artifact_date": "2024-05-14",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2024-25",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "d1a529ef09ad69e5f3c0a2e6da36dcf4449ace0fad82c2a7f2af82ca1a5e281a",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2024-25/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of Finance",
+        "treasury_period_label": "2024-25"
+      },
+      "source_artifact_id": "13ae98bc66404753efd5770ec5a3b12ebb3c610c6046e6a5934f8f262e747c7a"
+    }
+  ]
+}

--- a/crates/adapters/treasury/tests/snapshots/parse__bp4_agency_resourcing_2025_26.snap
+++ b/crates/adapters/treasury/tests/snapshots/parse__bp4_agency_resourcing_2025_26.snap
@@ -1,0 +1,220 @@
+---
+source: crates/adapters/treasury/tests/parse.rs
+expression: snapshot
+---
+{
+  "observation_count": 6,
+  "series_count": 2,
+  "first_rows": [
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2025-26",
+        "line_item": "department_of_the_treasury",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2023-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 292.0,
+      "status": "Normal",
+      "attributes": {
+        "artifact_date": "2025-05-13",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2025-26",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "54f406de577dc6b8baa3a4a59df76b77bbb28e129b2d68cd43187d4186a41bef",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2025-26/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of the Treasury",
+        "treasury_period_label": "2023-24"
+      },
+      "source_artifact_id": "e90b72bae033fc4c48cecad2fed5d42ae38d7a6c158c8503e8c523d076d01255"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2025-26",
+        "line_item": "department_of_the_treasury",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2024-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 305.5,
+      "status": "Estimated",
+      "attributes": {
+        "artifact_date": "2025-05-13",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2025-26",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "54f406de577dc6b8baa3a4a59df76b77bbb28e129b2d68cd43187d4186a41bef",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2025-26/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of the Treasury",
+        "treasury_period_label": "2024-25"
+      },
+      "source_artifact_id": "e90b72bae033fc4c48cecad2fed5d42ae38d7a6c158c8503e8c523d076d01255"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2025-26",
+        "line_item": "department_of_the_treasury",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2025-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 320.0,
+      "status": "Forecast",
+      "attributes": {
+        "artifact_date": "2025-05-13",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2025-26",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "54f406de577dc6b8baa3a4a59df76b77bbb28e129b2d68cd43187d4186a41bef",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2025-26/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of the Treasury",
+        "treasury_period_label": "2025-26"
+      },
+      "source_artifact_id": "e90b72bae033fc4c48cecad2fed5d42ae38d7a6c158c8503e8c523d076d01255"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2025-26",
+        "line_item": "department_of_finance",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2023-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 398.0,
+      "status": "Normal",
+      "attributes": {
+        "artifact_date": "2025-05-13",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2025-26",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "54f406de577dc6b8baa3a4a59df76b77bbb28e129b2d68cd43187d4186a41bef",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2025-26/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of Finance",
+        "treasury_period_label": "2023-24"
+      },
+      "source_artifact_id": "e90b72bae033fc4c48cecad2fed5d42ae38d7a6c158c8503e8c523d076d01255"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2025-26",
+        "line_item": "department_of_finance",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2024-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 411.0,
+      "status": "Estimated",
+      "attributes": {
+        "artifact_date": "2025-05-13",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2025-26",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "54f406de577dc6b8baa3a4a59df76b77bbb28e129b2d68cd43187d4186a41bef",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2025-26/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of Finance",
+        "treasury_period_label": "2024-25"
+      },
+      "source_artifact_id": "e90b72bae033fc4c48cecad2fed5d42ae38d7a6c158c8503e8c523d076d01255"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2025-26",
+        "line_item": "department_of_finance",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2025-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 429.5,
+      "status": "Forecast",
+      "attributes": {
+        "artifact_date": "2025-05-13",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2025-26",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "54f406de577dc6b8baa3a4a59df76b77bbb28e129b2d68cd43187d4186a41bef",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://archive.budget.gov.au/2025-26/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of Finance",
+        "treasury_period_label": "2025-26"
+      },
+      "source_artifact_id": "e90b72bae033fc4c48cecad2fed5d42ae38d7a6c158c8503e8c523d076d01255"
+    }
+  ]
+}

--- a/crates/adapters/treasury/tests/snapshots/parse__bp4_agency_resourcing_2026_27.snap
+++ b/crates/adapters/treasury/tests/snapshots/parse__bp4_agency_resourcing_2026_27.snap
@@ -1,0 +1,220 @@
+---
+source: crates/adapters/treasury/tests/parse.rs
+expression: snapshot
+---
+{
+  "observation_count": 6,
+  "series_count": 2,
+  "first_rows": [
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2026-27",
+        "line_item": "department_of_the_treasury",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2024-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 310.0,
+      "status": "Normal",
+      "attributes": {
+        "artifact_date": "2026-05-12",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2026-27",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "206fb468a5a8b1d7514683f1087e30d5a163da126d5381347152218a8757c376",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of the Treasury",
+        "treasury_period_label": "2024-25"
+      },
+      "source_artifact_id": "837f149c2228a46e954833882a76f6c3d33a389680a07ce04aaf374af45d641d"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2026-27",
+        "line_item": "department_of_the_treasury",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2025-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 325.5,
+      "status": "Forecast",
+      "attributes": {
+        "artifact_date": "2026-05-12",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2026-27",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "206fb468a5a8b1d7514683f1087e30d5a163da126d5381347152218a8757c376",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of the Treasury",
+        "treasury_period_label": "2025-26"
+      },
+      "source_artifact_id": "837f149c2228a46e954833882a76f6c3d33a389680a07ce04aaf374af45d641d"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2026-27",
+        "line_item": "department_of_the_treasury",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2026-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 341.0,
+      "status": "Forecast",
+      "attributes": {
+        "artifact_date": "2026-05-12",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2026-27",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "206fb468a5a8b1d7514683f1087e30d5a163da126d5381347152218a8757c376",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of the Treasury",
+        "treasury_period_label": "2026-27"
+      },
+      "source_artifact_id": "837f149c2228a46e954833882a76f6c3d33a389680a07ce04aaf374af45d641d"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2026-27",
+        "line_item": "department_of_finance",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2024-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 420.0,
+      "status": "Normal",
+      "attributes": {
+        "artifact_date": "2026-05-12",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2026-27",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "206fb468a5a8b1d7514683f1087e30d5a163da126d5381347152218a8757c376",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of Finance",
+        "treasury_period_label": "2024-25"
+      },
+      "source_artifact_id": "837f149c2228a46e954833882a76f6c3d33a389680a07ce04aaf374af45d641d"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2026-27",
+        "line_item": "department_of_finance",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2025-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 438.5,
+      "status": "Forecast",
+      "attributes": {
+        "artifact_date": "2026-05-12",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2026-27",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "206fb468a5a8b1d7514683f1087e30d5a163da126d5381347152218a8757c376",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of Finance",
+        "treasury_period_label": "2025-26"
+      },
+      "source_artifact_id": "837f149c2228a46e954833882a76f6c3d33a389680a07ce04aaf374af45d641d"
+    },
+    {
+      "dataflow_id": "treasury.budget_papers",
+      "measure_id": "value",
+      "dimensions": {
+        "budget_year": "2026-27",
+        "line_item": "department_of_finance",
+        "paper": "bp4-agency-resourcing",
+        "table": "table_1_agency_resourcing_by_portfolio_m"
+      },
+      "unit": "$ million",
+      "time": "2026-07-01T00:00:00+00:00",
+      "time_precision": "Year",
+      "value": 456.0,
+      "status": "Forecast",
+      "attributes": {
+        "artifact_date": "2026-05-12",
+        "attribution": "Source: Australian Government, The Treasury",
+        "budget_year": "2026-27",
+        "extraction_backend": "fixture-pdfplumber",
+        "extraction_backend_version": "2026.1",
+        "license": "CC-BY-4.0",
+        "license_url": "https://creativecommons.org/licenses/by/4.0/",
+        "paper": "Budget Paper No. 4",
+        "paper_slug": "bp4-agency-resourcing",
+        "publication_title": "Agency resourcing table",
+        "schema_hash": "206fb468a5a8b1d7514683f1087e30d5a163da126d5381347152218a8757c376",
+        "source": "Australian Government, The Treasury",
+        "source_url": "https://budget.gov.au/content/bp4/download/bp4_05_agency_resourcing_tables.pdf",
+        "table_page": "12",
+        "table_title": "Table 1: Agency resourcing by portfolio ($m)",
+        "treasury_line_item": "Department of Finance",
+        "treasury_period_label": "2026-27"
+      },
+      "source_artifact_id": "837f149c2228a46e954833882a76f6c3d33a389680a07ce04aaf374af45d641d"
+    }
+  ]
+}

--- a/crates/bins/au-kpis-ingestion/Cargo.toml
+++ b/crates/bins/au-kpis-ingestion/Cargo.toml
@@ -13,6 +13,7 @@ au-kpis-adapter = { workspace = true }
 au-kpis-adapter-abs = { path = "../../adapters/abs" }
 au-kpis-adapter-apra = { path = "../../adapters/apra" }
 au-kpis-adapter-rba = { path = "../../adapters/rba" }
+au-kpis-adapter-treasury = { path = "../../adapters/treasury" }
 au-kpis-config = { workspace = true }
 au-kpis-db = { workspace = true }
 au-kpis-domain = { workspace = true }

--- a/crates/bins/au-kpis-ingestion/src/main.rs
+++ b/crates/bins/au-kpis-ingestion/src/main.rs
@@ -20,6 +20,7 @@ use au_kpis_adapter::{AdapterHttpClient, Adapters, DiscoveryCtx, ParseCtx};
 use au_kpis_adapter_abs::AbsAdapter;
 use au_kpis_adapter_apra::ApraAdapter;
 use au_kpis_adapter_rba::RbaAdapter;
+use au_kpis_adapter_treasury::TreasuryAdapter;
 use au_kpis_config::load_ingestion;
 use au_kpis_db::{connect as connect_db, migrate};
 use au_kpis_domain::ids::{DataflowId, SourceId};
@@ -40,6 +41,8 @@ const APRA_QUARTERLY_DATAFLOW_SLUG: &str = "quarterly-statistics";
 const APRA_QUARTERLY_DATAFLOW_ID: &str = "apra.quarterly_statistics";
 const RBA_STAT_TABLES_DATAFLOW_SLUG: &str = "statistical-tables";
 const RBA_STAT_TABLES_DATAFLOW_ID: &str = "rba.statistical_tables";
+const TREASURY_BUDGET_DATAFLOW_SLUG: &str = "budget-papers";
+const TREASURY_BUDGET_DATAFLOW_ID: &str = "treasury.budget_papers";
 const DEFAULT_POLL_INTERVAL_MS: u64 = 1_000;
 
 /// Command-line arguments for `au-kpis-ingestion`.
@@ -523,6 +526,16 @@ fn build_adapters() -> anyhow::Result<Adapters> {
         Err(_) => RbaAdapter::default(),
     };
     builder.register(rba).context("register RBA adapter")?;
+    let mut treasury = TreasuryAdapter::builder();
+    if let Ok(budget_url) = env::var("AU_KPIS_TREASURY_BUDGET_URL") {
+        treasury = treasury.budget_url(budget_url);
+    }
+    if let Ok(pdf_base_url) = env::var("AU_KPIS_PDF_BASE_URL") {
+        treasury = treasury.pdf_base_url(pdf_base_url);
+    }
+    builder
+        .register(treasury.try_build().context("build Treasury adapter")?)
+        .context("register Treasury adapter")?;
     Ok(builder.build())
 }
 
@@ -601,6 +614,7 @@ fn validate_once_target(source: &str, dataflow: &str) -> anyhow::Result<()> {
         "abs" if dataflow == ABS_CPI_DATAFLOW_SLUG => Ok(()),
         "apra" if dataflow == APRA_QUARTERLY_DATAFLOW_SLUG => Ok(()),
         "rba" if dataflow == RBA_STAT_TABLES_DATAFLOW_SLUG => Ok(()),
+        "treasury" if dataflow == TREASURY_BUDGET_DATAFLOW_SLUG => Ok(()),
         "abs" => bail!(
             "unsupported dataflow `{dataflow}` for source `abs`; supported dataflow: {ABS_CPI_DATAFLOW_SLUG}"
         ),
@@ -609,6 +623,9 @@ fn validate_once_target(source: &str, dataflow: &str) -> anyhow::Result<()> {
         ),
         "rba" => bail!(
             "unsupported dataflow `{dataflow}` for source `rba`; supported dataflow: {RBA_STAT_TABLES_DATAFLOW_SLUG}"
+        ),
+        "treasury" => bail!(
+            "unsupported dataflow `{dataflow}` for source `treasury`; supported dataflow: {TREASURY_BUDGET_DATAFLOW_SLUG}"
         ),
         _ => unreachable!("source was validated above"),
     }
@@ -620,6 +637,7 @@ fn once_run_request(source: &str, dataflow: &str) -> anyhow::Result<RunRequest> 
         "abs" => ABS_CPI_DATAFLOW_ID,
         "apra" => APRA_QUARTERLY_DATAFLOW_ID,
         "rba" => RBA_STAT_TABLES_DATAFLOW_ID,
+        "treasury" => TREASURY_BUDGET_DATAFLOW_ID,
         _ => unreachable!("source was validated above"),
     };
     Ok(RunRequest {
@@ -662,8 +680,8 @@ fn job_run_request(kind: &JobKind, trace_parent: Option<&str>) -> anyhow::Result
 }
 
 fn validate_supported_source(source: &str) -> anyhow::Result<()> {
-    if !matches!(source, "abs" | "apra" | "rba") {
-        bail!("unsupported source `{source}`; supported sources: abs, apra, rba");
+    if !matches!(source, "abs" | "apra" | "rba" | "treasury") {
+        bail!("unsupported source `{source}`; supported sources: abs, apra, rba, treasury");
     }
     Ok(())
 }
@@ -678,8 +696,11 @@ fn validate_supported_dataflow_id(source: &str, dataflow_id: &str) -> anyhow::Re
     if source == "rba" && dataflow_id == RBA_STAT_TABLES_DATAFLOW_ID {
         return Ok(());
     }
+    if source == "treasury" && dataflow_id == TREASURY_BUDGET_DATAFLOW_ID {
+        return Ok(());
+    }
     bail!(
-        "unsupported dataflow `{dataflow_id}` for source `{source}`; supported dataflows: {ABS_CPI_DATAFLOW_ID}, {APRA_QUARTERLY_DATAFLOW_ID}, {RBA_STAT_TABLES_DATAFLOW_ID}"
+        "unsupported dataflow `{dataflow_id}` for source `{source}`; supported dataflows: {ABS_CPI_DATAFLOW_ID}, {APRA_QUARTERLY_DATAFLOW_ID}, {RBA_STAT_TABLES_DATAFLOW_ID}, {TREASURY_BUDGET_DATAFLOW_ID}"
     );
 }
 
@@ -838,7 +859,7 @@ mod tests {
             .expect_err("unsupported source should fail")
             .to_string();
         assert!(err.contains("unsupported source"));
-        assert!(err.contains("abs, apra, rba"));
+        assert!(err.contains("abs, apra, rba, treasury"));
     }
 
     #[test]
@@ -862,6 +883,18 @@ mod tests {
         assert_eq!(
             request.dataflow_id.as_ref(),
             Some(&DataflowId::new("apra.quarterly_statistics").unwrap())
+        );
+    }
+
+    #[test]
+    fn treasury_once_mode_resolves_budget_papers_dataflow() {
+        let request = once_run_request("treasury", "budget-papers")
+            .expect("Treasury budget papers are supported");
+
+        assert_eq!(request.source_id.as_str(), "treasury");
+        assert_eq!(
+            request.dataflow_id.as_ref(),
+            Some(&DataflowId::new("treasury.budget_papers").unwrap())
         );
     }
 

--- a/crates/bins/au-kpis-scheduler/src/main.rs
+++ b/crates/bins/au-kpis-scheduler/src/main.rs
@@ -31,9 +31,11 @@ const DEFAULT_TICK_MS: u64 = 1_000;
 const DEFAULT_ABS_INTERVAL_MS: u64 = 60 * 60 * 1_000;
 const DEFAULT_APRA_INTERVAL_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
 const DEFAULT_RBA_INTERVAL_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
+const DEFAULT_TREASURY_INTERVAL_MS: u64 = 24 * 60 * 60 * 1_000;
 const ABS_DISCOVERY_CRON: &str = "0 * * * *";
 const APRA_DISCOVERY_CRON: &str = "0 0 * * 1";
 const RBA_DISCOVERY_CRON: &str = "0 0 * * 1";
+const TREASURY_DISCOVERY_CRON: &str = "0 0 * * *";
 
 /// Command-line arguments for `au-kpis-scheduler`.
 #[derive(Debug, Parser)]
@@ -70,6 +72,14 @@ struct Cli {
         default_value_t = DEFAULT_RBA_INTERVAL_MS
     )]
     rba_interval_ms: u64,
+
+    /// Test/ops override for the Treasury discovery cadence.
+    #[arg(
+        long,
+        env = "AU_KPIS_SCHEDULER_TREASURY_INTERVAL_MS",
+        default_value_t = DEFAULT_TREASURY_INTERVAL_MS
+    )]
+    treasury_interval_ms: u64,
 
     #[command(subcommand)]
     command: Option<Command>,
@@ -201,6 +211,7 @@ async fn main() -> anyhow::Result<()> {
             Duration::from_millis(cli.abs_interval_ms),
             Duration::from_millis(cli.rba_interval_ms),
             Duration::from_millis(cli.apra_interval_ms),
+            Duration::from_millis(cli.treasury_interval_ms),
         ),
         worker_id: cli.worker_id.unwrap_or_else(default_worker_id),
     };
@@ -343,6 +354,7 @@ fn default_discovery_schedules(
     abs_interval: Duration,
     rba_interval: Duration,
     apra_interval: Duration,
+    treasury_interval: Duration,
 ) -> Vec<DiscoverySchedule> {
     vec![
         DiscoverySchedule {
@@ -362,6 +374,12 @@ fn default_discovery_schedules(
             cron_expression: APRA_DISCOVERY_CRON,
             emit_every: apra_interval,
             job: Job::discover(SourceId::new("apra").expect("static source id is valid")),
+        },
+        DiscoverySchedule {
+            id: "treasury-discovery",
+            cron_expression: TREASURY_DISCOVERY_CRON,
+            emit_every: treasury_interval,
+            job: Job::discover(SourceId::new("treasury").expect("static source id is valid")),
         },
     ]
 }
@@ -481,9 +499,10 @@ mod tests {
             Duration::from_secs(3600),
             Duration::from_secs(604_800),
             Duration::from_secs(604_800),
+            Duration::from_secs(86_400),
         );
 
-        assert_eq!(schedules.len(), 3);
+        assert_eq!(schedules.len(), 4);
         assert_eq!(schedules[0].id, "abs-discovery");
         assert_eq!(schedules[0].cron_expression, "0 * * * *");
         assert_eq!(schedules[0].emit_every, Duration::from_secs(3600));
@@ -504,6 +523,13 @@ mod tests {
         assert!(matches!(
             schedules[2].job.kind(),
             JobKind::Discover { source_id } if source_id.as_str() == "apra"
+        ));
+        assert_eq!(schedules[3].id, "treasury-discovery");
+        assert_eq!(schedules[3].cron_expression, "0 0 * * *");
+        assert_eq!(schedules[3].emit_every, Duration::from_secs(86_400));
+        assert!(matches!(
+            schedules[3].job.kind(),
+            JobKind::Discover { source_id } if source_id.as_str() == "treasury"
         ));
     }
 


### PR DESCRIPTION
Closes #52

## Summary

- Adds the Treasury Budget Paper No. 4 PDF adapter for discovery, fetch, and deterministic table parsing through `au-kpis-pdf-client`.
- Registers Treasury in ingestion once-mode and default ingestion adapter wiring.
- Adds a daily Treasury discovery schedule for the scheduler.
- Adds deterministic discovery, fetch, sidecar-contract, provenance, and `insta` snapshot coverage for three historical Budget Paper fixtures.

## Pass requirements

- [x] Watches the Treasury budget publications page relevant to the target budget papers
- [x] Downloads budget PDFs and stores them through the object-storage path
- [x] Extracts tables via the PDF sidecar through `au-kpis-pdf-client`
- [x] `insta` snapshots are committed for 3 historical budget-paper fixtures
- [x] License and attribution are populated
- [x] Integration coverage proves the adapter-sidecar contract on deterministic fixtures

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace`
- [x] `cargo test -p au-kpis-adapter-treasury`
- [x] `cargo test -p au-kpis-ingestion --bin au-kpis-ingestion`
- [x] `cargo test -p au-kpis-scheduler --bin au-kpis-scheduler`
- [x] `pnpm run lint`
- [x] `pnpm turbo run typecheck test`
- [x] `cargo deny check`
- [x] `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- [x] `pnpm audit --audit-level critical`
- [x] `gitleaks detect --source . --no-banner --redact --config .gitleaks.toml`
- [x] `gitleaks protect --staged --no-banner --redact --config .gitleaks.toml`

`cargo sqlx prepare --workspace` skipped: no SQL queries or migrations changed.
OpenAPI drift check skipped: no API handlers or schema surfaces changed.

## Spec impact

No Spec changes required.
