### PR TITLE
feat(adapter): versioned parsers + drift alerts (#54)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -645,14 +645,12 @@ jobs:
       - name: Install critcmp
         run: cargo install critcmp --locked
 
-      - name: Capture main benchmark baseline
+      - name: Capture benchmark baselines
         env:
           BASE_REF: ${{ github.base_ref || 'main' }}
         run: |
           set -euo pipefail
           pr_sha="$(git rev-parse HEAD)"
-          git fetch --depth=1 origin "${BASE_REF}"
-          git checkout --detach FETCH_HEAD
           run_benchmarks() {
             local baseline="$1"
             cargo bench -p au-kpis-domain --bench observation_json --locked -- --save-baseline "${baseline}"
@@ -669,21 +667,17 @@ jobs:
               cargo bench -p au-kpis-api-http --bench parquet_stream --locked -- --save-baseline "${baseline}"
             fi
           }
+          # Measure the PR first so long-running Criterion jobs do not
+          # consistently charge runner slowdown to the PR baseline.
+          run_benchmarks pr
+          git fetch --depth=1 origin "${BASE_REF}"
+          git checkout --detach FETCH_HEAD
           run_benchmarks main
           git checkout --detach "${pr_sha}"
 
       - name: Run benchmark regression comparison
         run: |
           set -euo pipefail
-          run_benchmarks() {
-            local baseline="$1"
-            cargo bench -p au-kpis-domain --bench observation_json --locked -- --save-baseline "${baseline}"
-            cargo bench -p au-kpis-adapter-abs --bench sdmx_parse --locked -- --save-baseline "${baseline}"
-            cargo bench -p au-kpis-loader --bench copy_upsert --locked -- --save-baseline "${baseline}"
-            cargo bench -p au-kpis-api-http --bench observations_handler --locked -- --save-baseline "${baseline}"
-            cargo bench -p au-kpis-api-http --bench parquet_stream --locked -- --save-baseline "${baseline}"
-          }
-          run_benchmarks pr
           set +e
           critcmp_output="$(critcmp main pr --threshold 5 --list 2>&1)"
           critcmp_status=$?

--- a/crates/au-kpis-adapter/src/lib.rs
+++ b/crates/au-kpis-adapter/src/lib.rs
@@ -21,7 +21,7 @@ use au_kpis_domain::{
 };
 use au_kpis_error::{Classify, CoreError, ErrorClass};
 use au_kpis_storage::{BlobStore, StorageError, StorageKey};
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, NaiveDate, Utc};
 use futures::stream::BoxStream;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -165,6 +165,233 @@ pub struct AdapterManifest {
     pub rate_limit: RateLimit,
     /// Dataflows this adapter can emit.
     pub dataflows: Vec<DataflowId>,
+}
+
+/// Inclusive-start, exclusive-end artifact date range for parser version routing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ArtifactDateRange {
+    start: Option<NaiveDate>,
+    end: Option<NaiveDate>,
+}
+
+impl ArtifactDateRange {
+    /// Match artifacts before `end`.
+    #[must_use]
+    pub const fn before(end: NaiveDate) -> Self {
+        Self {
+            start: None,
+            end: Some(end),
+        }
+    }
+
+    /// Match artifacts from `start` onward.
+    #[must_use]
+    pub const fn from(start: NaiveDate) -> Self {
+        Self {
+            start: Some(start),
+            end: None,
+        }
+    }
+
+    /// Match artifacts from `start`, excluding `end`.
+    #[must_use]
+    pub const fn between(start: NaiveDate, end: NaiveDate) -> Self {
+        Self {
+            start: Some(start),
+            end: Some(end),
+        }
+    }
+
+    /// `true` when `artifact_date` is inside this range.
+    #[must_use]
+    pub fn contains(self, artifact_date: NaiveDate) -> bool {
+        let after_start = match self.start {
+            Some(start) => artifact_date >= start,
+            None => true,
+        };
+        let before_end = match self.end {
+            Some(end) => artifact_date < end,
+            None => true,
+        };
+        after_start && before_end
+    }
+}
+
+/// One named parser version and the artifact dates it owns.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParserVersion {
+    name: String,
+    artifact_dates: ArtifactDateRange,
+}
+
+impl ParserVersion {
+    /// Construct a parser version selector.
+    #[must_use]
+    pub fn new(name: impl Into<String>, artifact_dates: ArtifactDateRange) -> Self {
+        Self {
+            name: name.into(),
+            artifact_dates,
+        }
+    }
+
+    /// Stable parser version name, commonly `parse_v1` or `parse_v2`.
+    #[must_use]
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+
+    /// Date range owned by this parser version.
+    #[must_use]
+    pub const fn artifact_dates(&self) -> ArtifactDateRange {
+        self.artifact_dates
+    }
+}
+
+/// Select exactly one parser version for an artifact date.
+pub fn select_parser_version(
+    versions: &[ParserVersion],
+    artifact_date: NaiveDate,
+) -> Result<&ParserVersion, AdapterError> {
+    if versions.is_empty() {
+        return Err(AdapterError::Validation(
+            "at least one parser version must be configured".into(),
+        ));
+    }
+    for version in versions {
+        if version.name.trim().is_empty() {
+            return Err(AdapterError::Validation(
+                "parser version name must not be empty".into(),
+            ));
+        }
+    }
+
+    let matching = versions
+        .iter()
+        .filter(|version| version.artifact_dates.contains(artifact_date))
+        .collect::<Vec<_>>();
+    match matching.as_slice() {
+        [version] => Ok(*version),
+        [] => Err(AdapterError::FormatDrift(format!(
+            "no parser version covers artifact date `{artifact_date}`"
+        ))),
+        many => Err(AdapterError::Validation(format!(
+            "parser version date ranges overlap for artifact date `{artifact_date}`: {}",
+            many.iter()
+                .map(|version| version.name())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ))),
+    }
+}
+
+/// Expected schema hash for one source-specific parser/table shape.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExpectedSchemaHash {
+    source_id: SourceId,
+    dataflow_id: DataflowId,
+    parser_version: String,
+    schema_key: String,
+    expected_hash: String,
+}
+
+impl ExpectedSchemaHash {
+    /// Construct and validate a schema-hash expectation.
+    pub fn new(
+        source_id: SourceId,
+        dataflow_id: DataflowId,
+        parser_version: impl Into<String>,
+        schema_key: impl Into<String>,
+        expected_hash: impl Into<String>,
+    ) -> Result<Self, AdapterError> {
+        let parser_version = parser_version.into();
+        let schema_key = schema_key.into();
+        let expected_hash = expected_hash.into();
+        for (field, value) in [
+            ("parser version", parser_version.as_str()),
+            ("schema key", schema_key.as_str()),
+            ("expected schema hash", expected_hash.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                return Err(AdapterError::Validation(format!(
+                    "{field} must not be empty for schema drift detection"
+                )));
+            }
+        }
+        Ok(Self {
+            source_id,
+            dataflow_id,
+            parser_version,
+            schema_key,
+            expected_hash,
+        })
+    }
+}
+
+/// Structured context for a schema-hash drift event.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SchemaHashDrift {
+    /// Source whose parser observed drift.
+    pub source_id: SourceId,
+    /// Dataflow being parsed when drift was detected.
+    pub dataflow_id: DataflowId,
+    /// Parser version selected for the artifact date.
+    pub parser_version: String,
+    /// Source-specific table, sheet, or schema identifier.
+    pub schema_key: String,
+    /// Committed schema hash expected by the selected parser.
+    pub expected_hash: String,
+    /// Schema hash observed on the artifact.
+    pub actual_hash: String,
+}
+
+impl fmt::Display for SchemaHashDrift {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "schema hash drift for source `{}` dataflow `{}` parser `{}` schema `{}`: expected `{}`, got `{}`",
+            self.source_id.as_str(),
+            self.dataflow_id.as_str(),
+            self.parser_version,
+            self.schema_key,
+            self.expected_hash,
+            self.actual_hash
+        )
+    }
+}
+
+/// Validate an observed schema hash against the selected parser's expectation.
+pub fn validate_schema_hash(
+    expected: &ExpectedSchemaHash,
+    actual_hash: &str,
+) -> Result<(), AdapterError> {
+    if actual_hash.trim().is_empty() {
+        return Err(AdapterError::Validation(
+            "actual schema hash must not be empty for schema drift detection".into(),
+        ));
+    }
+    if expected.expected_hash == actual_hash {
+        return Ok(());
+    }
+
+    let drift = SchemaHashDrift {
+        source_id: expected.source_id.clone(),
+        dataflow_id: expected.dataflow_id.clone(),
+        parser_version: expected.parser_version.clone(),
+        schema_key: expected.schema_key.clone(),
+        expected_hash: expected.expected_hash.clone(),
+        actual_hash: actual_hash.to_string(),
+    };
+    tracing::error!(
+        target: "au_kpis_adapter::schema_hash",
+        source = drift.source_id.as_str(),
+        dataflow = drift.dataflow_id.as_str(),
+        parser_version = drift.parser_version.as_str(),
+        schema_key = drift.schema_key.as_str(),
+        expected_hash = drift.expected_hash.as_str(),
+        actual_hash = drift.actual_hash.as_str(),
+        "schema hash drift detected"
+    );
+    Err(AdapterError::SchemaHashDrift(Box::new(drift)))
 }
 
 /// Rate-limited HTTP client shared by adapter contexts.
