### PR TITLE
feat(db): observation rollups (#57)

### DIFF
--- a/crates/au-kpis-api-http/src/observations.rs
+++ b/crates/au-kpis-api-http/src/observations.rs
@@ -110,7 +110,7 @@ pub struct ObservationsResponse {
         ("dimensions[]" = Option<Vec<String>>, Query, description = "Dimension filters as repeated key=value values. The handler also accepts dimensions[region]=AUS."),
         ("since" = Option<String>, Query, format = Date, min_length = 1, description = "Inclusive lower time bound as YYYY-MM-DD or RFC3339."),
         ("until" = Option<String>, Query, format = Date, min_length = 1, description = "Inclusive upper time bound as YYYY-MM-DD or RFC3339."),
-        ("frequency" = Option<String>, Query, min_length = 1, pattern = "^(annual|quarterly|monthly|weekly|daily|irregular)$", description = "Optional dataflow frequency filter."),
+        ("frequency" = Option<String>, Query, min_length = 1, pattern = "^(annual|quarterly|monthly|weekly|daily|irregular)$", description = "Optional dataflow frequency filter, or weekly/monthly/quarterly rollup grain."),
         ("format" = Option<String>, Query, min_length = 3, max_length = 7, pattern = "^(json|csv|parquet)$", description = "Response format: json, csv, or parquet."),
         ("cursor" = Option<String>, Query, min_length = 1, description = "Opaque cursor from the previous page."),
         ("limit" = Option<u32>, Query, maximum = 10000, description = "Page size, maximum 10000.")
@@ -250,10 +250,49 @@ struct ParsedObservationsQuery {
     dimensions: BTreeMap<String, String>,
     since: Option<DateTime<Utc>>,
     until: Option<DateTime<Utc>>,
-    frequency: Option<String>,
+    frequency: Option<FrequencyQuery>,
     format: ResponseFormat,
     cursor: Option<ObservationCursor>,
     limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum FrequencyQuery {
+    Dataflow(String),
+    Rollup(RollupGrain),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RollupGrain {
+    Weekly,
+    Monthly,
+    Quarterly,
+}
+
+impl RollupGrain {
+    fn view_name(self) -> &'static str {
+        match self {
+            Self::Weekly => "observations_rollup_weekly",
+            Self::Monthly => "observations_rollup_monthly",
+            Self::Quarterly => "observations_rollup_quarterly",
+        }
+    }
+
+    fn query_label(self) -> &'static str {
+        match self {
+            Self::Weekly => "weekly",
+            Self::Monthly => "monthly",
+            Self::Quarterly => "quarterly",
+        }
+    }
+
+    fn time_precision_label(self) -> &'static str {
+        match self {
+            Self::Weekly => "week",
+            Self::Monthly => "month",
+            Self::Quarterly => "quarter",
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -379,11 +418,12 @@ fn parse_time_bound(name: &str, value: &str) -> Result<DateTime<Utc>, ApiError> 
         .map_err(|err| ApiError::Validation(format!("invalid {name}: {err}")))
 }
 
-fn parse_frequency(value: &str) -> Result<String, ApiError> {
+fn parse_frequency(value: &str) -> Result<FrequencyQuery, ApiError> {
     match value {
-        "daily" | "weekly" | "monthly" | "quarterly" | "annual" | "irregular" => {
-            Ok(value.to_string())
-        }
+        "weekly" => Ok(FrequencyQuery::Rollup(RollupGrain::Weekly)),
+        "monthly" => Ok(FrequencyQuery::Rollup(RollupGrain::Monthly)),
+        "quarterly" => Ok(FrequencyQuery::Rollup(RollupGrain::Quarterly)),
+        "daily" | "annual" | "irregular" => Ok(FrequencyQuery::Dataflow(value.to_string())),
         _ => Err(ApiError::Validation(format!(
             "unsupported frequency `{value}`"
         ))),
@@ -457,7 +497,11 @@ async fn compute_etag(pool: &PgPool, query: &ParsedObservationsQuery) -> Result<
                 max(o.ingested_at) AS max_ingested_at,
                 max(o.time) AS max_time,
                 max(o.revision_no) AS max_revision_no
-         FROM observations_latest o
+         FROM ",
+    );
+    builder.push(observation_source_table(query));
+    builder.push(
+        " o
          JOIN series s ON s.series_key = o.series_key
          JOIN dataflows d ON d.id = s.dataflow_id",
     );
@@ -516,6 +560,17 @@ fn observations_json_cache_key(raw_query: Option<&str>, query: &ParsedObservatio
         query.format,
         BASE64_URL_SAFE_NO_PAD.encode(raw_query.unwrap_or_default())
     )
+}
+
+fn rollup_grain(query: &ParsedObservationsQuery) -> Option<RollupGrain> {
+    match &query.frequency {
+        Some(FrequencyQuery::Rollup(grain)) => Some(*grain),
+        _ => None,
+    }
+}
+
+fn observation_source_table(query: &ParsedObservationsQuery) -> &'static str {
+    rollup_grain(query).map_or("observations_latest", RollupGrain::view_name)
 }
 
 async fn read_cached_json_observations(
@@ -1063,23 +1118,8 @@ fn fetch_observation_rows(
     query: ParsedObservationsQuery,
 ) -> impl Stream<Item = Result<ObservationsRow, ApiError>> + Send + 'static {
     async_stream::try_stream! {
-        let mut builder = QueryBuilder::<Postgres>::new(
-            "SELECT o.series_key,
-                    o.time,
-                    o.revision_no,
-                    o.time_precision,
-                    o.value,
-                    o.status,
-                    o.attributes,
-                    o.ingested_at,
-                    o.source_artifact_id,
-                    s.dimensions,
-                    s.measure_id,
-                    s.unit
-             FROM observations_latest o
-             JOIN series s ON s.series_key = o.series_key
-             JOIN dataflows d ON d.id = s.dataflow_id",
-        );
+        let mut builder = QueryBuilder::<Postgres>::new("");
+        push_observation_select(&mut builder, rollup_grain(&query));
         push_observation_filters(&mut builder, &query);
         builder.push(" ORDER BY o.time ASC, o.series_key ASC LIMIT ");
         builder.push_bind((query.limit + 1) as i64);
@@ -1089,6 +1129,66 @@ fn fetch_observation_rows(
             yield row_to_observation(row)?;
         }
     }
+}
+
+fn push_observation_select(
+    builder: &mut QueryBuilder<'_, Postgres>,
+    rollup_grain: Option<RollupGrain>,
+) {
+    builder.push(
+        "SELECT o.series_key,
+                o.time,
+                o.revision_no,
+                ",
+    );
+
+    if let Some(grain) = rollup_grain {
+        builder.push("'");
+        builder.push(grain.time_precision_label());
+        builder.push(
+            "'::text AS time_precision,
+                o.value,
+                'normal'::text AS status,
+                jsonb_build_object(
+                    'aggregate', 'avg',
+                    'rollup_grain', '",
+        );
+        builder.push(grain.query_label());
+        builder.push(
+            "',
+                    'observations_count', o.observations_count::text,
+                    'min_value', o.min_value::text,
+                    'max_value', o.max_value::text
+                ) AS attributes,
+                o.ingested_at,
+                o.source_artifact_id,
+                s.dimensions,
+                s.measure_id,
+                s.unit
+         FROM ",
+        );
+        builder.push(grain.view_name());
+        builder.push(" o");
+    } else {
+        builder.push(
+            "o.time_precision,
+                o.value,
+                o.status,
+                o.attributes,
+                o.ingested_at,
+                o.source_artifact_id,
+                s.dimensions,
+                s.measure_id,
+                s.unit
+         FROM observations_latest o",
+        );
+    }
+
+    builder.push(
+        "
+         JOIN series s ON s.series_key = o.series_key
+         JOIN dataflows d ON d.id = s.dataflow_id",
+    );
 }
 
 fn push_observation_filters(
@@ -1114,7 +1214,7 @@ fn push_observation_filters(
         builder.push_bind(until);
     }
 
-    if let Some(frequency) = &query.frequency {
+    if let Some(FrequencyQuery::Dataflow(frequency)) = &query.frequency {
         builder.push(" AND d.frequency = ");
         builder.push_bind(frequency.clone());
     }
@@ -1327,7 +1427,10 @@ mod tests {
             query.until,
             Some(Utc.with_ymd_and_hms(2024, 6, 30, 0, 0, 0).unwrap())
         );
-        assert_eq!(query.frequency.as_deref(), Some("quarterly"));
+        assert_eq!(
+            query.frequency,
+            Some(FrequencyQuery::Rollup(RollupGrain::Quarterly))
+        );
         assert_eq!(query.format, ResponseFormat::Csv);
         assert_eq!(query.limit, 500);
         assert_eq!(query.cursor.unwrap().series_key, series_key);

--- a/crates/au-kpis-api-http/tests/observations.rs
+++ b/crates/au-kpis-api-http/tests/observations.rs
@@ -1,4 +1,8 @@
-use std::{collections::BTreeMap, sync::Arc, time::Duration};
+use std::{
+    collections::BTreeMap,
+    sync::Arc,
+    time::{Duration, Instant},
+};
 
 use arrow_array::{Float64Array, StringArray, UInt32Array};
 use au_kpis_api_http::{AppState, ObservationsResponse, router};
@@ -278,6 +282,85 @@ async fn paginated_observations_concatenate_to_the_full_result() {
     }
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn observations_endpoint_uses_monthly_rollup_when_frequency_matches_grain() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let db = TestDb::start("au_kpis_api_observations_rollup").await;
+    seed_observations(db.pool()).await;
+    seed_daily_rollup_observations(db.pool()).await;
+    refresh_monthly_rollup(db.pool()).await;
+    let app = router(test_state(db.pool().clone())).expect("router");
+
+    let response = get_observations_json(
+        app.clone(),
+        "/v1/observations?dataflow=abs.daily&frequency=monthly&limit=10",
+    )
+    .await;
+
+    assert_eq!(response.metadata.dataflow.as_str(), "abs.daily");
+    assert_eq!(response.observations.len(), 2);
+    assert_eq!(
+        response.observations[0].time,
+        Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap()
+    );
+    assert_eq!(
+        response.observations[0].time_precision,
+        au_kpis_domain::TimePrecision::Month
+    );
+    assert_eq!(response.observations[0].value, Some(15.0));
+    assert_eq!(
+        response.observations[0]
+            .attributes
+            .get("aggregate")
+            .map(String::as_str),
+        Some("avg")
+    );
+    assert_eq!(
+        response.observations[0]
+            .attributes
+            .get("observations_count")
+            .map(String::as_str),
+        Some("2")
+    );
+    assert_eq!(
+        response.observations[1].time,
+        Utc.with_ymd_and_hms(2024, 2, 1, 0, 0, 0).unwrap()
+    );
+    assert_eq!(response.observations[1].value, Some(40.0));
+
+    for _ in 0..3 {
+        let response = get_observations_json(
+            app.clone(),
+            "/v1/observations?dataflow=abs.daily&frequency=monthly&limit=10",
+        )
+        .await;
+        assert_eq!(response.observations.len(), 2);
+    }
+
+    let mut samples = Vec::with_capacity(30);
+    for _ in 0..30 {
+        let started = Instant::now();
+        let response = get_observations_json(
+            app.clone(),
+            "/v1/observations?dataflow=abs.daily&frequency=monthly&limit=10",
+        )
+        .await;
+        assert_eq!(response.observations.len(), 2);
+        samples.push(started.elapsed());
+    }
+    samples.sort_unstable();
+    let p95_index = (samples.len() * 95).div_ceil(100).saturating_sub(1);
+    let p95 = samples[p95_index];
+    assert!(
+        p95 < Duration::from_millis(50),
+        "monthly rollup query p95 should stay under 50 ms; p95={p95:?}, samples={samples:?}"
+    );
+}
+
 fn request(uri: &str) -> Request<Body> {
     Request::builder()
         .uri(uri)
@@ -461,6 +544,91 @@ async fn seed_extra_pagination_observations(pool: &PgPool, artifact: ArtifactId)
     }
 }
 
+async fn seed_daily_rollup_observations(pool: &PgPool) {
+    sqlx::query(
+        "INSERT INTO dataflows (
+             id, source_id, name, description, dimensions, measures,
+             frequency, license, attribution, source_url
+         )
+         VALUES (
+             'abs.daily', 'abs', 'Daily indicator', NULL,
+             ARRAY['region'], ARRAY['index'], 'daily', 'CC-BY-4.0',
+             'Source: Australian Bureau of Statistics',
+             'https://www.abs.gov.au/'
+         )",
+    )
+    .execute(pool)
+    .await
+    .expect("insert daily dataflow");
+
+    let artifact = ArtifactId::of_content(b"api observations daily rollup fixture");
+    sqlx::query(
+        "INSERT INTO artifacts (
+             id, source_id, source_url, content_type, response_headers,
+             size_bytes, storage_key, fetched_at
+         )
+         VALUES ($1, 'abs', 'https://example.test/daily.json', 'application/json',
+                 '{}'::jsonb, 128, $2, $3)",
+    )
+    .bind(artifact.digest().as_bytes().as_slice())
+    .bind(format!("artifacts/{artifact}"))
+    .bind(Utc.with_ymd_and_hms(2024, 2, 24, 0, 0, 0).unwrap())
+    .execute(pool)
+    .await
+    .expect("insert daily artifact");
+
+    let dataflow = DataflowId::new("abs.daily").unwrap();
+    let dimensions: BTreeMap<String, String> = [("region".to_string(), "AUS".to_string())]
+        .into_iter()
+        .collect();
+    let key = SeriesKey::derive(
+        &dataflow,
+        dimensions
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    );
+
+    sqlx::query(
+        "INSERT INTO series (
+             series_key, dataflow_id, measure_id, dimensions, unit,
+             first_observed, last_observed, active
+         )
+         VALUES ($1, 'abs.daily', 'index', $2, 'index', $3, $4, true)",
+    )
+    .bind(key.digest().as_bytes().as_slice())
+    .bind(json!(dimensions))
+    .bind(Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap())
+    .bind(Utc.with_ymd_and_hms(2024, 2, 1, 0, 0, 0).unwrap())
+    .execute(pool)
+    .await
+    .expect("insert daily series");
+
+    for (date, value) in [
+        ((2024, 1, 1), 10.0),
+        ((2024, 1, 15), 20.0),
+        ((2024, 2, 1), 40.0),
+    ] {
+        insert_observation(
+            pool,
+            ObservationSeed::new(key, artifact, date, 0, value).with_time_precision("day"),
+        )
+        .await;
+    }
+}
+
+async fn refresh_monthly_rollup(pool: &PgPool) {
+    sqlx::query(
+        "CALL refresh_continuous_aggregate(
+            'observations_rollup_monthly',
+            '2024-01-01 00:00:00+00'::timestamptz,
+            '2024-03-01 00:00:00+00'::timestamptz
+         )",
+    )
+    .execute(pool)
+    .await
+    .expect("refresh monthly continuous aggregate");
+}
+
 async fn insert_series(pool: &PgPool, region: &str) -> SeriesKey {
     let dataflow = DataflowId::new("abs.cpi").unwrap();
     let dimensions: BTreeMap<String, String> = [("region".to_string(), region.to_string())]
@@ -496,6 +664,7 @@ struct ObservationSeed {
     date: (i32, u32, u32),
     revision_no: i32,
     value: f64,
+    time_precision: &'static str,
 }
 
 impl ObservationSeed {
@@ -512,7 +681,13 @@ impl ObservationSeed {
             date,
             revision_no,
             value,
+            time_precision: "quarter",
         }
+    }
+
+    fn with_time_precision(mut self, time_precision: &'static str) -> Self {
+        self.time_precision = time_precision;
+        self
     }
 }
 
