### PR TITLE
fix(ci): use trusted SDK publish runtime

### DIFF
--- a/.github/workflows/sdk-publish.yml
+++ b/.github/workflows/sdk-publish.yml
@@ -41,6 +41,37 @@ jobs:
       - name: Test SDK packages
         run: pnpm turbo run test --filter=@au-kpis/sdk --cache-dir=.turbo
 
+      - name: Set up npm trusted publishing runtime
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Verify npm trusted publishing runtime
+        run: |
+          node --version
+          npm --version
+          node <<'NODE'
+          const { execFileSync } = require("node:child_process");
+
+          const npmVersion = execFileSync("npm", ["--version"], { encoding: "utf8" }).trim();
+          const nodeVersion = process.versions.node;
+
+          const [nodeMajor] = nodeVersion.split(".").map(Number);
+          if (nodeMajor < 24) {
+            throw new Error("npm trusted publishing requires Node 24 in this workflow");
+          }
+
+          const [npmMajor, npmMinor, npmPatch] = npmVersion.split(".").map(Number);
+          if (
+            npmMajor < 11 ||
+            (npmMajor === 11 && npmMinor < 5) ||
+            (npmMajor === 11 && npmMinor === 5 && npmPatch < 1)
+          ) {
+            throw new Error("npm trusted publishing requires npm >= 11.5.1");
+          }
+          NODE
+
       - name: Publish or open SDK release PR
         uses: changesets/action@v1
         with:

--- a/crates/au-kpis-pdf-client/tests/client.rs
+++ b/crates/au-kpis-pdf-client/tests/client.rs
@@ -37,6 +37,8 @@ static PDF_HTTP_CHILD_SPANS: AtomicUsize = AtomicUsize::new(0);
 static PDF_HTTP_SPAN_TARGET_URL: Mutex<Option<String>> = Mutex::new(None);
 
 const PDF_EXTRACT_HTTP_SPAN: &str = "pdf.extract.http";
+const PDF_TIMEOUT_TEST_DEADLINE: Duration = Duration::from_millis(200);
+const PDF_TIMEOUT_TEST_DELAY: Duration = Duration::from_secs(1);
 
 fn ensure_pdf_span_counter() {
     PDF_HTTP_SPAN_COUNTER_INIT.call_once(|| {
@@ -399,13 +401,13 @@ async fn extract_stream_timeout_bounds_incomplete_response_body() {
             .await
             .expect("write headers");
         stream.write_all(first).await.expect("write first chunk");
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        tokio::time::sleep(PDF_TIMEOUT_TEST_DELAY).await;
     });
 
     let client = PdfClient::builder()
         .base_url(format!("http://{addr}"))
         .http_client(reqwest::Client::new())
-        .timeout(Duration::from_millis(20))
+        .timeout(PDF_TIMEOUT_TEST_DEADLINE)
         .retry_policy(RetryPolicy::none())
         .build()
         .unwrap();
@@ -475,12 +477,12 @@ async fn request_timeout_bounds_hung_sidecar_calls() {
         let request = read_http_request(&mut stream).await;
         assert!(request.starts_with("POST /extract HTTP/1.1"));
         attempts_for_task.fetch_add(1, Ordering::SeqCst);
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        tokio::time::sleep(PDF_TIMEOUT_TEST_DELAY).await;
     });
 
     let client = PdfClient::builder()
         .base_url(format!("http://{addr}"))
-        .timeout(Duration::from_millis(20))
+        .timeout(PDF_TIMEOUT_TEST_DEADLINE)
         .retry_policy(RetryPolicy::none())
         .build()
         .unwrap();
@@ -517,13 +519,13 @@ async fn extract_timeout_bounds_incomplete_response_body() {
             .await
             .expect("write response headers");
         stream.write_all(body).await.expect("write partial body");
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        tokio::time::sleep(PDF_TIMEOUT_TEST_DELAY).await;
     });
 
     let client = PdfClient::builder()
         .base_url(format!("http://{addr}"))
         .http_client(reqwest::Client::new())
