### PR TITLE
test(ci): cargo-mutants weekly (#65)

### DIFF
--- a/.github/workflows/mutation-weekly.yml
+++ b/.github/workflows/mutation-weekly.yml
@@ -1,0 +1,142 @@
+name: Mutation Testing
+
+on:
+  schedule:
+    - cron: "0 6 * * 0"
+  workflow_dispatch:
+
+concurrency:
+  group: cargo-mutants-weekly
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_RUSTC_WRAPPER: sccache
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_CACHE_SIZE: 2G
+  MUTATION_MIN_SCORE: "70"
+
+jobs:
+  cargo-mutants:
+    name: cargo-mutants weekly
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest --version 0.9.100 --locked
+
+      - name: Install cargo-mutants
+        run: cargo install cargo-mutants --version 26.0.0 --locked
+
+      - name: Run cargo-mutants
+        id: mutants
+        continue-on-error: true
+        run: |
+          set -euo pipefail
+          mkdir -p target/mutation
+          cargo mutants --workspace \
+            --test-workspace true \
+            --test-tool nextest \
+            --jobs 2 \
+            --minimum-test-timeout 120 \
+            --timeout-multiplier 3 \
+            --output target/mutation \
+            --no-times \
+            --colors never \
+            -- --profile ci
+
+      - name: Build mutation report
+        id: report
+        if: always()
+        run: |
+          set +e
+          python3 tools/ci/mutation_report.py \
+            --out-dir target/mutation/mutants.out \
+            --min-score "${MUTATION_MIN_SCORE}" \
+            --markdown target/mutation/report.md \
+            --json target/mutation/mutation-report.json \
+            --issue-body target/mutation/add-test-issue.md
+          report_status="$?"
+          echo "report_status=${report_status}" >> "${GITHUB_OUTPUT}"
+          python3 - <<'PY' >> "${GITHUB_OUTPUT}"
+          import json
+          from pathlib import Path
+
+          path = Path("target/mutation/mutation-report.json")
+          if not path.is_file():
+              print("missed=0")
+              print("score=0")
+              print("passed=false")
+          else:
+              report = json.loads(path.read_text())
+              print(f"missed={report['missed'] + report['timeout']}")
+              print(f"score={report['score']}")
+              print(f"passed={str(report['passed']).lower()}")
+          PY
+
+      - name: Create add test issue for surviving cargo-mutants
+        if: always() && steps.report.outputs.missed != '0'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const fs = require('fs')
+            const report = JSON.parse(fs.readFileSync('target/mutation/mutation-report.json', 'utf8'))
+            const body = [
+              `<!-- cargo-mutants-survivors:${context.runId} -->`,
+              fs.readFileSync('target/mutation/add-test-issue.md', 'utf8'),
+              '',
+              `Report artifact: cargo-mutants-report from workflow run ${context.runId}`,
+            ].join('\n')
+            const { owner, repo } = context.repo
+            try {
+              await github.rest.issues.createLabel({
+                owner,
+                repo,
+                name: 'add test',
+                color: 'fef2c0',
+                description: 'Follow-up test coverage requested by mutation testing',
+              })
+            } catch (error) {
+              if (error.status !== 422) throw error
+            }
+            await github.rest.issues.create({
+              owner,
+              repo,
+              title: `test: add coverage for surviving cargo-mutants results (${new Date().toISOString().slice(0, 10)})`,
+              body,
+              labels: ['type:test', 'add test'],
+            })
+            core.info(`Created add test issue for ${report.missed + report.timeout} surviving cargo-mutants results.`)
+
+      - name: Upload cargo-mutants report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-mutants-report
+          path: |
+            target/mutation/mutants.out
+            target/mutation/report.md
+            target/mutation/mutation-report.json
+            target/mutation/add-test-issue.md
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: Enforce mutation score
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.report.outputs.report_status }}" != "0" ]; then
+            echo "cargo-mutants mutation score was below ${MUTATION_MIN_SCORE}% or report generation failed." >&2
+            exit 1
+          fi

