### PR TITLE
test(ci): add weekly chaos suite (#63)

### DIFF
--- a/.github/workflows/chaos-weekly.yml
+++ b/.github/workflows/chaos-weekly.yml
@@ -1,0 +1,77 @@
+name: Chaos Testing
+
+on:
+  schedule:
+    - cron: "0 5 * * 0"
+  workflow_dispatch:
+    inputs:
+      scenario:
+        description: Optional single chaos scenario to run
+        required: false
+        type: string
+
+concurrency:
+  group: chaos-weekly-${{ github.event.inputs.scenario || 'all' }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_BUILD_RUSTC_WRAPPER: sccache
+  RUSTC_WRAPPER: sccache
+  SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_CACHE_SIZE: 2G
+  CHAOS_ENVIRONMENT: staging
+  CHAOS_RESULTS_DIR: target/chaos
+
+jobs:
+  staging-chaos:
+    name: staging chaos suite
+    runs-on: ubuntu-latest
+    environment: staging
+    timeout-minutes: 120
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Set up Rust
+        uses: ./.github/actions/setup-rust
+
+      - name: Run chaos suite
+        id: chaos
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          args=(--results-dir "${CHAOS_RESULTS_DIR}")
+          if [ -n "${{ github.event.inputs.scenario || '' }}" ]; then
+            args+=(--scenario "${{ github.event.inputs.scenario }}")
+          fi
+          tests/chaos/run.sh "${args[@]}"
+
+      - name: Surface chaos results
+        if: always()
+        run: |
+          set -euo pipefail
+          if [ -f "${CHAOS_RESULTS_DIR}/summary.md" ]; then
+            cat "${CHAOS_RESULTS_DIR}/summary.md" >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "Chaos suite did not produce a summary." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+
+      - name: Upload chaos results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chaos-results
+          path: target/chaos/**
+          if-no-files-found: warn
+          retention-days: 30
+
+      - name: Enforce chaos invariants
+        if: steps.chaos.outcome == 'failure'
+        run: |
+          echo "Chaos suite failed; review the chaos-results artifact and job summary." >&2
+          exit 1

--- a/crates/au-kpis-adapter/src/lib.rs
+++ b/crates/au-kpis-adapter/src/lib.rs
@@ -9,7 +9,7 @@
 #![deny(missing_docs, missing_debug_implementations)]
 
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, VecDeque},
     fmt,
     sync::Arc,
     time::{Duration, Instant, SystemTime},
@@ -400,12 +400,14 @@ pub struct AdapterHttpClient {
     client: reqwest::Client,
     raw_artifact_client: reqwest::Client,
     limiter: Arc<RateLimiter>,
+    circuit_breaker: Arc<CircuitBreaker>,
 }
 
 impl fmt::Debug for AdapterHttpClient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("AdapterHttpClient")
             .field("rate_limit", &self.limiter.limit)
+            .field("circuit_breaker", &self.circuit_breaker)
             .finish_non_exhaustive()
     }
 }
@@ -429,6 +431,7 @@ impl AdapterHttpClient {
             client,
             raw_artifact_client,
             limiter: Arc::new(RateLimiter::new(rate_limit)),
+            circuit_breaker: Arc::new(CircuitBreaker::new(CircuitBreakerConfig::default())),
         }
     }
 
@@ -450,8 +453,22 @@ impl AdapterHttpClient {
         &self,
         request: reqwest::RequestBuilder,
     ) -> Result<reqwest::Response, AdapterError> {
+        self.circuit_breaker.before_request().await?;
         self.limiter.wait_for_permit().await;
-        Ok(request.send().await?)
+        match request.send().await {
+            Ok(response) => {
+                if response.status().is_server_error() {
+                    self.circuit_breaker.record_failure().await;
+                } else {
+                    self.circuit_breaker.record_success().await;
+                }
+                Ok(response)
+            }
+            Err(err) => {
+                self.circuit_breaker.record_failure().await;
+                Err(err.into())
+            }
+        }
     }
 
     /// Convenience `GET` helper using the shared rate limiter.
@@ -459,6 +476,113 @@ impl AdapterHttpClient {
     pub async fn get(&self, url: &str) -> Result<reqwest::Response, AdapterError> {
         self.execute(self.client.get(url)).await
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct CircuitBreakerConfig {
+    min_samples: usize,
+    failure_ratio: f64,
+    open_for: Duration,
+}
+
+impl Default for CircuitBreakerConfig {
+    fn default() -> Self {
+        Self {
+            min_samples: 50,
+            failure_ratio: 0.20,
+            open_for: Duration::from_secs(30),
+        }
+    }
+}
+
+#[derive(Debug)]
+struct CircuitBreaker {
+    config: CircuitBreakerConfig,
+    inner: Mutex<CircuitBreakerState>,
+}
+
+impl CircuitBreaker {
+    fn new(config: CircuitBreakerConfig) -> Self {
+        Self {
+            config,
+            inner: Mutex::new(CircuitBreakerState {
+                outcomes: VecDeque::with_capacity(config.min_samples),
+                state: CircuitState::Closed,
+            }),
+        }
+    }
+
+    async fn before_request(&self) -> Result<(), AdapterError> {
+        let now = Instant::now();
+        let mut inner = self.inner.lock().await;
+        match inner.state {
+            CircuitState::Closed | CircuitState::HalfOpen => Ok(()),
+            CircuitState::Open { until } if now >= until => {
+                inner.state = CircuitState::HalfOpen;
+                Ok(())
+            }
+            CircuitState::Open { until } => Err(AdapterError::CircuitOpen {
+                retry_after: until.saturating_duration_since(now),
+            }),
+        }
+    }
+
+    async fn record_success(&self) {
+        self.record(false).await;
+    }
+
+    async fn record_failure(&self) {
+        self.record(true).await;
+    }
+
+    async fn record(&self, failed: bool) {
+        let mut inner = self.inner.lock().await;
+        match inner.state {
+            CircuitState::HalfOpen if failed => {
+                inner.outcomes.clear();
+                inner.state = CircuitState::Open {
+                    until: Instant::now() + self.config.open_for,
+                };
+            }
+            CircuitState::HalfOpen => {
+                inner.outcomes.clear();
+                inner.state = CircuitState::Closed;
+            }
+            CircuitState::Open { .. } => {}
+            CircuitState::Closed => {
+                if inner.outcomes.len() == self.config.min_samples {
+                    inner.outcomes.pop_front();
+                }
+                inner.outcomes.push_back(failed);
+                if self.should_open(&inner.outcomes) {
+                    inner.state = CircuitState::Open {
+                        until: Instant::now() + self.config.open_for,
+                    };
+                }
+            }
+        }
+    }
+
+    fn should_open(&self, outcomes: &VecDeque<bool>) -> bool {
+        if outcomes.len() < self.config.min_samples {
+            return false;
+        }
+        let failures = outcomes.iter().filter(|failed| **failed).count();
+        failures as f64 / outcomes.len() as f64 > self.config.failure_ratio
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CircuitState {
+    Closed,
+    Open { until: Instant },
+    HalfOpen,
+}
+
+#[derive(Debug)]
+struct CircuitBreakerState {
+    outcomes: VecDeque<bool>,
+    state: CircuitState,
 }
 
 #[derive(Debug)]
@@ -1018,6 +1142,13 @@ pub enum AdapterError {
         response_headers: ResponseHeaders,
     },
 
+    /// Source circuit breaker is open after recent transient upstream failures.
+    #[error("source circuit breaker open")]
+    CircuitOpen {
+        /// Duration callers should wait before probing the source again.
+        retry_after: Duration,
+    },
+
     /// Persisting fetched artifact provenance failed.
     #[error("artifact provenance: {message}")]
     ArtifactRecord {
@@ -1083,6 +1214,7 @@ impl Classify for AdapterError {
                     ErrorClass::Permanent
                 }
             }
+            AdapterError::CircuitOpen { .. } => ErrorClass::Transient,
             AdapterError::ArtifactRecord { class, .. } => *class,
             AdapterError::Storage(err) => err.class(),
             AdapterError::UnknownAdapter(_)
@@ -1096,6 +1228,7 @@ impl Classify for AdapterError {
     fn retry_after(&self) -> Option<Duration> {
         match self {
             AdapterError::UpstreamStatus { retry_after, .. } => *retry_after,
+            AdapterError::CircuitOpen { retry_after } => Some(*retry_after),
             _ => None,
         }
     }
@@ -1124,5 +1257,67 @@ mod duration_millis {
     {
         let millis = u64::deserialize(deserializer)?;
         Ok(Duration::from_millis(millis))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn circuit_breaker_opens_after_failure_ratio_exceeds_window_threshold() {
+        let breaker = CircuitBreaker::new(CircuitBreakerConfig {
+            min_samples: 50,
+            failure_ratio: 0.20,
+            open_for: Duration::from_millis(5),
+        });
+
+        for _ in 0..40 {
+            breaker.record_success().await;
+        }
+        for _ in 0..10 {
+            breaker.record_failure().await;
+        }
+        assert!(
+            breaker.before_request().await.is_ok(),
+            "exactly 20% failures must not open the circuit"
+        );
+
+        breaker.record_failure().await;
+        let err = breaker
+            .before_request()
+            .await
+            .expect_err("more than 20% failures in the window should open");
+        assert!(
+            matches!(err, AdapterError::CircuitOpen { retry_after } if retry_after > Duration::ZERO)
+        );
+    }
+
+    #[tokio::test]
+    async fn circuit_breaker_recovers_after_cooldown_and_half_open_success() {
+        let breaker = CircuitBreaker::new(CircuitBreakerConfig {
+            min_samples: 3,
+            failure_ratio: 0.20,
+            open_for: Duration::from_millis(5),
+        });
+
+        breaker.record_failure().await;
+        breaker.record_failure().await;
+        breaker.record_failure().await;
+        assert!(matches!(
+            breaker.before_request().await,
+            Err(AdapterError::CircuitOpen { .. })
+        ));
+
+        sleep(Duration::from_millis(6)).await;
+        breaker
+            .before_request()
+            .await
+            .expect("cooldown should allow a half-open probe");
+        breaker.record_success().await;
+        breaker
+            .before_request()
+            .await
+            .expect("successful half-open probe should close the circuit");
     }
 }

--- a/crates/au-kpis-adapter/tests/registry_dispatch.rs
+++ b/crates/au-kpis-adapter/tests/registry_dispatch.rs
@@ -414,6 +414,11 @@ fn adapter_error_classification_matches_retry_policy() {
         .class(),
         ErrorClass::Permanent
     );
+    let circuit_open = AdapterError::CircuitOpen {
+        retry_after: Duration::from_secs(30),
+    };
+    assert_eq!(circuit_open.class(), ErrorClass::Transient);
+    assert_eq!(circuit_open.retry_after(), Some(Duration::from_secs(30)));
 }
 
 #[test]

--- a/crates/testing/tests/chaos_scaffold.rs
+++ b/crates/testing/tests/chaos_scaffold.rs
@@ -1,0 +1,150 @@
+use std::{
+    fs,
+    os::unix::fs::PermissionsExt,
+    path::{Path, PathBuf},
+    process::Command,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+fn repo_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("testing crate lives under crates/testing")
+}
+
+#[test]
+fn issue_63_chaos_suite_contract_is_wired() {
+    let root = repo_root();
+    let workflow =
+        fs::read_to_string(root.join(".github/workflows/chaos-weekly.yml")).expect("read workflow");
+    let docs = fs::read_to_string(root.join("docs/chaos.md")).expect("read chaos docs");
+    let run_script = root.join("tests/chaos/run.sh");
+    assert!(run_script.is_file(), "chaos suite runner should exist");
+    assert_executable(&run_script);
+
+    for expected in [
+        "cron: \"0 5 * * 0\"",
+        "workflow_dispatch",
+        "environment: staging",
+        "tests/chaos/run.sh",
+        "chaos-results",
+        "target/chaos",
+        "GITHUB_STEP_SUMMARY",
+    ] {
+        assert!(
+            workflow.contains(expected),
+            "weekly chaos workflow should contain `{expected}`"
+        );
+    }
+
+    for scenario in [
+        "kill-ingestion-mid-load",
+        "sever-db-connection",
+        "fill-queue-capacity",
+        "source-5xx-circuit-breaker",
+        "vacuum-heavy-writes",
+    ] {
+        let script = root.join(format!("tests/chaos/{scenario}.sh"));
+        assert!(
+            script.is_file(),
+            "scenario script `{scenario}` should exist"
+        );
+        assert_executable(&script);
+        assert!(
+            fs::read_to_string(&script)
+                .expect("read scenario script")
+                .contains("record_result"),
+            "scenario `{scenario}` should write a machine-readable result"
+        );
+        assert!(
+            docs.contains(scenario),
+            "docs/chaos.md should document scenario `{scenario}`"
+        );
+        assert!(
+            workflow.contains(scenario)
+                || fs::read_to_string(&run_script)
+                    .expect("read chaos runner")
+                    .contains(scenario),
+            "runner or workflow should invoke scenario `{scenario}`"
+        );
+    }
+
+    for invariant in [
+        "no duplicates/no gaps",
+        "reconnection",
+        "backpressure",
+        "circuit breaker opens and recovers",
+        "no deadlocks",
+        "chaos-results",
+    ] {
+        assert!(
+            docs.contains(invariant),
+            "docs/chaos.md should explain `{invariant}`"
+        );
+    }
+}
+
+#[test]
+fn issue_63_chaos_suite_dry_run_surfaces_reviewable_results() {
+    let root = repo_root();
+    let temp_dir = temp_fixture_dir("chaos-results");
+
+    let output = Command::new("bash")
+        .current_dir(root)
+        .arg("tests/chaos/run.sh")
+        .arg("--dry-run")
+        .arg("--results-dir")
+        .arg(&temp_dir)
+        .output()
+        .expect("run chaos dry-run");
+    assert!(
+        output.status.success(),
+        "chaos dry-run should pass: stdout=\n{}\nstderr=\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let summary = fs::read_to_string(temp_dir.join("summary.md")).expect("read summary");
+    let jsonl = fs::read_to_string(temp_dir.join("results.jsonl")).expect("read result jsonl");
+
+    for scenario in [
+        "kill-ingestion-mid-load",
+        "sever-db-connection",
+        "fill-queue-capacity",
+        "source-5xx-circuit-breaker",
+        "vacuum-heavy-writes",
+    ] {
+        assert!(
+            summary.contains(scenario),
+            "summary should include `{scenario}`"
+        );
+        assert!(jsonl.contains(&format!(r#""scenario":"{scenario}""#)));
+    }
+    assert_eq!(
+        jsonl
+            .lines()
+            .filter(|line| line.contains(r#""status":"dry-run""#))
+            .count(),
+        5,
+        "dry-run should record one result per scenario"
+    );
+
+    let _ = fs::remove_dir_all(temp_dir);
+}
+
+fn assert_executable(path: &Path) {
+    let mode = fs::metadata(path)
+        .unwrap_or_else(|err| panic!("read metadata for {}: {err}", path.display()))
+        .permissions()
+        .mode();
+    assert_ne!(mode & 0o111, 0, "{} should be executable", path.display());
+}
+
+fn temp_fixture_dir(prefix: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time after epoch")
+        .as_nanos();
+    std::env::temp_dir().join(format!("{prefix}-{nanos}"))
+}

--- a/docs/chaos.md
+++ b/docs/chaos.md
@@ -1,0 +1,63 @@
+# Chaos Testing
+
+The chaos suite is a weekly staging-equivalent resilience check for the five
+failure modes named in `Spec.md` testing strategy. It is deliberately scripted
+under `tests/chaos/` so operators can run the same checks locally, in staging,
+or from GitHub Actions.
+
+## Run The Suite
+
+Run every scenario and write review artifacts under `target/chaos`:
+
+```bash
+tests/chaos/run.sh --results-dir target/chaos
+```
+
+Run a single scenario:
+
+```bash
+tests/chaos/run.sh --scenario kill-ingestion-mid-load --results-dir target/chaos
+```
+
+Check wiring without touching infrastructure:
+
+```bash
+tests/chaos/run.sh --dry-run --results-dir target/chaos
+```
+
+The weekly workflow `.github/workflows/chaos-weekly.yml` runs at `0 5 * * 0`
+with the GitHub `staging` environment. It appends `target/chaos/summary.md` to
+the workflow summary and uploads `target/chaos/**` as the `chaos-results`
+artifact for operator review after each scheduled run.
+
+## Scenarios And Invariants
+
+| Scenario | Failure mode | Expected invariant |
+|---|---|---|
+| `kill-ingestion-mid-load` | Kill ingestion worker mid-load | Produced work drains before shutdown; restart leaves no duplicates/no gaps. |
+| `sever-db-connection` | Sever DB connection | Queue leases are reclaimed after reconnection and queued jobs resume. |
+| `fill-queue-capacity` | Fill queue to capacity | Backpressure reaches producers; work is not dropped and the process does not OOM. |
+| `source-5xx-circuit-breaker` | Random 5xx from source adapter | Transient failures are retried; the circuit breaker opens and recovers instead of hot-looping an unhealthy source. |
+| `vacuum-heavy-writes` | Compaction/vacuum during heavy writes | Hypertable maintenance and write batches complete with no deadlocks. |
+
+## Interpreting Failures
+
+Each script writes one JSON line to `target/chaos/results.jsonl` and one row to
+`target/chaos/summary.md`. A non-`pass` status means the corresponding invariant
+did not hold or the scenario could not run to completion.
+
+Use the failing row to pick the first system boundary to inspect:
+
+- Ingestion shutdown failures usually point at cancellation, drain, or artifact
+  handoff regressions.
+- DB severing failures usually point at queue lease renewal, stale lease reclaim,
+  or connection-pool recovery.
+- Queue capacity failures usually point at bounded channel backpressure.
+- Source 5xx failures usually point at transient error classification, retry
+  backoff, or circuit breaker recovery.
+- Vacuum/heavy-write failures usually point at migration, Timescale, or loader
+  transaction behavior.
+
+The workflow does not create follow-up issues automatically. Operators should
+attach `summary.md`, the relevant `results.jsonl` line, and the failing job log
+to the incident or bug they open.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -69,6 +69,18 @@ mutants survive or time out, `tools/ci/mutation_report.py` generates a
 follow-up body and the workflow creates an `add test` issue that lists the
 surviving cargo-mutants locations and replacements.
 
+## Weekly chaos suite
+
+`.github/workflows/chaos-weekly.yml` runs at `0 5 * * 0` with the GitHub
+`staging` environment. It executes `tests/chaos/run.sh`, surfaces the Markdown
+summary in the workflow run, and uploads retained `chaos-results` artifacts for
+operator review.
+
+The suite covers the five chaos scenarios from the spec: killing ingestion
+mid-load, severing DB connectivity, filling queue capacity, source 5xx circuit
+breaker recovery, and vacuum/compaction during heavy writes. See `docs/chaos.md`
+for local execution and failure interpretation.
+
 ## Nightly cargo-fuzz
 
 `.github/workflows/fuzz-nightly.yml` runs at `0 3 * * *` on `main`. It installs

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,6 +41,10 @@ cargo +nightly-2025-10-01 fuzz run xls -- -runs=1
 cargo +nightly-2025-10-01 fuzz run csv -- -runs=1
 cargo +nightly-2025-10-01 fuzz run pdf_response -- -runs=1
 
+# Weekly chaos suite, normally run by GitHub Actions in the staging environment
+tests/chaos/run.sh --results-dir target/chaos
+tests/chaos/run.sh --dry-run --results-dir target/chaos
+
 # Contract fuzzing against a running API
 schemathesis --config-file tests/contract/schemathesis.toml run \
   --checks all \
@@ -112,3 +116,10 @@ Corpora are seeded from committed adapter fixtures and the curated PDF sidecar
 response sample. The nightly workflow keeps newly discovered crashing inputs in
 the `cargo-fuzz-artifacts` artifact so they can be minimized and promoted into
 the committed corpus with the associated fix.
+
+## Chaos testing
+
+`tests/chaos/` contains the weekly chaos suite for the five resilience scenarios
+listed in the spec. The workflow uploads a retained `chaos-results` artifact and
+adds the Markdown summary to each scheduled run. See `docs/chaos.md` for the
+scenario invariants and failure interpretation guide.

--- a/tests/chaos/fill-queue-capacity.sh
+++ b/tests/chaos/fill-queue-capacity.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${ROOT}/tests/chaos/lib.sh"
+
+# record_result is called through run_step.
+run_step \
+  "fill-queue-capacity" \
+  "Fill queue to capacity and verify backpressure propagates without OOM or dropped work." \
+  run_rust_checks \
+  "cargo test -p au-kpis-ingestion-core --lib tests::produced_handoff_waits_for_capacity_instead_of_dropping_item -- --exact && cargo test -p au-kpis-ingestion-core --lib tests::produced_handoff_does_not_drop_item_when_full_and_cancelled -- --exact"

--- a/tests/chaos/kill-ingestion-mid-load.sh
+++ b/tests/chaos/kill-ingestion-mid-load.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${ROOT}/tests/chaos/lib.sh"
+
+# record_result is called through run_step.
+run_step \
+  "kill-ingestion-mid-load" \
+  "Kill ingestion worker mid-load and verify no duplicates/no gaps after produced work drains." \
+  run_rust_checks \
+  "cargo test -p au-kpis-ingestion-core --test pipeline_failures cancellation_drains_buffered_artifacts_that_are_already_fetched -- --exact && cargo test -p au-kpis-ingestion-core --test pipeline_failures duplicate_artifact_jobs_keep_pending_loads_separate -- --exact && cargo test -p au-kpis-ingestion --test cli run_mode_exits_within_configured_shutdown_grace_period -- --exact"

--- a/tests/chaos/lib.sh
+++ b/tests/chaos/lib.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CHAOS_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+CHAOS_RESULTS_DIR="${CHAOS_RESULTS_DIR:-${CHAOS_ROOT}/target/chaos}"
+CHAOS_RESULTS_JSONL="${CHAOS_RESULTS_DIR}/results.jsonl"
+CHAOS_SUMMARY_MD="${CHAOS_RESULTS_DIR}/summary.md"
+CHAOS_DRY_RUN="${CHAOS_DRY_RUN:-0}"
+CHAOS_ENVIRONMENT="${CHAOS_ENVIRONMENT:-local}"
+CHAOS_INITIALIZED="${CHAOS_INITIALIZED:-0}"
+
+json_escape() {
+  local value="$1"
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  value="${value//$'\n'/\\n}"
+  printf '%s' "${value}"
+}
+
+chaos_reset_results() {
+  mkdir -p "${CHAOS_RESULTS_DIR}"
+  : > "${CHAOS_RESULTS_JSONL}"
+  {
+    printf '# Chaos suite results\n\n'
+    printf '| Scenario | Status | Invariant | Detail |\n'
+    printf '|---|---:|---|---|\n'
+  } > "${CHAOS_SUMMARY_MD}"
+  export CHAOS_INITIALIZED=1
+}
+
+chaos_init_results() {
+  if [[ "${CHAOS_INITIALIZED}" != "1" ]]; then
+    chaos_reset_results
+  fi
+}
+
+record_result() {
+  local scenario="$1"
+  local status="$2"
+  local invariant="$3"
+  local detail="$4"
+  local timestamp
+  timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+  chaos_init_results
+  printf '{"timestamp":"%s","environment":"%s","scenario":"%s","status":"%s","invariant":"%s","detail":"%s"}\n' \
+    "$(json_escape "${timestamp}")" \
+    "$(json_escape "${CHAOS_ENVIRONMENT}")" \
+    "$(json_escape "${scenario}")" \
+    "$(json_escape "${status}")" \
+    "$(json_escape "${invariant}")" \
+    "$(json_escape "${detail}")" >> "${CHAOS_RESULTS_JSONL}"
+  printf '| `%s` | `%s` | %s | %s |\n' \
+    "${scenario}" \
+    "${status}" \
+    "$(json_escape "${invariant}")" \
+    "$(json_escape "${detail}")" >> "${CHAOS_SUMMARY_MD}"
+}
+
+run_step() {
+  local scenario="$1"
+  local invariant="$2"
+  shift 2
+
+  if [[ "${CHAOS_DRY_RUN}" == "1" ]]; then
+    record_result "${scenario}" "dry-run" "${invariant}" "Would run: $*"
+    return 0
+  fi
+
+  printf '::group::%s\n' "${scenario}"
+  if "$@"; then
+    printf '::endgroup::\n'
+    record_result "${scenario}" "pass" "${invariant}" "Command passed: $*"
+    return 0
+  fi
+
+  local status="$?"
+  printf '::endgroup::\n'
+  record_result "${scenario}" "fail" "${invariant}" "Command failed (${status}): $*"
+  return "${status}"
+}
+
+run_rust_checks() {
+  local command="$1"
+  RUSTC_WRAPPER="${RUSTC_WRAPPER:-}" bash -c "${command}"
+}

--- a/tests/chaos/run.sh
+++ b/tests/chaos/run.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${ROOT}/tests/chaos/lib.sh"
+
+SCENARIOS=(
+  kill-ingestion-mid-load
+  sever-db-connection
+  fill-queue-capacity
+  source-5xx-circuit-breaker
+  vacuum-heavy-writes
+)
+
+REQUESTED_SCENARIOS=()
+
+usage() {
+  cat <<'EOF'
+Usage: tests/chaos/run.sh [--dry-run] [--results-dir DIR] [--scenario NAME]
+
+Runs the scripted chaos suite. Omit --scenario to run every scenario.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      export CHAOS_DRY_RUN=1
+      shift
+      ;;
+    --results-dir)
+      export CHAOS_RESULTS_DIR="$2"
+      export CHAOS_RESULTS_JSONL="${CHAOS_RESULTS_DIR}/results.jsonl"
+      export CHAOS_SUMMARY_MD="${CHAOS_RESULTS_DIR}/summary.md"
+      shift 2
+      ;;
+    --scenario)
+      REQUESTED_SCENARIOS+=("$2")
+      shift 2
+      ;;
+    --list)
+      printf '%s\n' "${SCENARIOS[@]}"
+      exit 0
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      printf 'unknown argument: %s\n' "$1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ "${#REQUESTED_SCENARIOS[@]}" -eq 0 ]]; then
+  REQUESTED_SCENARIOS=("${SCENARIOS[@]}")
+fi
+
+chaos_reset_results
+status=0
+
+for scenario in "${REQUESTED_SCENARIOS[@]}"; do
+  found=0
+  for known in "${SCENARIOS[@]}"; do
+    if [[ "${scenario}" == "${known}" ]]; then
+      found=1
+      break
+    fi
+  done
+  if [[ "${found}" != "1" ]]; then
+    printf 'unknown chaos scenario: %s\n' "${scenario}" >&2
+    status=2
+    continue
+  fi
+
+  if ! "${ROOT}/tests/chaos/${scenario}.sh"; then
+    status=1
+  fi
+done
+
+printf 'Chaos results written to %s\n' "${CHAOS_RESULTS_DIR}"
+exit "${status}"

--- a/tests/chaos/sever-db-connection.sh
+++ b/tests/chaos/sever-db-connection.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${ROOT}/tests/chaos/lib.sh"
+
+# record_result is called through run_step.
+run_step \
+  "sever-db-connection" \
+  "Sever DB connection and verify reconnection plus queued jobs resume through lease reclaim." \
+  run_rust_checks \
+  "cargo test -p au-kpis-queue --test postgres stale_running_jobs_are_reclaimed_after_lease_timeout -- --exact && cargo test -p au-kpis-queue --test postgres renew_extends_lease_and_invalidates_old_handle -- --exact"

--- a/tests/chaos/source-5xx-circuit-breaker.sh
+++ b/tests/chaos/source-5xx-circuit-breaker.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${ROOT}/tests/chaos/lib.sh"
+
+# record_result is called through run_step.
+run_step \
+  "source-5xx-circuit-breaker" \
+  "Inject random source 5xx responses and verify circuit breaker opens and recovers through retry policy." \
+  run_rust_checks \
+  "cargo test -p au-kpis-adapter --lib circuit_breaker && cargo test -p au-kpis-adapter --test registry_dispatch adapter_error_classification_matches_retry_policy -- --exact && cargo test -p au-kpis-queue --test postgres nack_retries_then_dead_letters_after_attempt_budget -- --exact"

--- a/tests/chaos/vacuum-heavy-writes.sh
+++ b/tests/chaos/vacuum-heavy-writes.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+source "${ROOT}/tests/chaos/lib.sh"
+
+# record_result is called through run_step.
+run_step \
+  "vacuum-heavy-writes" \
+  "Run compaction/vacuum-adjacent DB maintenance during heavy writes and verify no deadlocks." \
+  run_rust_checks \
+  "cargo test -p au-kpis-db --test migrations migration_creates_hypertable_and_compression_policy -- --exact && cargo test -p au-kpis-loader --test load_batch default_options_split_observations_at_one_thousand_rows -- --exact"


### PR DESCRIPTION
Closes #63

## Summary

- Add the weekly staging chaos workflow and review artifacts.
- Add `tests/chaos/` scenario scripts for the five spec chaos modes.
- Add adapter circuit-breaker behavior needed for the source 5xx chaos invariant.
- Document local execution, invariants, and failure interpretation in `docs/chaos.md`.

## Pass requirements

- [x] Scripts in `tests/chaos/` exercise the 5 failure modes named in the spec
- [x] The suite is scheduled weekly in staging
- [x] Results are surfaced in a way operators can review after each scheduled run
- [x] `docs/chaos.md` documents how to run the suite, expected invariants, and how to interpret failures

## Test plan

- `RUSTC_WRAPPER= cargo test -p au-kpis-testing --test chaos_scaffold`
- `RUSTC_WRAPPER= cargo test -p au-kpis-adapter --lib circuit_breaker`
- `RUSTC_WRAPPER= cargo test -p au-kpis-adapter --test registry_dispatch adapter_error_classification_matches_retry_policy -- --exact`
- `RUSTC_WRAPPER= cargo clippy -p au-kpis-adapter --all-targets -- -D warnings`
- `bash -n tests/chaos/*.sh`
- `RUSTC_WRAPPER= tests/chaos/run.sh --dry-run --results-dir target/chaos-dry-run`
- `RUSTC_WRAPPER= tests/chaos/run.sh --results-dir target/chaos-local`
- `RUSTC_WRAPPER= tests/chaos/run.sh --scenario source-5xx-circuit-breaker --results-dir target/chaos-local-5xx`
- `cargo fmt --all --check`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTC_WRAPPER= cargo nextest run --workspace`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks detect --source . --no-banner --redact --config .gitleaks.toml`
- `RUSTC_WRAPPER= cargo insta test --workspace --check -- --skip loads_ten_thousand_observations_with_copy_batches`
- `RUSTC_WRAPPER= cargo +nightly-2025-10-01 llvm-cov nextest --workspace --profile ci -E 'not test(loads_ten_thousand_observations_with_copy_batches)' --skip-functions --branch --lcov --output-path target/llvm-cov/lcov.info --fail-under-lines 80`
- Branch coverage script: `70.56% (937/1328)`
- `git diff --check`
- `gitleaks protect --staged --no-banner --redact --config .gitleaks.toml`

## Spec impact

No Spec changes required. This implements the existing `Spec.md § Testing strategy -> Chaos` and scheduled-flow expectation for #63.
