### PR TITLE
fix(sdk): isolate release test build cache

### DIFF
--- a/crates/testing/tests/sdk_release_scaffold.rs
+++ b/crates/testing/tests/sdk_release_scaffold.rs
@@ -19,6 +19,10 @@ fn issue_61_sdk_release_contract_is_wired() {
         fs::read_to_string(root.join(".github/workflows/pr.yml")).expect("read PR workflow");
     let sdk_package =
         fs::read_to_string(root.join("packages/sdk/package.json")).expect("read SDK package");
+    let sdk_tsconfig =
+        fs::read_to_string(root.join("packages/sdk/tsconfig.json")).expect("read SDK tsconfig");
+    let sdk_build_tsconfig = fs::read_to_string(root.join("packages/sdk/tsconfig.build.json"))
+        .expect("read SDK build tsconfig");
     let generated_package = fs::read_to_string(root.join("packages/sdk-generated/package.json"))
         .expect("read generated SDK package");
     let sdk_readme =
@@ -78,6 +82,7 @@ fn issue_61_sdk_release_contract_is_wired() {
 
     assert_publishable_sdk_package(&sdk_package);
     assert_publishable_generated_package(&generated_package);
+    assert_sdk_build_modes_do_not_share_incremental_cache(&sdk_tsconfig, &sdk_build_tsconfig);
 
     for expected in [
         "npm install @au-kpis/sdk",
@@ -156,5 +161,20 @@ fn assert_publishable_generated_package(package: &str) {
     assert!(
         !package.contains("\"private\": true"),
         "generated SDK package must be publishable because the public SDK depends on it"
+    );
+}
+
+fn assert_sdk_build_modes_do_not_share_incremental_cache(tsconfig: &str, build_tsconfig: &str) {
+    assert!(
+        tsconfig.contains("\"tsBuildInfoFile\": \"dist/.tsbuildinfo.test\""),
+        "SDK test/typecheck config should emit test files using an isolated incremental cache"
+    );
+    assert!(
+        build_tsconfig.contains("\"tsBuildInfoFile\": \"dist/.tsbuildinfo\""),
+        "SDK production build config should keep its own incremental cache"
+    );
+    assert!(
+        build_tsconfig.contains("\"exclude\": [\"src/**/*.test.ts\"]"),
+        "SDK production build should keep runtime tests out of publishable output"
     );
 }

--- a/packages/sdk/tsconfig.build.json
+++ b/packages/sdk/tsconfig.build.json
@@ -1,4 +1,7 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "dist/.tsbuildinfo"
+  },
   "exclude": ["src/**/*.test.ts"]
 }

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -4,7 +4,7 @@
     "rootDir": "src",
     "outDir": "dist",
     "composite": true,
-    "tsBuildInfoFile": "dist/.tsbuildinfo"
+    "tsBuildInfoFile": "dist/.tsbuildinfo.test"
   },
   "references": [{ "path": "../sdk-generated" }],
   "include": ["src/**/*.ts"]


### PR DESCRIPTION
## Context

Repairs the main-branch `Publish SDK` workflow failure after #139/#61. The workflow builds production SDK output before running SDK runtime tests; both modes were sharing one TypeScript incremental cache, so fresh CI runners skipped emitting `dist/client.runtime.test.js`.

## Changes

- Give SDK test/typecheck builds their own `.tsbuildinfo.test` cache.
- Keep production builds on `.tsbuildinfo` and excluding `src/**/*.test.ts`.
- Add a release-scaffold regression assertion for the separated caches.

## Test plan

- `git clean -fdX -- packages/sdk/dist packages/sdk-generated/dist .turbo`
- `pnpm turbo run build --filter=@au-kpis/sdk... --cache-dir=.turbo`
- `pnpm turbo run test --filter=@au-kpis/sdk --cache-dir=.turbo`
- `RUSTC_WRAPPER= cargo test -p au-kpis-testing --test sdk_release_scaffold -- --nocapture`
- `cargo fmt --all --check`
- `pnpm run lint`
- `pnpm turbo run typecheck test --cache-dir=.turbo`
- `RUSTC_WRAPPER= cargo check --workspace --locked`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTC_WRAPPER= cargo nextest run --workspace`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks protect --staged`

## Spec impact

No Spec changes required; this keeps the SDK release workflow introduced for #61 operational.