@@ -522,8 +697,8 @@ async fn insert_observation(pool: &PgPool, seed: ObservationSeed) {
              series_key, time, revision_no, time_precision, value, status,
              attributes, ingested_at, source_artifact_id
          )
-         VALUES ($1, $2, $3, 'quarter', $4, 'normal',
-                 '{}'::jsonb, $5, $6)",
+         VALUES ($1, $2, $3, $4, $5, 'normal',
+                 '{}'::jsonb, $6, $7)",
     )
     .bind(seed.series_key.digest().as_bytes().as_slice())
     .bind(
@@ -531,6 +706,7 @@ async fn insert_observation(pool: &PgPool, seed: ObservationSeed) {
             .unwrap(),
     )
     .bind(seed.revision_no)
+    .bind(seed.time_precision)
     .bind(seed.value)
     .bind(Utc.with_ymd_and_hms(2024, 4, 24, 0, 0, 0).unwrap())
     .bind(seed.artifact.digest().as_bytes().as_slice())

--- a/crates/au-kpis-db/tests/migrations.rs
+++ b/crates/au-kpis-db/tests/migrations.rs
@@ -64,6 +64,37 @@ async fn has_compression_policy(pool: &PgPool, name: &str) -> bool {
     row.0
 }
 
+async fn continuous_aggregate_exists(pool: &PgPool, name: &str) -> bool {
+    let row: (bool,) = sqlx::query_as(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM   timescaledb_information.continuous_aggregates
+            WHERE  view_name = $1
+        )",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("query continuous aggregate existence");
+    row.0
+}
+
+async fn has_continuous_aggregate_policy(pool: &PgPool, name: &str) -> bool {
+    let row: (bool,) = sqlx::query_as(
+        "SELECT EXISTS (
+            SELECT 1
+            FROM   timescaledb_information.jobs
+            WHERE  proc_name = 'policy_refresh_continuous_aggregate'
+            AND    hypertable_name = $1
+        )",
+    )
+    .bind(name)
+    .fetch_one(pool)
+    .await
+    .expect("query continuous aggregate policy existence");
+    row.0
+}
+
 async fn index_exists(pool: &PgPool, name: &str) -> bool {
     let row: (bool,) = sqlx::query_as(
         "SELECT EXISTS (
@@ -184,6 +215,9 @@ async fn migration_creates_hypertable_and_compression_policy() {
         "measures",
         "observations",
         "observations_latest",
+        "observations_rollup_monthly",
+        "observations_rollup_quarterly",
+        "observations_rollup_weekly",
         "parse_errors",
         "series",
         "sources",
@@ -205,6 +239,21 @@ async fn migration_creates_hypertable_and_compression_policy() {
         assert!(
             index_exists(&pool, expected).await,
             "expected catalog search index `{expected}` to exist"
+        );
+    }
+
+    for expected in [
+        "observations_rollup_weekly",
+        "observations_rollup_monthly",
+        "observations_rollup_quarterly",
+    ] {
+        assert!(
+            continuous_aggregate_exists(&pool, expected).await,
+            "expected continuous aggregate `{expected}` to exist"
+        );
+        assert!(
+            has_continuous_aggregate_policy(&pool, expected).await,
+            "expected continuous aggregate `{expected}` to have a refresh policy"
         );
     }
 }

--- a/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
+++ b/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
@@ -1183,7 +1183,7 @@ expression: emitted_spec()
             }
           },
           {
-            "description": "Optional dataflow frequency filter.",
+            "description": "Optional dataflow frequency filter, or weekly/monthly/quarterly rollup grain.",
             "in": "query",
             "name": "frequency",
             "required": false,

--- a/infra/migrations/0006_observation_rollups.down.sql
+++ b/infra/migrations/0006_observation_rollups.down.sql
@@ -1,0 +1,6 @@
+-- Drop rollup continuous aggregates. Timescale removes associated refresh
+-- jobs when the continuous aggregate views are dropped.
+
+DROP MATERIALIZED VIEW IF EXISTS observations_rollup_quarterly CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS observations_rollup_monthly CASCADE;
+DROP MATERIALIZED VIEW IF EXISTS observations_rollup_weekly CASCADE;

--- a/infra/migrations/0006_observation_rollups.up.sql
+++ b/infra/migrations/0006_observation_rollups.up.sql
@@ -1,0 +1,82 @@
+-- Continuous aggregates for common observation rollups.
+--
+-- These views aggregate numeric, non-missing observations per series. The API
+-- enriches rows with series metadata and rollup attributes at read time.
+
+CREATE MATERIALIZED VIEW observations_rollup_weekly
+WITH (
+    timescaledb.continuous,
+    timescaledb.materialized_only = false
+) AS
+SELECT series_key,
+       time_bucket(INTERVAL '1 week', time) AS time,
+       avg(value)                           AS value,
+       min(value)                           AS min_value,
+       max(value)                           AS max_value,
+       count(value)::BIGINT                 AS observations_count,
+       max(revision_no)::INTEGER            AS revision_no,
+       max(ingested_at)                     AS ingested_at,
+       last(source_artifact_id, ingested_at) AS source_artifact_id
+FROM   observations
+WHERE  value IS NOT NULL
+GROUP  BY series_key, time_bucket(INTERVAL '1 week', time)
+WITH NO DATA;
+
+CREATE MATERIALIZED VIEW observations_rollup_monthly
+WITH (
+    timescaledb.continuous,
+    timescaledb.materialized_only = false
+) AS
+SELECT series_key,
+       time_bucket(INTERVAL '1 month', time) AS time,
+       avg(value)                            AS value,
+       min(value)                            AS min_value,
+       max(value)                            AS max_value,
+       count(value)::BIGINT                  AS observations_count,
+       max(revision_no)::INTEGER             AS revision_no,
+       max(ingested_at)                      AS ingested_at,
+       last(source_artifact_id, ingested_at) AS source_artifact_id
+FROM   observations
+WHERE  value IS NOT NULL
+GROUP  BY series_key, time_bucket(INTERVAL '1 month', time)
+WITH NO DATA;
+
+CREATE MATERIALIZED VIEW observations_rollup_quarterly
+WITH (
+    timescaledb.continuous,
+    timescaledb.materialized_only = false
+) AS
+SELECT series_key,
+       time_bucket(INTERVAL '3 months', time) AS time,
+       avg(value)                             AS value,
+       min(value)                             AS min_value,
+       max(value)                             AS max_value,
+       count(value)::BIGINT                   AS observations_count,
+       max(revision_no)::INTEGER              AS revision_no,
+       max(ingested_at)                       AS ingested_at,
+       last(source_artifact_id, ingested_at)  AS source_artifact_id
+FROM   observations
+WHERE  value IS NOT NULL
+GROUP  BY series_key, time_bucket(INTERVAL '3 months', time)
+WITH NO DATA;
+
+SELECT add_continuous_aggregate_policy(
+    'observations_rollup_weekly',
+    start_offset      => NULL,
+    end_offset        => INTERVAL '1 hour',
+    schedule_interval => INTERVAL '1 hour'
+);
+
+SELECT add_continuous_aggregate_policy(
+    'observations_rollup_monthly',
+    start_offset      => NULL,
+    end_offset        => INTERVAL '1 hour',
+    schedule_interval => INTERVAL '1 hour'
+);
+
+SELECT add_continuous_aggregate_policy(
+    'observations_rollup_quarterly',
+    start_offset      => NULL,
+    end_offset        => INTERVAL '1 hour',
+    schedule_interval => INTERVAL '1 hour'
+);

--- a/openapi.json
+++ b/openapi.json
@@ -315,7 +315,7 @@
           {
             "name": "frequency",
             "in": "query",
-            "description": "Optional dataflow frequency filter.",
+            "description": "Optional dataflow frequency filter, or weekly/monthly/quarterly rollup grain.",
             "required": false,
             "schema": {
               "type": "string",

--- a/packages/sdk-generated/src/client.ts
+++ b/packages/sdk-generated/src/client.ts
@@ -545,7 +545,7 @@ since?: string;
  */
 until?: string;
 /**
- * Optional dataflow frequency filter.
+ * Optional dataflow frequency filter, or weekly/monthly/quarterly rollup grain.
  */
 frequency?: string;
 /**

--- a/packages/sdk-generated/src/types.ts
+++ b/packages/sdk-generated/src/types.ts
@@ -664,7 +664,7 @@ export interface operations {
                 since?: string;
                 /** @description Inclusive upper time bound as YYYY-MM-DD or RFC3339. */
                 until?: string;
-                /** @description Optional dataflow frequency filter. */
+                /** @description Optional dataflow frequency filter, or weekly/monthly/quarterly rollup grain. */
                 frequency?: string;
                 /** @description Response format: json, csv, or parquet. */
                 format?: string;


### PR DESCRIPTION
Closes #57

## Pass requirements

- [x] Weekly/monthly/quarterly continuous aggregates per series
- [x] Refresh policy configured
- [x] API consumes them automatically when query matches grain
- [x] <50 ms p95 on rollup queries

## Test plan

- cargo fmt --all --check
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo nextest run --workspace
- cargo test -p au-kpis-db --test migrations -- --nocapture
- cargo test -p au-kpis-api-http --test observations -- --nocapture
- cargo test -p au-kpis-openapi --test emitter emitted_openapi_matches_snapshot -- --exact --nocapture
- pnpm run lint
- pnpm turbo run typecheck test
- cargo deny check
- cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111
- pnpm audit --audit-level critical
- sqlx migrate run --source infra/migrations against a fresh local Timescale database
- cargo sqlx prepare --workspace against a fresh local Timescale database
- OpenAPI committed/generated normalized diff
- oasdiff breaking target/openapi/base-openapi.json target/openapi/openapi.json
- gitleaks protect --staged --config .gitleaks.toml

Local notes: trivy and k6 are not installed in this workspace, so those gates are left to GitHub CI.

## Spec impact

No Spec changes required; this implements the continuous aggregate rollups already called out in Spec.md database schema and the existing observations frequency query surface.