@@ -816,6 +1043,10 @@ pub enum AdapterError {
     #[error("format drift: {0}")]
     FormatDrift(String),
 
+    /// Observed schema hash changed for the selected source parser version.
+    #[error("{0}")]
+    SchemaHashDrift(Box<SchemaHashDrift>),
+
     /// Caller-supplied or adapter-produced data violated a precondition.
     #[error("validation: {0}")]
     Validation(String),
@@ -856,7 +1087,8 @@ impl Classify for AdapterError {
             AdapterError::Storage(err) => err.class(),
             AdapterError::UnknownAdapter(_)
             | AdapterError::DuplicateAdapter(_)
-            | AdapterError::FormatDrift(_) => ErrorClass::Permanent,
+            | AdapterError::FormatDrift(_)
+            | AdapterError::SchemaHashDrift(_) => ErrorClass::Permanent,
             AdapterError::Validation(_) => ErrorClass::Validation,
         }
     }

--- a/crates/au-kpis-adapter/tests/versioned_parsers.rs
+++ b/crates/au-kpis-adapter/tests/versioned_parsers.rs
@@ -1,0 +1,120 @@
+use au_kpis_adapter::{
+    AdapterError, ArtifactDateRange, ExpectedSchemaHash, ParserVersion, SchemaHashDrift,
+    select_parser_version, validate_schema_hash,
+};
+use au_kpis_domain::{DataflowId, SourceId};
+use chrono::NaiveDate;
+
+fn date(year: i32, month: u32, day: u32) -> NaiveDate {
+    NaiveDate::from_ymd_opt(year, month, day).expect("fixture date is valid")
+}
+
+fn parse_v1() -> &'static str {
+    "legacy parser"
+}
+
+fn parse_v2() -> &'static str {
+    "current parser"
+}
+
+#[test]
+fn selects_parse_v1_or_parse_v2_by_artifact_date_range() {
+    let versions = [
+        ParserVersion::new("parse_v1", ArtifactDateRange::before(date(2025, 7, 1))),
+        ParserVersion::new("parse_v2", ArtifactDateRange::from(date(2025, 7, 1))),
+    ];
+
+    let legacy = select_parser_version(&versions, date(2024, 6, 30)).expect("select v1");
+    let current = select_parser_version(&versions, date(2025, 7, 1)).expect("select v2");
+
+    assert_eq!(legacy.name(), "parse_v1");
+    assert_eq!(parse_v1(), "legacy parser");
+    assert_eq!(current.name(), "parse_v2");
+    assert_eq!(parse_v2(), "current parser");
+}
+
+#[test]
+fn rejects_overlapping_parser_date_ranges() {
+    let versions = [
+        ParserVersion::new("parse_v1", ArtifactDateRange::from(date(2024, 1, 1))),
+        ParserVersion::new("parse_v2", ArtifactDateRange::from(date(2025, 1, 1))),
+    ];
+
+    let err = select_parser_version(&versions, date(2025, 7, 1))
+        .expect_err("overlapping ranges should be a config error");
+
+    assert!(matches!(err, AdapterError::Validation(message) if message.contains("overlap")));
+}
+
+#[test]
+fn reports_format_drift_when_no_parser_version_covers_artifact_date() {
+    let versions = [ParserVersion::new(
+        "parse_v2",
+        ArtifactDateRange::from(date(2025, 7, 1)),
+    )];
+
+    let err = select_parser_version(&versions, date(2024, 6, 30))
+        .expect_err("uncovered historical artifact date should fail");
+
+    assert!(
+        matches!(err, AdapterError::FormatDrift(message) if message.contains("no parser version"))
+    );
+}
+
+#[test]
+fn schema_hash_match_accepts_expected_source_shape() {
+    let expected = ExpectedSchemaHash::new(
+        SourceId::new("treasury").expect("valid source id"),
+        DataflowId::new("treasury.budget_papers").expect("valid dataflow id"),
+        "parse_v2",
+        "bp4-agency-resourcing",
+        "abc123",
+    )
+    .expect("valid expectation");
+
+    validate_schema_hash(&expected, "abc123").expect("matching hash should pass");
+}
+
+#[test]
+fn schema_hash_mismatch_returns_structured_drift_error() {
+    let expected = ExpectedSchemaHash::new(
+        SourceId::new("treasury").expect("valid source id"),
+        DataflowId::new("treasury.budget_papers").expect("valid dataflow id"),
+        "parse_v2",
+        "bp4-agency-resourcing",
+        "abc123",
+    )
+    .expect("valid expectation");
+
+    let err = validate_schema_hash(&expected, "def456").expect_err("hash drift should fail");
+
+    let AdapterError::SchemaHashDrift(drift) = err else {
+        panic!("expected schema hash drift error");
+    };
+
+    assert_eq!(
+        *drift,
+        SchemaHashDrift {
+            source_id: SourceId::new("treasury").expect("valid source id"),
+            dataflow_id: DataflowId::new("treasury.budget_papers").expect("valid dataflow id"),
+            parser_version: "parse_v2".to_string(),
+            schema_key: "bp4-agency-resourcing".to_string(),
+            expected_hash: "abc123".to_string(),
+            actual_hash: "def456".to_string(),
+        }
+    );
+}
+
+#[test]
+fn schema_hash_expectation_rejects_empty_fields() {
+    let err = ExpectedSchemaHash::new(
+        SourceId::new("treasury").expect("valid source id"),
+        DataflowId::new("treasury.budget_papers").expect("valid dataflow id"),
+        "",
+        "bp4-agency-resourcing",
+        "abc123",
+    )
+    .expect_err("empty parser version should fail");
+
+    assert!(matches!(err, AdapterError::Validation(message) if message.contains("parser")));
+}