-        .timeout(Duration::from_millis(20))
+        .timeout(PDF_TIMEOUT_TEST_DEADLINE)
         .retry_policy(RetryPolicy::none())
         .build()
         .unwrap();
@@ -550,13 +552,13 @@ async fn custom_http_client_still_enforces_request_timeout() {
         let request = read_http_request(&mut stream).await;
         assert!(request.starts_with("POST /extract HTTP/1.1"));
         attempts_for_task.fetch_add(1, Ordering::SeqCst);
-        tokio::time::sleep(Duration::from_millis(250)).await;
+        tokio::time::sleep(PDF_TIMEOUT_TEST_DELAY).await;
     });
 
     let client = PdfClient::builder()
         .base_url(format!("http://{addr}"))
         .http_client(reqwest::Client::new())
-        .timeout(Duration::from_millis(20))
+        .timeout(PDF_TIMEOUT_TEST_DEADLINE)
         .retry_policy(RetryPolicy::none())
         .build()
         .unwrap();

--- a/crates/testing/tests/sdk_release_scaffold.rs
+++ b/crates/testing/tests/sdk_release_scaffold.rs
@@ -63,6 +63,9 @@ fn issue_61_sdk_release_contract_is_wired() {
         "version: pnpm version-packages",
         "publish: pnpm release:sdk",
         "NPM_TOKEN: ${{ secrets.NPM_TOKEN }}",
+        "node-version: \"24\"",
+        "registry-url: \"https://registry.npmjs.org\"",
+        "npm trusted publishing requires npm >= 11.5.1",
         "pnpm turbo run build --filter=@au-kpis/sdk... --cache-dir=.turbo",
         "pnpm turbo run test --filter=@au-kpis/sdk --cache-dir=.turbo",
     ] {


### PR DESCRIPTION
## Context

Follow-up for #61 after the main `Publish SDK` run reached the publish step but failed with npm `ENEEDAUTH`. The SDK build/test pieces are now passing; the remaining repo-side gap is that npm trusted publishing needs a current Node/npm runtime when `NPM_TOKEN` is not set.

## Changes

- Switch the SDK publish step to Node 24 with the npm registry configured before `changesets/action` publishes.
- Add a runtime guard that fails early if the publish job does not have npm >= 11.5.1.
- Extend the SDK release scaffold test to keep the trusted-publishing runtime wired.
- Stabilize PDF client timeout tests that failed during preflight because a 20 ms test timeout could expire before the local server observed the request under full-suite load.

## Pass requirements

- [x] `@changesets/cli` remains configured
- [x] `npm publish` workflow remains wired on changeset/main merge
- [x] Semver and changelog wiring remains unchanged
- [x] TypeScript declarations remain shipped by package manifests
- [x] README quickstart remains covered by release scaffold test
- [x] Bun, Node, browser, and Deno runtime coverage remains wired

## Test plan

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sdk-publish.yml"); puts "yaml ok"'`
- `git diff --check`
- `cargo fmt --all --check`
- `pnpm run lint`
- `pnpm turbo run typecheck test --cache-dir=.turbo`
- `RUSTC_WRAPPER= cargo check --workspace --locked`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- `RUSTC_WRAPPER= cargo test -p au-kpis-testing --test sdk_release_scaffold -- --nocapture`
- `RUSTC_WRAPPER= cargo nextest run -p au-kpis-pdf-client --test client request_timeout_bounds_hung_sidecar_calls extract_timeout_bounds_incomplete_response_body extract_stream_timeout_bounds_incomplete_response_body custom_http_client_still_enforces_request_timeout --no-capture`
- `RUSTC_WRAPPER= cargo nextest run --workspace`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks protect --staged`

## Spec impact

No Spec changes required. This keeps the existing SDK release contract and fixes the workflow runtime used to satisfy it.

## Residual setup note

If the next main publish run still fails at npm auth, the remaining work is external npm setup: either add a repo `NPM_TOKEN` secret or configure npm trusted publishing for `ponderingdemocritus/australian-kpis` and the `sdk-publish.yml` workflow for both `@au-kpis/sdk` and `@au-kpis/sdk-generated`.