--- a/crates/testing/tests/mutation_scaffold.rs
+++ b/crates/testing/tests/mutation_scaffold.rs
@@ -1,0 +1,205 @@
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("testing crate lives under crates/testing")
+}
+
+#[test]
+fn issue_65_cargo_mutants_weekly_contract_is_wired() {
+    let root = repo_root();
+    let workflow = fs::read_to_string(root.join(".github/workflows/mutation-weekly.yml"))
+        .expect("read mutation workflow");
+    let report_script = root.join("tools/ci/mutation_report.py");
+    assert!(
+        report_script.is_file(),
+        "issue #65 should provide a cargo-mutants report script"
+    );
+    let ci_docs = fs::read_to_string(root.join("docs/ci.md")).expect("read CI docs");
+    let testing_docs = fs::read_to_string(root.join("docs/testing.md")).expect("read testing docs");
+
+    for expected in [
+        "cron: \"0 6 * * 0\"",
+        "cargo install cargo-mutants --version 26.0.0 --locked",
+        "cargo mutants --workspace",
+        "--test-tool nextest",
+        "--test-workspace true",
+        "--minimum-test-timeout 120",
+        "MUTATION_MIN_SCORE: \"70\"",
+        "tools/ci/mutation_report.py",
+        "actions/upload-artifact@v4",
+        "cargo-mutants-report",
+        "retention-days: 30",
+        "actions/github-script@v8",
+        "add test",
+        "surviving cargo-mutants",
+    ] {
+        assert!(
+            workflow.contains(expected),
+            "weekly cargo-mutants workflow should contain `{expected}`"
+        );
+    }
+
+    assert!(
+        ci_docs.contains("Weekly cargo-mutants")
+            && ci_docs.contains("mutation score")
+            && ci_docs.contains("add test"),
+        "CI docs should document the weekly mutation workflow and follow-up issues"
+    );
+    assert!(
+        testing_docs.contains("cargo mutants --workspace")
+            && testing_docs.contains("70%")
+            && testing_docs.contains("cargo-mutants-report"),
+        "testing docs should document local mutation testing and retained reports"
+    );
+}
+
+#[test]
+fn mutation_report_scores_and_lists_surviving_mutants() {
+    let root = repo_root();
+    let temp_dir = temp_fixture_dir("mutation-report");
+    let mutants_out = temp_dir.join("mutants.out");
+    fs::create_dir_all(&mutants_out).expect("create mutants output fixture");
+    fs::create_dir_all(mutants_out.join("diff")).expect("create diff fixture dir");
+    fs::write(
+        mutants_out.join("diff/survivor.diff"),
+        "--- original\n+++ mutant\n",
+    )
+    .expect("write survivor diff");
+    fs::write(
+        mutants_out.join("outcomes.json"),
+        r#"{
+  "outcomes": [
+    {
+      "scenario": {
+        "Mutant": {
+          "package": "au-kpis-error",
+          "file": "crates/au-kpis-error/src/lib.rs",
+          "function": { "function_name": "ErrorClass::is_retryable" },
+          "span": { "start": { "line": 68, "column": 9 } },
+          "replacement": "true"
+        }
+      },
+      "summary": "CaughtMutant"
+    },
+    {
+      "scenario": {
+        "Mutant": {
+          "package": "au-kpis-error",
+          "file": "crates/au-kpis-error/src/lib.rs",
+          "function": { "function_name": "Classify::retry_after" },
+          "span": { "start": { "line": 85, "column": 9 } },
+          "replacement": "Some(Default::default())"
+        }
+      },
+      "summary": "CaughtMutant"
+    },
+    {
+      "scenario": {
+        "Mutant": {
+          "package": "au-kpis-error",
+          "file": "crates/au-kpis-error/src/lib.rs",
+          "function": { "function_name": "CoreError::class" },
+          "span": { "start": { "line": 122, "column": 9 } },
+          "replacement": "Default::default()"
+        }
+      },
+      "summary": "CaughtMutant"
+    },
+    {
+      "scenario": {
+        "Mutant": {
+          "package": "au-kpis-error",
+          "file": "crates/au-kpis-error/src/lib.rs",
+          "function": { "function_name": "Classify::retry_after" },
+          "span": { "start": { "line": 85, "column": 9 } },
+          "replacement": "None"
+        }
+      },
+      "summary": "MissedMutant",
+      "diff_path": "diff/survivor.diff"
+    },
+    {
+      "scenario": {
+        "Mutant": {
+          "package": "au-kpis-error",
+          "file": "crates/au-kpis-error/src/lib.rs",
+          "function": { "function_name": "unviable" },
+          "span": { "start": { "line": 1, "column": 1 } },
+          "replacement": "Default::default()"
+        }
+      },
+      "summary": "Unviable"
+    }
+  ]
+}"#,
+    )
+    .expect("write outcomes fixture");
+
+    let markdown = temp_dir.join("report.md");
+    let json = temp_dir.join("report.json");
+    let issue = temp_dir.join("issue.md");
+    let status = Command::new("python3")
+        .current_dir(root)
+        .arg("tools/ci/mutation_report.py")
+        .arg("--out-dir")
+        .arg(&mutants_out)
+        .arg("--min-score")
+        .arg("70")
+        .arg("--markdown")
+        .arg(&markdown)
+        .arg("--json")
+        .arg(&json)
+        .arg("--issue-body")
+        .arg(&issue)
+        .status()
+        .expect("run mutation report script");
+
+    assert!(status.success(), "75% score should meet a 70% threshold");
+    let markdown = fs::read_to_string(markdown).expect("read markdown report");
+    assert!(markdown.contains("Mutation score: 75.00%"));
+    assert!(markdown.contains("Surviving Mutants"));
+    assert!(markdown.contains("crates/au-kpis-error/src/lib.rs:85"));
+
+    let json = fs::read_to_string(json).expect("read json report");
+    assert!(json.contains(r#""score": 75.0"#));
+    assert!(json.contains(r#""missed": 1"#));
+
+    let issue = fs::read_to_string(issue).expect("read issue body");
+    assert!(issue.contains("Follow-up add test work"));
+    assert!(issue.contains("Classify::retry_after"));
+
+    let failing = Command::new("python3")
+        .current_dir(root)
+        .arg("tools/ci/mutation_report.py")
+        .arg("--out-dir")
+        .arg(&mutants_out)
+        .arg("--min-score")
+        .arg("80")
+        .arg("--markdown")
+        .arg(temp_dir.join("failing.md"))
+        .arg("--json")
+        .arg(temp_dir.join("failing.json"))
+        .arg("--issue-body")
+        .arg(temp_dir.join("failing-issue.md"))
+        .status()
+        .expect("run failing mutation report script");
+    assert!(!failing.success(), "75% score should fail an 80% threshold");
+
+    let _ = fs::remove_dir_all(temp_dir);
+}
+
+fn temp_fixture_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -56,6 +56,19 @@ Adding the `perf:regression` label to a PR runs the same staging load suite,
 downloads the latest successful scheduled summary when available, and posts a
 `k6 load comparison` PR comment through `actions/github-script`.
 
+## Weekly cargo-mutants
+
+`.github/workflows/mutation-weekly.yml` runs at `0 6 * * 0` on `main`. The job
+installs `cargo-mutants` and `cargo-nextest`, then runs `cargo mutants
+--workspace` with `--test-workspace true` so each mutant is checked against the
+full workspace test suite. The mutation score threshold is 70%.
+
+The workflow always writes a Markdown report, machine-readable JSON, and the raw
+`mutants.out` directory to the retained `cargo-mutants-report` artifact. If any
+mutants survive or time out, `tools/ci/mutation_report.py` generates a
+follow-up body and the workflow creates an `add test` issue that lists the
+surviving cargo-mutants locations and replacements.
+
 ## Contract fuzzing
 
 The pull request `Contract (schemathesis)` job starts the docker-compose API

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -17,6 +17,22 @@ cargo llvm-cov nextest --workspace --profile ci --lcov --output-path target/llvm
 # Snapshot verification
 cargo insta test --workspace --check
 
+# Weekly-style mutation score report, normally run by GitHub Actions
+cargo mutants --workspace \
+  --test-workspace true \
+  --test-tool nextest \
+  --minimum-test-timeout 120 \
+  --output target/mutation \
+  --no-times \
+  --colors never \
+  -- --profile ci
+python3 tools/ci/mutation_report.py \
+  --out-dir target/mutation/mutants.out \
+  --min-score 70 \
+  --markdown target/mutation/report.md \
+  --json target/mutation/mutation-report.json \
+  --issue-body target/mutation/add-test-issue.md
+
 # Contract fuzzing against a running API
 schemathesis --config-file tests/contract/schemathesis.toml run \
   --checks all \
@@ -68,3 +84,14 @@ CI uses the `ci` nextest profile from `.config/nextest.toml`:
 - JUnit output is written to `target/nextest/ci/junit.xml` for reporting
 
 This matches the repository's zero-flake policy: fix flaky tests or delete them.
+
+## Mutation testing
+
+`.github/workflows/mutation-weekly.yml` runs `cargo mutants --workspace` every
+Sunday at 06:00 UTC with `cargo-nextest` as the test runner. The scheduled gate
+requires at least a 70% mutation score and uploads the retained
+`cargo-mutants-report` artifact for maintainers to inspect.
+
+Surviving or timed-out mutants are summarized by `tools/ci/mutation_report.py`.
+When the scheduled run finds survivors, the workflow opens a follow-up issue
+labeled `add test` so the missing coverage is tracked as normal backlog work.

--- a/tools/ci/mutation_report.py
+++ b/tools/ci/mutation_report.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Summarise cargo-mutants outcomes for CI and follow-up issue triage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CAUGHT = {"CaughtMutant"}
+MISSED = {"MissedMutant", "Success"}
+TIMEOUT = {"Timeout", "TimedOut"}
+UNVIABLE = {"Unviable"}
+
+
+def main() -> int:
+    args = parse_args()
+    outcomes_path = args.out_dir / "outcomes.json"
+    if not outcomes_path.is_file():
+        print(f"cargo-mutants outcomes not found: {outcomes_path}", file=sys.stderr)
+        return 2
+
+    outcomes = json.loads(outcomes_path.read_text()).get("outcomes", [])
+    if not outcomes:
+        print("cargo-mutants outcomes.json did not contain any outcomes", file=sys.stderr)
+        return 2
+
+    summary = summarize(outcomes, args.min_score)
+    args.markdown.parent.mkdir(parents=True, exist_ok=True)
+    args.json.parent.mkdir(parents=True, exist_ok=True)
+    args.issue_body.parent.mkdir(parents=True, exist_ok=True)
+    args.markdown.write_text(markdown_report(summary))
+    args.json.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    args.issue_body.write_text(issue_body(summary))
+
+    print(
+        "Mutation score: "
+        f"{summary['score']:.2f}% "
+        f"({summary['caught']}/{summary['scored_total']} caught, "
+        f"{summary['missed']} surviving, threshold {summary['min_score']:.2f}%)"
+    )
+    return 0 if summary["passed"] else 1
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        required=True,
+        help="Path to cargo-mutants mutants.out directory.",
+    )
+    parser.add_argument("--min-score", type=float, required=True)
+    parser.add_argument("--markdown", type=Path, required=True)
+    parser.add_argument("--json", type=Path, required=True)
+    parser.add_argument("--issue-body", type=Path, required=True)
+    return parser.parse_args()
+
+
+def summarize(outcomes: list[dict[str, Any]], min_score: float) -> dict[str, Any]:
+    caught = 0
+    missed = 0
+    timeout = 0
+    unviable = 0
+    other = 0
+    survivors: list[dict[str, Any]] = []
+
+    for outcome in outcomes:
+        kind = str(outcome.get("summary", ""))
+        if kind in CAUGHT:
+            caught += 1
+        elif kind in MISSED:
+            missed += 1
+            survivors.append(mutant_details(outcome))
+        elif kind in TIMEOUT:
+            timeout += 1
+            survivors.append(mutant_details(outcome))
+        elif kind in UNVIABLE:
+            unviable += 1
+        else:
+            other += 1
+
+    scored_total = caught + missed + timeout
+    if scored_total == 0:
+        score = 0.0
+    else:
+        score = (caught / scored_total) * 100.0
+
+    return {
+        "caught": caught,
+        "missed": missed,
+        "timeout": timeout,
+        "unviable": unviable,
+        "other": other,
+        "scored_total": scored_total,
+        "total_outcomes": len(outcomes),
+        "score": round(score, 2),
+        "min_score": float(min_score),
+        "passed": score >= min_score,
+        "survivors": survivors,
+    }
+
+
+def mutant_details(outcome: dict[str, Any]) -> dict[str, Any]:
+    mutant = outcome.get("scenario", {}).get("Mutant", {})
+    span = mutant.get("span", {}).get("start", {})
+    function = mutant.get("function", {})
+    line = span.get("line")
+    return {
+        "summary": outcome.get("summary", ""),
+        "package": mutant.get("package", ""),
+        "file": mutant.get("file", ""),
+        "line": line,
+        "column": span.get("column"),
+        "function": function.get("function_name", ""),
+        "replacement": mutant.get("replacement", ""),
+        "diff_path": outcome.get("diff_path", ""),
+    }
+
+
+def markdown_report(summary: dict[str, Any]) -> str:
+    lines = [
+        "# cargo-mutants Report",
+        "",
+        f"Mutation score: {summary['score']:.2f}%",
+        f"Threshold: {summary['min_score']:.2f}%",
+        f"Status: {'pass' if summary['passed'] else 'fail'}",
+        "",
+        "| Outcome | Count |",
+        "|---|---:|",
+        f"| Caught | {summary['caught']} |",
+        f"| Surviving | {summary['missed']} |",
+        f"| Timed out | {summary['timeout']} |",
+        f"| Unviable | {summary['unviable']} |",
+        f"| Other | {summary['other']} |",
+        "",
+    ]
+    if summary["survivors"]:
+        lines.extend(["## Surviving Mutants", ""])
+        for survivor in summary["survivors"]:
+            location = format_location(survivor)
+            lines.extend(
+                [
+                    f"- `{location}` `{survivor['function']}`",
+                    f"  - Replacement: `{survivor['replacement']}`",
+                    f"  - Summary: `{survivor['summary']}`",
+                ]
+            )
+            if survivor.get("diff_path"):
+                lines.append(f"  - Diff: `{survivor['diff_path']}`")
+    else:
+        lines.extend(["## Surviving Mutants", "", "None."])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def issue_body(summary: dict[str, Any]) -> str:
+    lines = [
+        "## Follow-up add test work",
+        "",
+        "The weekly `cargo-mutants` run found surviving mutants. Add tests that catch the listed behavioral changes, then close this issue from the fixing PR.",
+        "",
+        f"- Mutation score: {summary['score']:.2f}%",
+        f"- Threshold: {summary['min_score']:.2f}%",
+        f"- Surviving mutants: {summary['missed']}",
+        f"- Timed-out mutants: {summary['timeout']}",
+        "",
+        "## Surviving mutants",
+        "",
+    ]
+    if summary["survivors"]:
+        for survivor in summary["survivors"]:
+            lines.append(
+                f"- `{format_location(survivor)}` `{survivor['function']}` -> `{survivor['replacement']}`"
+            )
+    else:
+        lines.append("None.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def format_location(survivor: dict[str, Any]) -> str:
+    file = survivor.get("file", "")
+    line = survivor.get("line")
+    if line is None:
+        return str(file)
+    return f"{file}:{line}"
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes #65

## Pass requirements

- [x] Weekly scheduled `cargo-mutants` job is configured.
- [x] Mutation score target is at least 70%.
- [x] Surviving mutants are exported in a reviewable report and triaged into follow-up `add test` issues.
- [x] Scheduled-job output is retained where maintainers can inspect it.

## Test plan

- `RUSTC_WRAPPER= cargo test -p au-kpis-testing --test mutation_scaffold`
- `RUSTC_WRAPPER= cargo mutants --file crates/au-kpis-error/src/lib.rs --baseline skip --output target/mutation-local --no-times --colors never -j 1 --timeout 120`
- `python3 tools/ci/mutation_report.py --out-dir target/mutation-local/mutants.out --min-score 70 --markdown target/mutation-local/report.md --json target/mutation-local/mutation-report.json --issue-body target/mutation-local/add-test-issue.md`
- `cargo fmt --all --check`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTC_WRAPPER= cargo nextest run --workspace`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `RUSTC_WRAPPER= cargo insta test --workspace --check -- --skip loads_ten_thousand_observations_with_copy_batches`
- `RUSTC_WRAPPER= cargo +nightly-2025-10-01 llvm-cov nextest --workspace --profile ci -E 'not test(loads_ten_thousand_observations_with_copy_batches)' --skip-functions --branch --lcov --output-path target/llvm-cov/lcov.info --fail-under-lines 80`
- Branch coverage check: `70.44% (927/1316)`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `python3 -m py_compile tools/ci/mutation_report.py`
- `gitleaks detect --source . --no-banner --redact --config .gitleaks.toml`
- `gitleaks protect --staged --no-banner --redact --config .gitleaks.toml`
- `git diff --check`

## Spec impact

No Spec changes required. This implements the existing scheduled mutation testing contract from `Spec.md`.
