### PR TITLE
fix(sdk): normalize trusted publish repository URLs

### DIFF
--- a/crates/testing/tests/sdk_release_scaffold.rs
+++ b/crates/testing/tests/sdk_release_scaffold.rs
@@ -127,6 +127,8 @@ fn assert_publishable_sdk_package(package: &str) {
         "\"engines\"",
         "\"node\": \">=20\"",
         "\"@au-kpis/sdk-generated\": \"workspace:^\"",
+        "\"url\": \"git+https://github.com/ponderingdemocritus/australian-kpis.git\"",
+        "\"directory\": \"packages/sdk\"",
     ] {
         assert!(
             package.contains(expected),
@@ -154,6 +156,8 @@ fn assert_publishable_generated_package(package: &str) {
         "\"access\": \"public\"",
         "\"engines\"",
         "\"node\": \">=20\"",
+        "\"url\": \"git+https://github.com/ponderingdemocritus/australian-kpis.git\"",
+        "\"directory\": \"packages/sdk-generated\"",
     ] {
         assert!(
             package.contains(expected),

--- a/packages/sdk-generated/package.json
+++ b/packages/sdk-generated/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ponderingdemocritus/australian-kpis.git",
+    "url": "git+https://github.com/ponderingdemocritus/australian-kpis.git",
     "directory": "packages/sdk-generated"
   },
   "type": "module",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -5,7 +5,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ponderingdemocritus/australian-kpis.git",
+    "url": "git+https://github.com/ponderingdemocritus/australian-kpis.git",
     "directory": "packages/sdk"
   },
   "type": "module",


### PR DESCRIPTION
## Context

Follow-up for #61. The SDK publish workflow now reaches npm trusted publishing, but npm still rejects the initial publish. npm trusted-publishing troubleshooting requires each package repository URL to exactly match the GitHub repository; local dry-run publish was auto-normalizing our package metadata before this change.

## Changes

- Normalize both SDK package repository URLs to npm canonical git+https form.
- Extend the SDK release scaffold test so the trusted-publishing repository metadata stays wired.

## Test plan

- cargo fmt --all --check
- git diff --check
- pnpm run lint
- pnpm turbo run build --filter=@au-kpis/sdk... --cache-dir=.turbo
- pnpm turbo run typecheck test --cache-dir=.turbo
- RUSTC_WRAPPER= cargo check --workspace --locked
- RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings
- RUSTC_WRAPPER= cargo test -p au-kpis-testing --test sdk_release_scaffold -- --nocapture
- npm publish --dry-run --access public in packages/sdk
- npm publish --dry-run --access public in packages/sdk-generated
- RUSTC_WRAPPER= cargo nextest run -p au-kpis-api --test sigterm api_binary_serves_health_route --no-capture
- RUSTC_WRAPPER= cargo nextest run --workspace (rerun clean: 447 passed, 1 skipped)
- cargo deny check
- cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111
- pnpm audit --audit-level critical
- gitleaks protect --staged

## Notes

The first full nextest run hit a transient Docker/testcontainers Redis startup failure in api_binary_serves_health_route; the isolated rerun passed, then the full workspace rerun passed cleanly.