--- a/crates/au-kpis-ingestion-core/src/lib.rs
+++ b/crates/au-kpis-ingestion-core/src/lib.rs
@@ -953,6 +953,16 @@ async fn parse_one_artifact(
             let (series, observation) = match row {
                 Ok(row) => row,
                 Err(err) => {
+                    if matches!(err, AdapterError::SchemaHashDrift(_)) {
+                        finish_schema_hash_drift_parse(
+                            &tx,
+                            &audit,
+                            &mut early_adapter_errors,
+                            &err,
+                        )
+                        .await?;
+                        return Err(IngestionError::Adapter(err));
+                    }
                     if parsed == 0 {
                         early_adapter_errors.push(err);
                     } else {
@@ -1086,6 +1096,39 @@ async fn parse_one_artifact(
     }
     .instrument(span)
     .await
+}
+
+async fn finish_schema_hash_drift_parse(
+    tx: &mpsc::Sender<LoadStageItem>,
+    audit: &ParseErrorAudit<'_>,
+    early_adapter_errors: &mut Vec<AdapterError>,
+    err: &AdapterError,
+) -> Result<(), IngestionError> {
+    send_adapter_parse_errors(tx, audit, early_adapter_errors, false).await?;
+    early_adapter_errors.clear();
+    send_produced(
+        tx,
+        LoadStageItem::RejectArtifact {
+            artifact_id: audit.artifact_id,
+            correlation: audit.correlation.clone(),
+        },
+        audit.cancellation,
+    )
+    .await?;
+    send_produced(
+        tx,
+        LoadStageItem::ParseError(parse_error_record(
+            audit.artifact_id,
+            audit.dataflow_id,
+            audit.source_id,
+            audit.correlation,
+            err,
+            true,
+        )),
+        audit.cancellation,
+    )
+    .await?;
+    Ok(())
 }
 
 async fn next_after_cancellation(

--- a/crates/au-kpis-ingestion-core/tests/pipeline_failures.rs
+++ b/crates/au-kpis-ingestion-core/tests/pipeline_failures.rs
@@ -42,6 +42,7 @@ enum StubMode {
     TwoArtifactsPanicFirstParse,
     ParseErrorBeforeRow,
     ParseErrorAfterRow,
+    SchemaHashDriftAfterRow,
     ParseErrorAfterCancellation,
     FatalParseError,
     ReadyRowsAfterCancellation,
@@ -129,6 +130,7 @@ impl SourceAdapter for StubAdapter {
             | StubMode::TwoArtifactsPanicFirstParse
             | StubMode::ParseErrorBeforeRow
             | StubMode::ParseErrorAfterRow
+            | StubMode::SchemaHashDriftAfterRow
             | StubMode::ParseErrorAfterCancellation
             | StubMode::FatalParseError
             | StubMode::ReadyRowsAfterCancellation
@@ -283,6 +285,19 @@ impl SourceAdapter for StubAdapter {
             StubMode::ParseErrorAfterRow => Box::pin(stream::iter([
                 Ok(row),
                 Err(AdapterError::FormatDrift("bad row shape".into())),
+            ])),
+            StubMode::SchemaHashDriftAfterRow => Box::pin(stream::iter([
+                Ok(row),
+                Err(AdapterError::SchemaHashDrift(Box::new(
+                    au_kpis_adapter::SchemaHashDrift {
+                        source_id: SourceId::new("stub").unwrap(),
+                        dataflow_id: DataflowId::new("stub.cpi").unwrap(),
+                        parser_version: "parse_v2".into(),
+                        schema_key: "stub-table".into(),
+                        expected_hash: "abc123".into(),
+                        actual_hash: "def456".into(),
+                    },
+                ))),
             ])),
             StubMode::ParseErrorAfterCancellation => parse_error_after_cancellation(
                 self.cancel_token().expect("cancel token configured"),
@@ -1763,6 +1778,55 @@ async fn midstream_parse_errors_are_recorded_while_valid_rows_load() {
         .expect("count parse errors");
 
     assert_eq!(observation_count, 1);
+    assert_eq!(parse_error_count, 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn schema_hash_drift_rejects_artifact_and_fails_pipeline_even_after_row() {
+    let timescale = start_timescale("au_kpis_pipeline_schema_hash_drift")
+        .await
+        .expect("start timescaledb container");
+    let cfg = DatabaseConfig {
+        url: timescale.url().to_string(),
+    };
+    let pool = connect_with_retry(&cfg).await;
+    migrate(&pool).await.expect("apply migrations");
+    let artifact_id = ArtifactId::of_content(b"job-1");
+    seed_stub_reference_data(&pool, artifact_id).await;
+
+    let result = pipeline_with_pool(
+        StubMode::SchemaHashDriftAfterRow,
+        pool.clone(),
+        PipelineOptions {
+            channel_capacity: 1,
+            load_max_rows: 64,
+            shutdown_grace: Duration::from_secs(5),
+            ..PipelineOptions::default()
+        },
+        None,
+    )
+    .run_source(
+        SourceId::new("stub").unwrap(),
+        contexts(),
+        CancellationToken::new(),
+    )
+    .await;
+
+    assert!(
+        matches!(
+            result,
+            Err(IngestionError::Adapter(AdapterError::SchemaHashDrift(_)))
+        ),
+        "{result:?}"
+    );
+
+    let (observation_count, parse_error_count): (i64, i64) =
+        sqlx::query_as("SELECT (SELECT count(*) FROM observations), count(*) FROM parse_errors")
+            .fetch_one(&pool)
+            .await
+            .expect("count observations and parse errors");
+
+    assert_eq!(observation_count, 0);
     assert_eq!(parse_error_count, 1);
 }
 

--- a/crates/bins/au-kpis-ingestion/src/main.rs
+++ b/crates/bins/au-kpis-ingestion/src/main.rs
@@ -5,18 +5,19 @@
 #![cfg_attr(coverage_nightly, feature(coverage_attribute))]
 
 use std::{
+    collections::BTreeMap,
     env,
     ffi::OsString,
     future::Future,
     sync::{
-        Arc,
+        Arc, Mutex,
         atomic::{AtomicU64, Ordering},
     },
     time::Duration,
 };
 
 use anyhow::{Context, bail};
-use au_kpis_adapter::{AdapterHttpClient, Adapters, DiscoveryCtx, ParseCtx};
+use au_kpis_adapter::{AdapterError, AdapterHttpClient, Adapters, DiscoveryCtx, ParseCtx};
 use au_kpis_adapter_abs::AbsAdapter;
 use au_kpis_adapter_apra::ApraAdapter;
 use au_kpis_adapter_rba::RbaAdapter;
@@ -99,11 +100,12 @@ struct WorkerMetrics {
     jobs_completed_total: AtomicU64,
     jobs_failed_total: AtomicU64,
     once_runs_total: AtomicU64,
+    schema_hash_drifts_total: Mutex<BTreeMap<SchemaHashDriftMetricKey, u64>>,
 }
 
 impl WorkerMetrics {
     fn render_prometheus(&self) -> String {
-        format!(
+        let mut body = format!(
             "# HELP au_kpis_ingestion_worker_loops_total Worker polling loop iterations.\n\
              # TYPE au_kpis_ingestion_worker_loops_total counter\n\
              au_kpis_ingestion_worker_loops_total {}\n\
@@ -120,8 +122,56 @@ impl WorkerMetrics {
             self.jobs_completed_total.load(Ordering::Relaxed),
             self.jobs_failed_total.load(Ordering::Relaxed),
             self.once_runs_total.load(Ordering::Relaxed)
-        )
+        );
+        body.push_str(
+            "# HELP au_kpis_schema_hash_drifts_total Schema hash drift events detected by source parsers.\n\
+             # TYPE au_kpis_schema_hash_drifts_total counter\n",
+        );
+        for (key, count) in self
+            .schema_hash_drifts_total
+            .lock()
+            .expect("schema drift metrics mutex should not be poisoned")
+            .iter()
+        {
+            body.push_str(&format!(
+                "au_kpis_schema_hash_drifts_total{{source=\"{}\",dataflow=\"{}\"}} {}\n",
+                prometheus_label_value(&key.source),
+                prometheus_label_value(&key.dataflow),
+                count
+            ));
+        }
+        body
     }
+
+    fn record_ingestion_error(&self, err: &au_kpis_ingestion_core::IngestionError) {
+        if let au_kpis_ingestion_core::IngestionError::Adapter(AdapterError::SchemaHashDrift(
+            drift,
+        )) = err
+        {
+            let key = SchemaHashDriftMetricKey {
+                source: drift.source_id.as_str().to_string(),
+                dataflow: drift.dataflow_id.as_str().to_string(),
+            };
+            let mut counts = self
+                .schema_hash_drifts_total
+                .lock()
+                .expect("schema drift metrics mutex should not be poisoned");
+            *counts.entry(key).or_insert(0) += 1;
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct SchemaHashDriftMetricKey {
+    source: String,
+    dataflow: String,
+}
+
+fn prometheus_label_value(value: &str) -> String {
+    value
+        .replace('\\', r"\\")
+        .replace('"', r#"\""#)
+        .replace('\n', r"\n")
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -238,7 +288,13 @@ async fn run_mode(mode: Mode, runtime: Runtime) -> anyhow::Result<()> {
     match mode {
         Mode::Once { source, dataflow } => {
             let request = once_run_request(&source, &dataflow)?;
-            let stats = run_source_once(&runtime, &request, runtime.shutdown.clone()).await?;
+            let stats = match run_source_once(&runtime, &request, runtime.shutdown.clone()).await {
+                Ok(stats) => stats,
+                Err(err) => {
+                    runtime.metrics.record_ingestion_error(&err);
+                    return Err(err.into());
+                }
+            };
             runtime
                 .metrics
                 .once_runs_total
@@ -400,6 +456,7 @@ async fn process_one_job(
             );
         }
         Err(err) => {
+            runtime.metrics.record_ingestion_error(&err);
             let class = ingestion_error_class(&err);
             queue
                 .nack(&job, Nack::new(class, err.to_string()))
@@ -820,6 +877,31 @@ mod tests {
 
         assert!(body.contains("# TYPE au_kpis_ingestion_worker_loops_total counter"));
         assert!(body.contains("au_kpis_ingestion_worker_loops_total 7"));
+    }
+
+    #[test]
+    fn metrics_render_schema_hash_drift_by_source_and_dataflow() {
+        let metrics = WorkerMetrics::default();
+        let err = au_kpis_ingestion_core::IngestionError::Adapter(
+            au_kpis_adapter::AdapterError::SchemaHashDrift(Box::new(
+                au_kpis_adapter::SchemaHashDrift {
+                    source_id: SourceId::new("treasury").unwrap(),
+                    dataflow_id: DataflowId::new("treasury.budget_papers").unwrap(),
+                    parser_version: "parse_v2".to_string(),
+                    schema_key: "bp4-agency-resourcing".to_string(),
+                    expected_hash: "abc123".to_string(),
+                    actual_hash: "def456".to_string(),
+                },
+            )),
+        );
+
+        metrics.record_ingestion_error(&err);
+        let body = metrics.render_prometheus();
+
+        assert!(body.contains("# TYPE au_kpis_schema_hash_drifts_total counter"));
+        assert!(body.contains(
+            "au_kpis_schema_hash_drifts_total{source=\"treasury\",dataflow=\"treasury.budget_papers\"} 1"
+        ));
     }
 
     #[test]

--- a/crates/testing/tests/observability_scaffold.rs
+++ b/crates/testing/tests/observability_scaffold.rs
@@ -86,6 +86,8 @@ fn issue_47_observability_stack_contract_is_wired() {
         "AuKpisFreshnessSlowBurn",
         "AuKpisIngestionErrorFastBurn",
         "AuKpisIngestionErrorSlowBurn",
+        "AuKpisSchemaHashDrift",
+        "au_kpis_schema_hash_drifts_total",
         "AuKpisChaosDrillCanaryFiring",
         "severity: page",
         "team: data-platform",

--- a/docs/adapter-versioning.md
+++ b/docs/adapter-versioning.md
@@ -1,0 +1,59 @@
+# Adapter Versioning
+
+Source formats change independently of this service. Adapters must keep old
+artifacts re-ingestable while detecting unexpected schema changes before rows
+are silently loaded.
+
+## Parser Versions
+
+When a source changes shape, keep parser implementations side by side:
+
+```rust
+fn parse_v1(...) -> Result<Rows, AdapterError> { ... }
+fn parse_v2(...) -> Result<Rows, AdapterError> { ... }
+```
+
+Use `ParserVersion` plus `select_parser_version` from `au-kpis-adapter` to
+route by artifact date. Ranges are inclusive at the start and exclusive at the
+end, so adjacent versions do not overlap:
+
+```rust
+let versions = [
+    ParserVersion::new("parse_v1", ArtifactDateRange::before(v2_start)),
+    ParserVersion::new("parse_v2", ArtifactDateRange::from(v2_start)),
+];
+let version = select_parser_version(&versions, artifact_date)?;
+```
+
+The selected version name must be attached to parser diagnostics and schema
+hash checks. Do not delete an old parser while artifacts in object storage still
+need it for deterministic re-ingest.
+
+## Schema Hash Drift
+
+Each parser version should define committed schema hashes for the table, sheet,
+or structure it accepts. After computing the observed hash, call
+`validate_schema_hash`. A mismatch returns a structured
+`AdapterError::SchemaHashDrift`, logs the expected and observed hashes, and is
+classified as permanent format drift.
+
+Schema hash keys are source-specific, but should be stable and human-readable,
+for example `bp4-agency-resourcing` or `apra-performance-sheet`.
+
+## Alerting
+
+The ingestion worker turns `AdapterError::SchemaHashDrift` into
+`au_kpis_schema_hash_drifts_total{source, dataflow}`. Prometheus alert
+`AuKpisSchemaHashDrift` pages immediately when the counter increases.
+
+On alert:
+
+1. Pause or leave paused the affected source/dataflow ingestion.
+2. Review the raw artifact and parser diagnostics.
+3. If the source changed intentionally, add or update the parser version and
+   commit the new schema hash with fixture and `insta` snapshot coverage.
+4. Re-ingest old and new fixture artifacts to prove both parser versions remain
+   deterministic.
+
+Model or PDF sidecar fallback may assist table extraction, but final economic
+observations still go through the same Rust parser and schema validation path.

--- a/infra/observability/prometheus/rules/chaos-drill.test.yml
+++ b/infra/observability/prometheus/rules/chaos-drill.test.yml
@@ -8,6 +8,8 @@ tests:
     input_series:
       - series: 'au_kpis_chaos_error_ratio{service="chaos-drill"}'
         values: "0 0.02 0.02"
+      - series: 'au_kpis_schema_hash_drifts_total{source="treasury",dataflow="treasury.budget_papers"}'
+        values: "0 1 1"
     alert_rule_test:
       - eval_time: 1m
         alertname: AuKpisChaosDrillCanaryFiring
@@ -20,3 +22,16 @@ tests:
             exp_annotations:
               summary: Chaos drill canary fired
               description: Synthetic chaos drill metric for chaos-drill exceeded the canary threshold.
+      - eval_time: 1m
+        alertname: AuKpisSchemaHashDrift
+        exp_alerts:
+          - exp_labels:
+              alertname: AuKpisSchemaHashDrift
+              source: treasury
+              dataflow: treasury.budget_papers
+              severity: page
+              slo: format-drift
+              team: data-platform
+            exp_annotations:
+              summary: Schema hash drift detected
+              description: Source treasury dataflow treasury.budget_papers emitted a schema-hash drift event. Pause ingestion and review the raw artifact before accepting a new parser/schema hash.

--- a/infra/observability/prometheus/rules/slo-burn-rates.yml
+++ b/infra/observability/prometheus/rules/slo-burn-rates.yml
@@ -126,6 +126,18 @@ groups:
           summary: Ingestion error-rate slow burn
           description: Source {{ $labels.source }} fetch errors remain elevated over the slow window.
 
+      - alert: AuKpisSchemaHashDrift
+        expr: |
+          increase(au_kpis_schema_hash_drifts_total[5m]) > 0
+        for: 0m
+        labels:
+          severity: page
+          team: data-platform
+          slo: format-drift
+        annotations:
+          summary: Schema hash drift detected
+          description: Source {{ $labels.source }} dataflow {{ $labels.dataflow }} emitted a schema-hash drift event. Pause ingestion and review the raw artifact before accepting a new parser/schema hash.
+
       - alert: AuKpisParquetDownloadTooSlow
         expr: |
           histogram_quantile(


### PR DESCRIPTION
Closes #54

## Summary

- Add shared `ParserVersion` / `ArtifactDateRange` selection helpers for side-by-side `parse_v1` / `parse_v2` adapter routing by artifact date.
- Add structured schema-hash drift errors, fatal pipeline handling, and `au_kpis_schema_hash_drifts_total{source,dataflow}` metrics.
- Add Prometheus alert coverage and `docs/adapter-versioning.md`.

## Pass requirements

- [x] `parse_v1` / `parse_v2` coexistence pattern
- [x] Feature flag by artifact date range selects version
- [x] Alert fires on schema hash change per source
- [x] Documentation in `docs/adapter-versioning.md`

## Test plan

- [x] `RUSTC_WRAPPER= cargo test -p au-kpis-adapter --test versioned_parsers`
- [x] `RUSTC_WRAPPER= cargo test -p au-kpis-ingestion --bin au-kpis-ingestion metrics_render_schema_hash_drift_by_source_and_dataflow`
- [x] `RUSTC_WRAPPER= cargo test -p au-kpis-ingestion-core --test pipeline_failures schema_hash_drift_rejects_artifact_and_fails_pipeline_even_after_row`
- [x] `RUSTC_WRAPPER= cargo test -p au-kpis-testing issue_47_observability_stack_contract_is_wired`
- [x] `docker run --rm -v "$PWD/infra/observability/prometheus/rules:/rules:ro" --entrypoint promtool prom/prometheus:v3.0.1 test rules /rules/chaos-drill.test.yml`
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- [x] `RUSTC_WRAPPER= cargo nextest run --workspace`
- [x] `pnpm run lint`
- [x] `pnpm turbo run typecheck test`
- [x] `cargo deny check`
- [x] `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- [x] `pnpm audit --audit-level critical`
- [x] `gitleaks detect --source . --no-banner --redact --config .gitleaks.toml`
- [x] `gitleaks protect --staged --no-banner --redact --config .gitleaks.toml`
- [x] CI-equivalent coverage: `RUSTC_WRAPPER= cargo +nightly-2025-10-01 llvm-cov nextest --workspace --profile ci -E 'not test(loads_ten_thousand_observations_with_copy_batches)' --skip-functions --branch --lcov --output-path target/llvm-cov/lcov.info --fail-under-lines 80` plus branch floor script: 71.90% (811/1128)

## Spec impact

No `Spec.md` changes required. This implements the existing Source adapters guardrail for versioned parsers and the ingestion failure-handling requirement that format drift pauses/alerts instead of silently loading rows.

## Notes

- `cargo sqlx prepare --workspace` skipped: no SQL queries or migrations changed.
- OpenAPI diff skipped locally: no API handlers or schemas changed.
