### PR TITLE
feat(api): add webhook subscriptions (#58)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -508,11 +508,15 @@ dependencies = [
  "criterion",
  "dhat",
  "futures",
+ "hex",
+ "hmac",
  "http",
  "jsonschema",
  "parquet",
+ "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",
@@ -522,6 +526,7 @@ dependencies = [
  "tracing",
  "url",
  "utoipa",
+ "uuid",
 ]
 
 [[package]]
@@ -5386,6 +5391,7 @@ dependencies = [
  "quote",
  "regex",
  "syn",
+ "uuid",
 ]
 
 [[package]]

--- a/crates/au-kpis-api-http/Cargo.toml
+++ b/crates/au-kpis-api-http/Cargo.toml
@@ -25,10 +25,14 @@ chrono = { version = "0.4", default-features = false, features = ["std", "serde"
 dhat = { version = "0.3", optional = true }
 futures = "0.3" # TryStreamExt over sqlx row streams
 http = "1"
+hmac = "0.12" # HMAC-SHA256 signatures for webhook deliveries
+hex = "0.4" # lowercase signature encoding for webhook headers
 parquet = { version = "58.3.0", default-features = false, features = ["arrow", "async", "zstd"] } # encode streamed Parquet responses with zstd and without unused codecs
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] } # outbound webhook delivery client
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sqlx = { version = "0.8", default-features = false, features = ["postgres", "runtime-tokio", "tls-rustls", "chrono", "json"] }
+sha2 = "0.10" # HMAC-SHA256 digest implementation
+sqlx = { version = "0.8", default-features = false, features = ["postgres", "runtime-tokio", "tls-rustls", "chrono", "json", "uuid"] }
 thiserror = "2"
 tokio = { version = "1", features = ["signal"] }
 tokio-util = "0.7"
@@ -36,7 +40,8 @@ tower = { version = "0.5", features = ["timeout"] }
 tower-http = { version = "0.6", features = ["compression-full", "cors", "request-id", "timeout", "trace"] }
 tracing = "0.1"
 url = "2" # robust query-string decoding for dimensions[region]=AUS filters
-utoipa = { version = "5", features = ["axum_extras", "chrono"] }
+utoipa = { version = "5", features = ["axum_extras", "chrono", "uuid"] }
+uuid = { version = "1", features = ["serde", "v4"] }
 
 [dev-dependencies]
 anyhow = "1"

--- a/crates/au-kpis-api-http/src/auth.rs
+++ b/crates/au-kpis-api-http/src/auth.rs
@@ -2,12 +2,41 @@
 
 use au_kpis_auth::{ApiKeyManager, AuthError, VerifiedApiKey};
 use axum::{
-    extract::{Request, State},
+    extract::{FromRequestParts, Request, State},
+    http::{HeaderMap, request::Parts},
     middleware::Next,
     response::{IntoResponse, Response},
 };
 
 use crate::{ApiError, AppState};
+
+/// API-key identity required by protected handlers.
+///
+/// As a handler extractor this runs after axum has accepted the request method
+/// for a route, so unsupported methods still receive axum's 405 response.
+#[derive(Debug, Clone)]
+pub struct RequiredApiKey {
+    /// Verified API key identity.
+    pub key: VerifiedApiKey,
+}
+
+#[axum::async_trait]
+impl FromRequestParts<AppState> for RequiredApiKey {
+    type Rejection = ApiError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        if let Some(key) = parts.extensions.get::<VerifiedApiKey>() {
+            return Ok(Self { key: key.clone() });
+        }
+
+        let key = verify_api_key_header(state, &parts.headers).await?;
+        parts.extensions.insert(key.clone());
+        Ok(Self { key })
+    }
+}
 
 /// Validate the `X-API-Key` header and attach the verified key to extensions.
 pub async fn require_api_key(
@@ -19,23 +48,34 @@ pub async fn require_api_key(
         return next.run(request).await;
     }
 
-    let Some(header) = request.headers().get("x-api-key") else {
-        return unauthorized().into_response();
-    };
-    let Ok(plaintext) = header.to_str() else {
-        return unauthorized().into_response();
-    };
-
-    let manager = ApiKeyManager::new(state.db.clone(), state.cache.clone());
-    match manager.verify(plaintext).await {
+    match verify_api_key_header(&state, request.headers()).await {
         Ok(verified) => {
             request.extensions_mut().insert(verified);
             next.run(request).await
         }
-        Err(AuthError::InvalidApiKey | AuthError::Validation(_)) => unauthorized().into_response(),
+        Err(err) => err.into_response(),
+    }
+}
+
+/// Verify the `X-API-Key` header from a request.
+pub async fn verify_api_key_header(
+    state: &AppState,
+    headers: &HeaderMap,
+) -> Result<VerifiedApiKey, ApiError> {
+    let Some(header) = headers.get("x-api-key") else {
+        return Err(unauthorized());
+    };
+    let Ok(plaintext) = header.to_str() else {
+        return Err(unauthorized());
+    };
+
+    let manager = ApiKeyManager::new(state.db.clone(), state.cache.clone());
+    match manager.verify(plaintext).await {
+        Ok(verified) => Ok(verified),
+        Err(AuthError::InvalidApiKey | AuthError::Validation(_)) => Err(unauthorized()),
         Err(err) => {
             tracing::error!(error = %err, "api key verification failed");
-            ApiError::Internal.into_response()
+            Err(ApiError::Internal)
         }
     }
 }

--- a/crates/au-kpis-api-http/src/docs.rs
+++ b/crates/au-kpis-api-http/src/docs.rs
@@ -15,6 +15,10 @@ use crate::{
     routes::{__path_health, __path_openapi, HealthResponse},
     search::{__path_search_catalog, SearchQuery, SearchResponse, SearchResult, SearchResultKind},
     series::{__path_get_series, SeriesLookupResponse, SeriesRevisionMetadata},
+    subscriptions::{
+        __path_create_subscription, CreateSubscriptionRequest, CreateSubscriptionResponse,
+        SubscriptionDetails,
+    },
 };
 
 /// Root OpenAPI document for the API handlers in this crate.
@@ -33,7 +37,8 @@ use crate::{
         get_dataflow_codelist,
         list_observations,
         get_series,
-        search_catalog
+        search_catalog,
+        create_subscription
     ),
     components(schemas(
         au_kpis_domain::Code,
@@ -57,13 +62,33 @@ use crate::{
         SearchResult,
         SearchResultKind,
         SeriesLookupResponse,
-        SeriesRevisionMetadata
+        SeriesRevisionMetadata,
+        CreateSubscriptionRequest,
+        CreateSubscriptionResponse,
+        SubscriptionDetails
     )),
+    modifiers(&SecurityAddon),
     tags(
         (name = "dataflows", description = "Dataflow catalog and codelists"),
         (name = "observations", description = "Time-series observations"),
         (name = "search", description = "Ranked catalog search"),
-        (name = "series", description = "Series metadata lookups")
+        (name = "series", description = "Series metadata lookups"),
+        (name = "subscriptions", description = "Webhook subscriptions")
     )
 )]
 pub struct ApiDoc;
+
+#[derive(Debug)]
+struct SecurityAddon;
+
+impl utoipa::Modify for SecurityAddon {
+    fn modify(&self, openapi: &mut utoipa::openapi::OpenApi) {
+        use utoipa::openapi::security::{ApiKey, ApiKeyValue, SecurityScheme};
+
+        let components = openapi.components.get_or_insert_with(Default::default);
+        components.add_security_scheme(
+            "ApiKeyAuth",
+            SecurityScheme::ApiKey(ApiKey::Header(ApiKeyValue::new("X-API-Key"))),
+        );
+    }
+}

--- a/crates/au-kpis-api-http/src/lib.rs
+++ b/crates/au-kpis-api-http/src/lib.rs
@@ -35,7 +35,7 @@ pub mod series;
 pub mod state;
 pub mod subscriptions;
 
-pub use auth::require_api_key;
+pub use auth::{RequiredApiKey, require_api_key, verify_api_key_header};
 pub use dataflows::{
     DataflowCodelistResponse, DataflowDetailResponse, DataflowsQuery, DataflowsResponse,
     get_dataflow, get_dataflow_codelist, list_dataflows,
@@ -103,9 +103,7 @@ pub fn router(state: AppState) -> Result<Router, RouterBuildError> {
             .route("/v1/search", get(search::search_catalog))
             .route(
                 "/v1/subscriptions",
-                post(subscriptions::create_subscription).route_layer(
-                    middleware::from_fn_with_state(state.clone(), require_api_key),
-                ),
+                post(subscriptions::create_subscription),
             )
             .route("/v1/openapi.json", get(openapi)),
         state,

--- a/crates/au-kpis-api-http/src/lib.rs
+++ b/crates/au-kpis-api-http/src/lib.rs
@@ -12,7 +12,7 @@ use axum::{
     http::{HeaderValue, Method, header, header::InvalidHeaderValue},
     middleware,
     response::IntoResponse,
-    routing::get,
+    routing::{get, post},
 };
 use thiserror::Error;
 use tower::{BoxError, ServiceBuilder, timeout::TimeoutLayer};
@@ -33,6 +33,7 @@ pub mod routes;
 pub mod search;
 pub mod series;
 pub mod state;
+pub mod subscriptions;
 
 pub use auth::require_api_key;
 pub use dataflows::{
@@ -50,6 +51,12 @@ pub use routes::{HealthResponse, health, openapi};
 pub use search::{SearchQuery, SearchResponse, SearchResult, SearchResultKind, search_catalog};
 pub use series::{SeriesLookupResponse, SeriesRevisionMetadata, get_series};
 pub use state::AppState;
+pub use subscriptions::{
+    CreateSubscriptionRequest, CreateSubscriptionResponse, DeliveryOptions, DeliveryRunOutcome,
+    SubscriptionDetails, SubscriptionError, WebhookDeliveryEvent, create_subscription,
+    deliver_due_webhooks, enqueue_data_update_event, run_webhook_delivery_worker,
+    spawn_webhook_delivery_worker,
+};
 
 const REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
 const REQUEST_ID_HEADER: header::HeaderName = header::HeaderName::from_static("x-request-id");
@@ -94,6 +101,12 @@ pub fn router(state: AppState) -> Result<Router, RouterBuildError> {
             .route("/v1/observations", get(observations::list_observations))
             .route("/v1/series/:dataflow/:series_key", get(series::get_series))
             .route("/v1/search", get(search::search_catalog))
+            .route(
+                "/v1/subscriptions",
+                post(subscriptions::create_subscription).route_layer(
+                    middleware::from_fn_with_state(state.clone(), require_api_key),
+                ),
+            )
             .route("/v1/openapi.json", get(openapi)),
         state,
     )
@@ -110,7 +123,7 @@ async fn handle_timeout_error(err: BoxError) -> impl IntoResponse {
 
 fn cors_layer(config: &AppConfig) -> Result<CorsLayer, RouterBuildError> {
     let mut layer = CorsLayer::new()
-        .allow_methods([Method::GET])
+        .allow_methods([Method::GET, Method::POST])
         .allow_headers([
             header::ACCEPT,
             header::ACCEPT_ENCODING,

--- a/crates/au-kpis-api-http/src/rate_limit.rs
+++ b/crates/au-kpis-api-http/src/rate_limit.rs
@@ -51,20 +51,17 @@ async fn verified_key(
     let Some(header) = request.headers().get("x-api-key") else {
         return Ok(None);
     };
-    let plaintext = header
-        .to_str()
-        .map_err(|_| ApiError::Unauthorized("missing or invalid API key".into()))?
-        .to_owned();
+    let Ok(plaintext) = header.to_str() else {
+        return Ok(None);
+    };
 
     let manager = ApiKeyManager::new(state.db.clone(), state.cache.clone());
-    match manager.verify(&plaintext).await {
+    match manager.verify(plaintext).await {
         Ok(verified) => {
             request.extensions_mut().insert(verified.clone());
             Ok(Some(verified))
         }
-        Err(AuthError::InvalidApiKey | AuthError::Validation(_)) => {
-            Err(ApiError::Unauthorized("missing or invalid API key".into()))
-        }
+        Err(AuthError::InvalidApiKey | AuthError::Validation(_)) => Ok(None),
         Err(err) => {
             tracing::error!(error = %err, "api key verification failed during rate limiting");
             Err(ApiError::Internal)

--- a/crates/au-kpis-api-http/src/subscriptions.rs
+++ b/crates/au-kpis-api-http/src/subscriptions.rs
@@ -2,10 +2,9 @@
 
 use std::time::{Duration, Instant};
 
-use au_kpis_auth::VerifiedApiKey;
 use au_kpis_domain::ids::{ArtifactId, DataflowId};
 use axum::{
-    Extension, Json,
+    Json,
     extract::State,
     http::{HeaderMap, HeaderValue, StatusCode, header},
     response::{IntoResponse, Response},
@@ -23,7 +22,7 @@ use tokio_util::sync::CancellationToken;
 use utoipa::ToSchema;
 use uuid::Uuid;
 
-use crate::{ApiError, AppState};
+use crate::{ApiError, AppState, auth::RequiredApiKey};
 
 type HmacSha256 = Hmac<Sha256>;
 
@@ -154,7 +153,7 @@ pub enum SubscriptionError {
 )]
 pub async fn create_subscription(
     State(state): State<AppState>,
-    Extension(api_key): Extension<VerifiedApiKey>,
+    RequiredApiKey { key: api_key }: RequiredApiKey,
     Json(request): Json<CreateSubscriptionRequest>,
 ) -> Result<Response, ApiError> {
     let response = create_subscription_record(&state.db, api_key.id, request)

--- a/crates/au-kpis-api-http/src/subscriptions.rs
+++ b/crates/au-kpis-api-http/src/subscriptions.rs
@@ -1,0 +1,793 @@
+//! `/v1/subscriptions` and webhook delivery helpers.
+
+use std::time::{Duration, Instant};
+
+use au_kpis_auth::VerifiedApiKey;
+use au_kpis_domain::ids::{ArtifactId, DataflowId};
+use axum::{
+    Extension, Json,
+    extract::State,
+    http::{HeaderMap, HeaderValue, StatusCode, header},
+    response::{IntoResponse, Response},
+};
+use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+use chrono::{DateTime, Duration as ChronoDuration, Utc};
+use hmac::{Hmac, Mac, digest::InvalidLength};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::{Value, json};
+use sha2::Sha256;
+use sqlx::{PgPool, Row};
+use thiserror::Error;
+use tokio_util::sync::CancellationToken;
+use utoipa::ToSchema;
+use uuid::Uuid;
+
+use crate::{ApiError, AppState};
+
+type HmacSha256 = Hmac<Sha256>;
+
+const EVENT_DATA_UPDATED: &str = "data.updated";
+const DEFAULT_DELIVERY_MAX_ATTEMPTS: i32 = 5;
+const DEFAULT_DELIVERY_BATCH_SIZE: u32 = 100;
+const DEFAULT_DELIVERY_BASE_BACKOFF: Duration = Duration::from_secs(30);
+const DEFAULT_DELIVERY_MAX_BACKOFF: Duration = Duration::from_secs(60 * 60);
+const DEFAULT_DELIVERY_POLL_INTERVAL: Duration = Duration::from_secs(5);
+const WEBHOOK_REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Request body for `POST /v1/subscriptions`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct CreateSubscriptionRequest {
+    /// Absolute HTTP(S) URL to receive webhook deliveries.
+    pub url: String,
+    /// Optional dataflow filter. Empty means every dataflow update.
+    #[serde(default)]
+    pub dataflow_ids: Vec<DataflowId>,
+}
+
+/// Created webhook subscription details.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct SubscriptionDetails {
+    /// Stable subscription id.
+    pub id: Uuid,
+    /// Delivery target URL.
+    pub url: String,
+    /// Dataflow filter attached to the subscription.
+    pub dataflow_ids: Vec<DataflowId>,
+    /// Current subscription status.
+    pub status: String,
+    /// UTC creation timestamp.
+    pub created_at: DateTime<Utc>,
+    /// HMAC signing secret shown once at creation.
+    pub signing_secret: String,
+}
+
+/// Response body for `POST /v1/subscriptions`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
+pub struct CreateSubscriptionResponse {
+    /// Created subscription.
+    pub subscription: SubscriptionDetails,
+}
+
+/// Data-update event used to fan out webhook delivery rows.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WebhookDeliveryEvent {
+    /// Dataflow that received new observations.
+    pub dataflow_id: DataflowId,
+    /// Optional source artifact that produced the update.
+    pub artifact_id: Option<ArtifactId>,
+    /// Number of observations loaded for the update.
+    pub observations_loaded: u64,
+    /// Timestamp associated with the update.
+    pub occurred_at: DateTime<Utc>,
+}
+
+/// Runtime options for a webhook delivery sweep.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DeliveryOptions {
+    /// Maximum attempts before marking a delivery failed.
+    pub max_attempts: i32,
+    /// Delay after the first failed attempt.
+    pub base_backoff: Duration,
+    /// Maximum retry delay.
+    pub max_backoff: Duration,
+    /// Maximum due deliveries claimed in one sweep.
+    pub batch_size: u32,
+}
+
+impl Default for DeliveryOptions {
+    fn default() -> Self {
+        Self {
+            max_attempts: DEFAULT_DELIVERY_MAX_ATTEMPTS,
+            base_backoff: DEFAULT_DELIVERY_BASE_BACKOFF,
+            max_backoff: DEFAULT_DELIVERY_MAX_BACKOFF,
+            batch_size: DEFAULT_DELIVERY_BATCH_SIZE,
+        }
+    }
+}
+
+/// Aggregate result of one webhook delivery sweep.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct DeliveryRunOutcome {
+    /// Deliveries attempted.
+    pub attempted: u64,
+    /// Deliveries successfully accepted by subscribers.
+    pub delivered: u64,
+    /// Deliveries permanently failed after exhausting attempts.
+    pub failed: u64,
+}
+
+/// Errors returned by webhook subscription and delivery operations.
+#[derive(Debug, Error)]
+pub enum SubscriptionError {
+    /// Invalid caller input or persisted state.
+    #[error("subscription validation: {0}")]
+    Validation(String),
+    /// Database access failed.
+    #[error(transparent)]
+    Db(#[from] sqlx::Error),
+    /// HTTP delivery failed before a response was received.
+    #[error(transparent)]
+    Http(#[from] reqwest::Error),
+    /// JSON serialization failed.
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    /// HMAC signing failed.
+    #[error(transparent)]
+    Hmac(#[from] InvalidLength),
+}
+
+/// `POST /v1/subscriptions`.
+#[utoipa::path(
+    post,
+    operation_id = "createSubscription",
+    path = "/v1/subscriptions",
+    request_body(content = CreateSubscriptionRequest, content_type = "application/json"),
+    responses(
+        (status = 201, description = "Subscription created.", body = CreateSubscriptionResponse, content_type = "application/json"),
+        (status = 400, description = "Invalid subscription request.", body = crate::ProblemDetails, content_type = "application/problem+json"),
+        (status = 401, description = "Missing or invalid API key.", body = crate::ProblemDetails, content_type = "application/problem+json"),
+        (status = 500, description = "Internal error.", body = crate::ProblemDetails, content_type = "application/problem+json")
+    ),
+    security(("ApiKeyAuth" = [])),
+    tag = "subscriptions"
+)]
+pub async fn create_subscription(
+    State(state): State<AppState>,
+    Extension(api_key): Extension<VerifiedApiKey>,
+    Json(request): Json<CreateSubscriptionRequest>,
+) -> Result<Response, ApiError> {
+    let response = create_subscription_record(&state.db, api_key.id, request)
+        .await
+        .map_err(subscription_error_to_api_error)?;
+    Ok((StatusCode::CREATED, Json(response)).into_response())
+}
+
+/// Insert webhook delivery rows for every active matching subscription.
+#[tracing::instrument(skip(pool, event), fields(dataflow_id = %event.dataflow_id))]
+pub async fn enqueue_data_update_event(
+    pool: &PgPool,
+    event: &WebhookDeliveryEvent,
+) -> Result<u64, SubscriptionError> {
+    let payload = delivery_payload(event);
+    let artifact_bytes = event
+        .artifact_id
+        .map(|artifact_id| artifact_id.digest().as_bytes().to_vec());
+    let rows = sqlx::query(
+        "INSERT INTO webhook_deliveries (
+             subscription_id, event_type, dataflow_id, artifact_id, payload,
+             status, attempts, max_attempts, next_attempt_at
+         )
+         SELECT id, $2, $1, $3, $4, 'pending', 0, $5, now()
+         FROM webhook_subscriptions
+         WHERE status = 'active'
+           AND (cardinality(dataflow_ids) = 0 OR $1 = ANY(dataflow_ids))",
+    )
+    .bind(event.dataflow_id.as_str())
+    .bind(EVENT_DATA_UPDATED)
+    .bind(artifact_bytes)
+    .bind(payload)
+    .bind(DEFAULT_DELIVERY_MAX_ATTEMPTS)
+    .execute(pool)
+    .await?;
+
+    tracing::info!(
+        dataflow_id = %event.dataflow_id,
+        deliveries = rows.rows_affected(),
+        "webhook deliveries enqueued"
+    );
+
+    Ok(rows.rows_affected())
+}
+
+/// Deliver due webhook rows and persist success/failure attempts.
+#[tracing::instrument(skip(pool, client))]
+pub async fn deliver_due_webhooks(
+    pool: &PgPool,
+    client: &Client,
+    now: DateTime<Utc>,
+    options: DeliveryOptions,
+) -> Result<DeliveryRunOutcome, SubscriptionError> {
+    validate_delivery_options(options)?;
+    let deliveries = claim_due_deliveries(pool, now, options.batch_size).await?;
+    let mut outcome = DeliveryRunOutcome::default();
+
+    for delivery in deliveries {
+        outcome.attempted += 1;
+        let attempt = delivery.attempts + 1;
+        let started = Instant::now();
+        let result = send_delivery(client, &delivery, now).await;
+        let latency_ms = started.elapsed().as_millis().min(i64::MAX as u128) as i64;
+
+        match result {
+            Ok(status) if status.is_success() => {
+                record_delivery_success(
+                    pool,
+                    delivery.id,
+                    attempt,
+                    status.as_u16(),
+                    now,
+                    latency_ms,
+                )
+                .await?;
+                outcome.delivered += 1;
+                tracing::info!(
+                    delivery_id = delivery.id,
+                    subscription_id = %delivery.subscription_id,
+                    attempt,
+                    status_code = status.as_u16(),
+                    "webhook delivery accepted"
+                );
+            }
+            Ok(status) => {
+                if record_delivery_failure(
+                    pool,
+                    FailureRecord {
+                        delivery_id: delivery.id,
+                        subscription_id: delivery.subscription_id,
+                        attempt,
+                        max_attempts: effective_max_attempts(&delivery, options),
+                        now,
+                        status_code: Some(status.as_u16()),
+                        error_message: format!("subscriber returned HTTP {}", status.as_u16()),
+                        latency_ms,
+                        options,
+                    },
+                )
+                .await?
+                {
+                    outcome.failed += 1;
+                }
+            }
+            Err(err) => {
+                let failed = record_delivery_failure(
+                    pool,
+                    FailureRecord {
+                        delivery_id: delivery.id,
+                        subscription_id: delivery.subscription_id,
+                        attempt,
+                        max_attempts: effective_max_attempts(&delivery, options),
+                        now,
+                        status_code: None,
+                        error_message: err.to_string(),
+                        latency_ms,
+                        options,
+                    },
+                )
+                .await?;
+                if failed {
+                    outcome.failed += 1;
+                }
+            }
+        }
+    }
+
+    Ok(outcome)
+}
+
+/// Spawn the long-running webhook delivery worker used by the API process.
+#[must_use]
+pub fn spawn_webhook_delivery_worker(
+    pool: PgPool,
+    shutdown: CancellationToken,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        if let Err(err) = run_webhook_delivery_worker(
+            pool,
+            shutdown,
+            DeliveryOptions::default(),
+            DEFAULT_DELIVERY_POLL_INTERVAL,
+        )
+        .await
+        {
+            tracing::error!(error = %err, "webhook delivery worker exited");
+        }
+    })
+}
+
+/// Run a polling worker that delivers due webhook rows until shutdown.
+#[tracing::instrument(skip(pool, shutdown))]
+pub async fn run_webhook_delivery_worker(
+    pool: PgPool,
+    shutdown: CancellationToken,
+    options: DeliveryOptions,
+    poll_interval: Duration,
+) -> Result<(), SubscriptionError> {
+    validate_delivery_options(options)?;
+    if poll_interval.is_zero() {
+        return Err(SubscriptionError::Validation(
+            "poll_interval must be positive".into(),
+        ));
+    }
+
+    let client = Client::new();
+    loop {
+        tokio::select! {
+            () = shutdown.cancelled() => {
+                tracing::info!("webhook delivery worker stopped");
+                return Ok(());
+            }
+            () = tokio::time::sleep(poll_interval) => {
+                match deliver_due_webhooks(&pool, &client, Utc::now(), options).await {
+                    Ok(outcome) if outcome.attempted > 0 => {
+                        tracing::info!(
+                            attempted = outcome.attempted,
+                            delivered = outcome.delivered,
+                            failed = outcome.failed,
+                            "webhook delivery sweep completed"
+                        );
+                    }
+                    Ok(_) => {}
+                    Err(err) => {
+                        tracing::warn!(error = %err, "webhook delivery sweep failed");
+                    }
+                }
+            }
+        }
+    }
+}
+
+async fn create_subscription_record(
+    pool: &PgPool,
+    api_key_id: Uuid,
+    request: CreateSubscriptionRequest,
+) -> Result<CreateSubscriptionResponse, SubscriptionError> {
+    validate_subscription_request(pool, &request).await?;
+
+    let id = Uuid::new_v4();
+    let signing_secret = generate_signing_secret();
+    let dataflow_ids = request
+        .dataflow_ids
+        .iter()
+        .map(DataflowId::as_str)
+        .collect::<Vec<_>>();
+
+    let row = sqlx::query(
+        "INSERT INTO webhook_subscriptions (
+             id, api_key_id, target_url, dataflow_ids, signing_secret
+         )
+         VALUES ($1, $2, $3, $4, $5)
+         RETURNING created_at",
+    )
+    .bind(id)
+    .bind(api_key_id)
+    .bind(&request.url)
+    .bind(dataflow_ids)
+    .bind(&signing_secret)
+    .fetch_one(pool)
+    .await?;
+
+    tracing::info!(
+        subscription_id = %id,
+        api_key_id = %api_key_id,
+        dataflow_count = request.dataflow_ids.len(),
+        "webhook subscription created"
+    );
+
+    Ok(CreateSubscriptionResponse {
+        subscription: SubscriptionDetails {
+            id,
+            url: request.url,
+            dataflow_ids: request.dataflow_ids,
+            status: "active".into(),
+            created_at: row.get("created_at"),
+            signing_secret,
+        },
+    })
+}
+
+async fn validate_subscription_request(
+    pool: &PgPool,
+    request: &CreateSubscriptionRequest,
+) -> Result<(), SubscriptionError> {
+    let url = url::Url::parse(&request.url)
+        .map_err(|err| SubscriptionError::Validation(format!("invalid url: {err}")))?;
+    if !matches!(url.scheme(), "http" | "https") {
+        return Err(SubscriptionError::Validation(
+            "url must use http or https".into(),
+        ));
+    }
+
+    for dataflow_id in &request.dataflow_ids {
+        let exists: bool =
+            sqlx::query_scalar("SELECT EXISTS (SELECT 1 FROM dataflows WHERE id = $1)")
+                .bind(dataflow_id.as_str())
+                .fetch_one(pool)
+                .await?;
+        if !exists {
+            return Err(SubscriptionError::Validation(format!(
+                "unknown dataflow `{dataflow_id}`"
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+fn generate_signing_secret() -> String {
+    let mut bytes = [0_u8; 32];
+    bytes[..16].copy_from_slice(Uuid::new_v4().as_bytes());
+    bytes[16..].copy_from_slice(Uuid::new_v4().as_bytes());
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn delivery_payload(event: &WebhookDeliveryEvent) -> Value {
+    json!({
+        "event": EVENT_DATA_UPDATED,
+        "dataflow_id": event.dataflow_id,
+        "artifact_id": event.artifact_id,
+        "observations_loaded": event.observations_loaded,
+        "occurred_at": event.occurred_at,
+    })
+}
+
+#[derive(Debug, Clone)]
+struct ClaimedDelivery {
+    id: i64,
+    subscription_id: Uuid,
+    target_url: String,
+    signing_secret: String,
+    payload: Value,
+    attempts: i32,
+    max_attempts: i32,
+}
+
+async fn claim_due_deliveries(
+    pool: &PgPool,
+    now: DateTime<Utc>,
+    batch_size: u32,
+) -> Result<Vec<ClaimedDelivery>, SubscriptionError> {
+    let rows = sqlx::query(
+        "WITH due AS (
+             SELECT id
+             FROM webhook_deliveries
+             WHERE status = 'pending'
+               AND next_attempt_at <= $1
+             ORDER BY next_attempt_at ASC, id ASC
+             LIMIT $2
+             FOR UPDATE SKIP LOCKED
+         )
+         UPDATE webhook_deliveries d
+         SET status = 'delivering',
+             updated_at = $1
+         FROM due, webhook_subscriptions s
+         WHERE d.id = due.id
+           AND s.id = d.subscription_id
+         RETURNING d.id, d.subscription_id, s.target_url, s.signing_secret,
+                   d.payload, d.attempts, d.max_attempts",
+    )
+    .bind(now)
+    .bind(i64::from(batch_size))
+    .fetch_all(pool)
+    .await?;
+
+    rows.into_iter()
+        .map(|row| {
+            Ok(ClaimedDelivery {
+                id: row.try_get("id")?,
+                subscription_id: row.try_get("subscription_id")?,
+                target_url: row.try_get("target_url")?,
+                signing_secret: row.try_get("signing_secret")?,
+                payload: row.try_get("payload")?,
+                attempts: row.try_get("attempts")?,
+                max_attempts: row.try_get("max_attempts")?,
+            })
+        })
+        .collect()
+}
+
+async fn send_delivery(
+    client: &Client,
+    delivery: &ClaimedDelivery,
+    now: DateTime<Utc>,
+) -> Result<StatusCode, SubscriptionError> {
+    let body = serde_json::to_vec(&delivery.payload)?;
+    let timestamp = now.to_rfc3339();
+    let signature = sign_payload(&delivery.signing_secret, &timestamp, &body)?;
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/json"),
+    );
+    headers.insert(
+        "x-au-kpis-webhook-id",
+        HeaderValue::from_str(&delivery.id.to_string())
+            .map_err(|err| SubscriptionError::Validation(err.to_string()))?,
+    );
+    headers.insert(
+        "x-au-kpis-webhook-timestamp",
+        HeaderValue::from_str(&timestamp)
+            .map_err(|err| SubscriptionError::Validation(err.to_string()))?,
+    );
+    headers.insert(
+        "x-au-kpis-webhook-signature",
+        HeaderValue::from_str(&signature)
+            .map_err(|err| SubscriptionError::Validation(err.to_string()))?,
+    );
+
+    let response = tokio::time::timeout(
+        WEBHOOK_REQUEST_TIMEOUT,
+        client
+            .post(&delivery.target_url)
+            .headers(headers)
+            .body(body)
+            .send(),
+    )
+    .await
+    .map_err(|_| SubscriptionError::Validation("webhook request timed out".into()))??;
+
+    StatusCode::from_u16(response.status().as_u16())
+        .map_err(|err| SubscriptionError::Validation(err.to_string()))
+}
+
+fn sign_payload(secret: &str, timestamp: &str, body: &[u8]) -> Result<String, SubscriptionError> {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())?;
+    mac.update(timestamp.as_bytes());
+    mac.update(b".");
+    mac.update(body);
+    Ok(format!(
+        "sha256={}",
+        hex::encode(mac.finalize().into_bytes())
+    ))
+}
+
+async fn record_delivery_success(
+    pool: &PgPool,
+    delivery_id: i64,
+    attempt: i32,
+    status_code: u16,
+    now: DateTime<Utc>,
+    latency_ms: i64,
+) -> Result<(), SubscriptionError> {
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        "INSERT INTO webhook_delivery_attempts (
+             delivery_id, attempt_no, success, status_code, attempted_at, latency_ms
+         )
+         VALUES ($1, $2, TRUE, $3, $4, $5)",
+    )
+    .bind(delivery_id)
+    .bind(attempt)
+    .bind(i32::from(status_code))
+    .bind(now)
+    .bind(latency_ms)
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        "UPDATE webhook_deliveries
+         SET status = 'delivered',
+             attempts = $2,
+             next_attempt_at = NULL,
+             delivered_at = $3,
+             last_status_code = $4,
+             last_error = NULL,
+             updated_at = $3
+         WHERE id = $1",
+    )
+    .bind(delivery_id)
+    .bind(attempt)
+    .bind(now)
+    .bind(i32::from(status_code))
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}
+
+#[derive(Debug)]
+struct FailureRecord {
+    delivery_id: i64,
+    subscription_id: Uuid,
+    attempt: i32,
+    max_attempts: i32,
+    now: DateTime<Utc>,
+    status_code: Option<u16>,
+    error_message: String,
+    latency_ms: i64,
+    options: DeliveryOptions,
+}
+
+async fn record_delivery_failure(
+    pool: &PgPool,
+    failure: FailureRecord,
+) -> Result<bool, SubscriptionError> {
+    let exhausted = failure.attempt >= failure.max_attempts;
+    let next_attempt_at = if exhausted {
+        None
+    } else {
+        Some(failure.now + chrono_backoff(failure.attempt, failure.options)?)
+    };
+    let status = if exhausted { "failed" } else { "pending" };
+    let status_code = failure.status_code.map(i32::from);
+
+    let mut tx = pool.begin().await?;
+    sqlx::query(
+        "INSERT INTO webhook_delivery_attempts (
+             delivery_id, attempt_no, success, status_code, error_message,
+             attempted_at, latency_ms
+         )
+         VALUES ($1, $2, FALSE, $3, $4, $5, $6)",
+    )
+    .bind(failure.delivery_id)
+    .bind(failure.attempt)
+    .bind(status_code)
+    .bind(&failure.error_message)
+    .bind(failure.now)
+    .bind(failure.latency_ms)
+    .execute(&mut *tx)
+    .await?;
+
+    sqlx::query(
+        "UPDATE webhook_deliveries
+         SET status = $2,
+             attempts = $3,
+             next_attempt_at = $4,
+             last_status_code = $5,
+             last_error = $6,
+             updated_at = $7
+         WHERE id = $1",
+    )
+    .bind(failure.delivery_id)
+    .bind(status)
+    .bind(failure.attempt)
+    .bind(next_attempt_at)
+    .bind(status_code)
+    .bind(&failure.error_message)
+    .bind(failure.now)
+    .execute(&mut *tx)
+    .await?;
+    tx.commit().await?;
+
+    if exhausted {
+        tracing::warn!(
+            delivery_id = failure.delivery_id,
+            subscription_id = %failure.subscription_id,
+            attempt = failure.attempt,
+            error = %failure.error_message,
+            "webhook delivery failed permanently"
+        );
+    } else {
+        tracing::warn!(
+            delivery_id = failure.delivery_id,
+            subscription_id = %failure.subscription_id,
+            attempt = failure.attempt,
+            next_attempt_at = ?next_attempt_at,
+            error = %failure.error_message,
+            "webhook delivery scheduled for retry"
+        );
+    }
+
+    Ok(exhausted)
+}
+
+fn effective_max_attempts(delivery: &ClaimedDelivery, options: DeliveryOptions) -> i32 {
+    delivery.max_attempts.min(options.max_attempts)
+}
+
+fn chrono_backoff(
+    attempt: i32,
+    options: DeliveryOptions,
+) -> Result<ChronoDuration, SubscriptionError> {
+    let exponent = u32::try_from((attempt - 1).max(0)).unwrap_or(0).min(30);
+    let multiplier = 2_u32.saturating_pow(exponent);
+    let delay = options
+        .base_backoff
+        .saturating_mul(multiplier)
+        .min(options.max_backoff);
+    ChronoDuration::from_std(delay).map_err(|err| SubscriptionError::Validation(err.to_string()))
+}
+
+fn validate_delivery_options(options: DeliveryOptions) -> Result<(), SubscriptionError> {
+    if options.max_attempts <= 0 {
+        return Err(SubscriptionError::Validation(
+            "max_attempts must be positive".into(),
+        ));
+    }
+    if options.batch_size == 0 {
+        return Err(SubscriptionError::Validation(
+            "batch_size must be positive".into(),
+        ));
+    }
+    if options.base_backoff.is_zero() {
+        return Err(SubscriptionError::Validation(
+            "base_backoff must be positive".into(),
+        ));
+    }
+    Ok(())
+}
+
+fn subscription_error_to_api_error(err: SubscriptionError) -> ApiError {
+    match err {
+        SubscriptionError::Validation(message) => ApiError::Validation(message),
+        SubscriptionError::Db(err) => ApiError::Db(err),
+        SubscriptionError::Http(err) => {
+            tracing::error!(error = %err, "webhook subscription HTTP error");
+            ApiError::Internal
+        }
+        SubscriptionError::Json(err) => {
+            tracing::error!(error = %err, "webhook subscription JSON error");
+            ApiError::Internal
+        }
+        SubscriptionError::Hmac(err) => {
+            tracing::error!(error = %err, "webhook subscription signing error");
+            ApiError::Internal
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use sqlx::postgres::PgPoolOptions;
+    use tokio_util::sync::CancellationToken;
+
+    use super::{
+        DeliveryOptions, SubscriptionError, run_webhook_delivery_worker, validate_delivery_options,
+    };
+
+    #[test]
+    fn delivery_options_reject_zero_values() {
+        assert!(matches!(
+            validate_delivery_options(DeliveryOptions {
+                max_attempts: 0,
+                ..DeliveryOptions::default()
+            }),
+            Err(SubscriptionError::Validation(_))
+        ));
+        assert!(matches!(
+            validate_delivery_options(DeliveryOptions {
+                batch_size: 0,
+                ..DeliveryOptions::default()
+            }),
+            Err(SubscriptionError::Validation(_))
+        ));
+        assert!(matches!(
+            validate_delivery_options(DeliveryOptions {
+                base_backoff: Duration::ZERO,
+                ..DeliveryOptions::default()
+            }),
+            Err(SubscriptionError::Validation(_))
+        ));
+    }
+
+    #[tokio::test]
+    async fn delivery_worker_exits_when_shutdown_is_already_cancelled() {
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .connect_lazy("postgres://postgres:postgres@localhost/au_kpis")
+            .expect("lazy postgres pool");
+        let shutdown = CancellationToken::new();
+        shutdown.cancel();
+
+        run_webhook_delivery_worker(
+            pool,
+            shutdown,
+            DeliveryOptions::default(),
+            Duration::from_millis(1),
+        )
+        .await
+        .expect("worker exits cleanly");
+    }
+}

--- a/crates/au-kpis-api-http/tests/routes.rs
+++ b/crates/au-kpis-api-http/tests/routes.rs
@@ -503,6 +503,25 @@ async fn cors_preflight_allows_x_api_key_header_for_configured_origin() {
 }
 
 #[tokio::test]
+async fn unsupported_subscription_methods_return_method_not_allowed_before_auth() {
+    let response = router(test_state())
+        .expect("router")
+        .oneshot(
+            Request::builder()
+                .method("TRACE")
+                .uri("/v1/subscriptions")
+                .header("x-api-key", "auk_live_unused")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"dataflow_ids":[],"url":""}"#))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::METHOD_NOT_ALLOWED);
+}
+
+#[tokio::test]
 async fn timeout_middleware_returns_problem_json_through_router_stack() {
     async fn slow() -> &'static str {
         tokio::time::sleep(Duration::from_secs(31)).await;

--- a/crates/au-kpis-api-http/tests/subscriptions.rs
+++ b/crates/au-kpis-api-http/tests/subscriptions.rs
@@ -1,0 +1,506 @@
+use std::{sync::Arc, time::Duration};
+
+use au_kpis_api_http::{
+    AppState, router,
+    subscriptions::{
+        DeliveryOptions, WebhookDeliveryEvent, deliver_due_webhooks, enqueue_data_update_event,
+    },
+};
+use au_kpis_auth::{ApiKeyManager, CreateApiKeyRequest};
+use au_kpis_cache::CacheClient;
+use au_kpis_config::{
+    AppConfig, DatabaseConfig, HttpConfig, LogFormat, RateLimitConfig, TelemetryConfig,
+};
+use au_kpis_db::{connect, migrate};
+use au_kpis_domain::ids::DataflowId;
+use au_kpis_telemetry::Telemetry;
+use au_kpis_testing::{
+    redis::{RedisHarness, start_redis},
+    timescale::{TimescaleHarness, start_timescale},
+};
+use axum::{
+    Router,
+    body::{Body, Bytes, to_bytes},
+    extract::State,
+    http::{HeaderMap, Request, StatusCode, header},
+    response::IntoResponse,
+    routing::post,
+};
+use chrono::{Duration as ChronoDuration, TimeZone, Utc};
+use hmac::{Hmac, Mac};
+use serde_json::{Value, json};
+use sha2::Sha256;
+use sqlx::PgPool;
+use tokio::{net::TcpListener, sync::mpsc};
+use tokio_util::sync::CancellationToken;
+use tower::ServiceExt;
+
+type HmacSha256 = Hmac<Sha256>;
+
+struct TestContext {
+    _postgres: TimescaleHarness,
+    _redis: RedisHarness,
+    pool: PgPool,
+    cache: Arc<CacheClient>,
+    manager: ApiKeyManager,
+}
+
+impl TestContext {
+    async fn start(database: &str) -> Self {
+        let postgres = start_timescale(database)
+            .await
+            .expect("start timescaledb container");
+        let redis = start_redis().await.expect("start redis container");
+        let pool = connect(&DatabaseConfig {
+            url: postgres.url().to_string(),
+        })
+        .await
+        .expect("connect postgres");
+        migrate(&pool).await.expect("apply migrations");
+        let cache = Arc::new(
+            CacheClient::connect(redis.url())
+                .await
+                .expect("connect redis"),
+        );
+        let manager = ApiKeyManager::new(pool.clone(), cache.clone());
+        seed_dataflow(&pool).await;
+
+        Self {
+            _postgres: postgres,
+            _redis: redis,
+            pool,
+            cache,
+            manager,
+        }
+    }
+
+    fn state(&self) -> AppState {
+        test_state(self.pool.clone(), self.cache.clone())
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn post_subscriptions_creates_authenticated_subscription_and_returns_secret() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let ctx = TestContext::start("au_kpis_subscription_create").await;
+    let key = ctx
+        .manager
+        .create_key(CreateApiKeyRequest {
+            name: "webhook client".into(),
+            scopes: vec!["subscriptions:write".into()],
+            rate_limit_tier: "free".into(),
+            actor: "platform-admin@example.com".into(),
+        })
+        .await
+        .expect("create api key");
+
+    let response = router(ctx.state())
+        .expect("router")
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/subscriptions")
+                .header("x-api-key", &key.plaintext)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "url": "https://example.com/au-kpis-webhook",
+                        "dataflow_ids": ["abs.cpi"]
+                    })
+                    .to_string(),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = response_json(response).await;
+    assert_eq!(
+        body["subscription"]["url"],
+        "https://example.com/au-kpis-webhook"
+    );
+    assert_eq!(body["subscription"]["status"], "active");
+    assert_eq!(body["subscription"]["dataflow_ids"], json!(["abs.cpi"]));
+    assert!(
+        body["subscription"]["signing_secret"]
+            .as_str()
+            .is_some_and(|secret| secret.len() >= 32),
+        "creation response should expose the signing secret once"
+    );
+
+    let persisted: (uuid::Uuid,) = sqlx::query_as(
+        "SELECT api_key_id
+         FROM webhook_subscriptions
+         WHERE target_url = $1",
+    )
+    .bind("https://example.com/au-kpis-webhook")
+    .fetch_one(&ctx.pool)
+    .await
+    .expect("fetch persisted subscription");
+    assert_eq!(persisted.0, key.id);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn due_webhook_deliveries_are_hmac_signed_and_marked_delivered() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let ctx = TestContext::start("au_kpis_subscription_delivery").await;
+    let receiver = WebhookReceiver::start(StatusCode::NO_CONTENT).await;
+    let (subscription_id, signing_secret) = create_subscription(&ctx, &receiver.url()).await;
+    let event = WebhookDeliveryEvent {
+        dataflow_id: DataflowId::new("abs.cpi").expect("valid dataflow"),
+        artifact_id: None,
+        observations_loaded: 7,
+        occurred_at: Utc.with_ymd_and_hms(2026, 5, 29, 10, 0, 0).unwrap(),
+    };
+
+    let enqueued = enqueue_data_update_event(&ctx.pool, &event)
+        .await
+        .expect("enqueue deliveries");
+    assert_eq!(enqueued, 1);
+
+    let outcome = deliver_due_webhooks(
+        &ctx.pool,
+        &reqwest::Client::new(),
+        Utc.with_ymd_and_hms(2026, 5, 29, 10, 0, 1).unwrap(),
+        DeliveryOptions {
+            max_attempts: 3,
+            base_backoff: Duration::from_secs(10),
+            max_backoff: Duration::from_secs(60),
+            batch_size: 10,
+        },
+    )
+    .await
+    .expect("deliver due webhooks");
+    assert_eq!(outcome.attempted, 1);
+    assert_eq!(outcome.delivered, 1);
+    assert_eq!(outcome.failed, 0);
+
+    let received = receiver.next().await;
+    let timestamp = received
+        .headers
+        .get("x-au-kpis-webhook-timestamp")
+        .expect("timestamp header")
+        .to_str()
+        .expect("timestamp header string");
+    let signature = received
+        .headers
+        .get("x-au-kpis-webhook-signature")
+        .expect("signature header")
+        .to_str()
+        .expect("signature header string");
+    assert_eq!(
+        signature,
+        expected_signature(&signing_secret, timestamp, &received.body)
+    );
+
+    let payload: Value = serde_json::from_slice(&received.body).expect("json payload");
+    assert_eq!(payload["event"], "data.updated");
+    assert_eq!(payload["dataflow_id"], "abs.cpi");
+    assert_eq!(payload["observations_loaded"], 7);
+
+    let delivery: (String, i32, i64) = sqlx::query_as(
+        "SELECT status, attempts, (
+             SELECT count(*) FROM webhook_delivery_attempts
+             WHERE webhook_delivery_attempts.delivery_id = webhook_deliveries.id
+         )::BIGINT
+         FROM webhook_deliveries
+         WHERE subscription_id = $1",
+    )
+    .bind(subscription_id)
+    .fetch_one(&ctx.pool)
+    .await
+    .expect("fetch delivery status");
+    assert_eq!(delivery, ("delivered".into(), 1, 1));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn failed_webhook_deliveries_retry_with_exponential_backoff_and_stop_after_bound() {
+    if !docker_available() {
+        eprintln!("skipping testcontainers integration test: Docker socket unavailable");
+        return;
+    }
+
+    let ctx = TestContext::start("au_kpis_subscription_retry").await;
+    let receiver = WebhookReceiver::start(StatusCode::SERVICE_UNAVAILABLE).await;
+    let (subscription_id, _) = create_subscription(&ctx, &receiver.url()).await;
+    let event = WebhookDeliveryEvent {
+        dataflow_id: DataflowId::new("abs.cpi").expect("valid dataflow"),
+        artifact_id: None,
+        observations_loaded: 1,
+        occurred_at: Utc.with_ymd_and_hms(2026, 5, 29, 11, 0, 0).unwrap(),
+    };
+    enqueue_data_update_event(&ctx.pool, &event)
+        .await
+        .expect("enqueue delivery");
+
+    let now = Utc.with_ymd_and_hms(2026, 5, 29, 11, 0, 1).unwrap();
+    let options = DeliveryOptions {
+        max_attempts: 2,
+        base_backoff: Duration::from_secs(10),
+        max_backoff: Duration::from_secs(60),
+        batch_size: 10,
+    };
+
+    let first = deliver_due_webhooks(&ctx.pool, &reqwest::Client::new(), now, options)
+        .await
+        .expect("first attempt");
+    assert_eq!(first.attempted, 1);
+    assert_eq!(first.delivered, 0);
+    assert_eq!(first.failed, 0);
+    let first_failure = delivery_state(&ctx.pool, subscription_id).await;
+    assert_eq!(first_failure.status, "pending");
+    assert_eq!(first_failure.attempts, 1);
+    assert!(first_failure.next_attempt_at.is_some_and(|due| due > now));
+
+    let too_early = deliver_due_webhooks(
+        &ctx.pool,
+        &reqwest::Client::new(),
+        now + ChronoDuration::seconds(9),
+        options,
+    )
+    .await
+    .expect("too early retry");
+    assert_eq!(too_early.attempted, 0);
+
+    let second = deliver_due_webhooks(
+        &ctx.pool,
+        &reqwest::Client::new(),
+        now + ChronoDuration::seconds(10),
+        options,
+    )
+    .await
+    .expect("second attempt");
+    assert_eq!(second.attempted, 1);
+    assert_eq!(second.delivered, 0);
+    assert_eq!(second.failed, 1);
+
+    let exhausted = delivery_state(&ctx.pool, subscription_id).await;
+    assert_eq!(exhausted.status, "failed");
+    assert_eq!(exhausted.attempts, 2);
+    assert!(exhausted.next_attempt_at.is_none());
+    assert_eq!(exhausted.attempt_rows, 2);
+}
+
+async fn create_subscription(ctx: &TestContext, url: &str) -> (uuid::Uuid, String) {
+    let key = ctx
+        .manager
+        .create_key(CreateApiKeyRequest {
+            name: "delivery client".into(),
+            scopes: vec!["subscriptions:write".into()],
+            rate_limit_tier: "free".into(),
+            actor: "platform-admin@example.com".into(),
+        })
+        .await
+        .expect("create api key");
+    let response = router(ctx.state())
+        .expect("router")
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/subscriptions")
+                .header("x-api-key", &key.plaintext)
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(
+                    json!({
+                        "url": url,
+                        "dataflow_ids": ["abs.cpi"]
+                    })
+                    .to_string(),
+                ))
+                .expect("request"),
+        )
+        .await
+        .expect("response");
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let body = response_json(response).await;
+    (
+        body["subscription"]["id"]
+            .as_str()
+            .expect("subscription id")
+            .parse()
+            .expect("uuid"),
+        body["subscription"]["signing_secret"]
+            .as_str()
+            .expect("signing secret")
+            .to_string(),
+    )
+}
+
+#[derive(Debug)]
+struct DeliveryState {
+    status: String,
+    attempts: i32,
+    next_attempt_at: Option<chrono::DateTime<Utc>>,
+    attempt_rows: i64,
+}
+
+async fn delivery_state(pool: &PgPool, subscription_id: uuid::Uuid) -> DeliveryState {
+    let (status, attempts, next_attempt_at, attempt_rows) = sqlx::query_as(
+        "SELECT status, attempts, next_attempt_at, (
+             SELECT count(*) FROM webhook_delivery_attempts
+             WHERE webhook_delivery_attempts.delivery_id = webhook_deliveries.id
+         )::BIGINT
+         FROM webhook_deliveries
+         WHERE subscription_id = $1",
+    )
+    .bind(subscription_id)
+    .fetch_one(pool)
+    .await
+    .expect("fetch delivery state");
+
+    DeliveryState {
+        status,
+        attempts,
+        next_attempt_at,
+        attempt_rows,
+    }
+}
+
+async fn response_json(response: axum::response::Response) -> Value {
+    let body = to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("body bytes");
+    serde_json::from_slice(&body).expect("json body")
+}
+
+async fn seed_dataflow(pool: &PgPool) {
+    sqlx::query(
+        "INSERT INTO sources (id, name, homepage, description)
+         VALUES ('abs', 'Australian Bureau of Statistics', 'https://www.abs.gov.au', 'ABS')
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .execute(pool)
+    .await
+    .expect("seed source");
+
+    sqlx::query(
+        "INSERT INTO dataflows (
+             id, source_id, name, description, dimensions, measures, frequency,
+             license, attribution, source_url
+         )
+         VALUES (
+             'abs.cpi', 'abs', 'Consumer Price Index', 'CPI',
+             ARRAY['region'], ARRAY['cpi'], 'quarterly',
+             'CC BY 4.0', 'ABS', 'https://www.abs.gov.au/cpi'
+         )
+         ON CONFLICT (id) DO NOTHING",
+    )
+    .execute(pool)
+    .await
+    .expect("seed dataflow");
+}
+
+fn test_state(db: PgPool, cache: Arc<CacheClient>) -> AppState {
+    let config = AppConfig {
+        http: HttpConfig {
+            bind: "127.0.0.1:0".into(),
+            cors_allowed_origins: Vec::new(),
+            shutdown_grace_period_secs: 30,
+        },
+        database: DatabaseConfig {
+            url: "postgres://postgres:postgres@localhost/au_kpis".into(),
+        },
+        cache: au_kpis_config::CacheConfig {
+            url: "redis://127.0.0.1:6379".into(),
+        },
+        telemetry: TelemetryConfig {
+            service_name: "au-kpis-test".into(),
+            log_format: LogFormat::Json,
+            log_level: "info".into(),
+            otlp_endpoint: None,
+        },
+        rate_limits: RateLimitConfig::default(),
+    };
+
+    AppState::new(
+        db,
+        cache,
+        Arc::new(config),
+        Arc::new(Telemetry::disabled()),
+        CancellationToken::new(),
+    )
+}
+
+#[derive(Debug)]
+struct ReceivedWebhook {
+    headers: HeaderMap,
+    body: Bytes,
+}
+
+#[derive(Debug)]
+struct WebhookReceiver {
+    url: String,
+    received: mpsc::Receiver<ReceivedWebhook>,
+}
+
+impl WebhookReceiver {
+    async fn start(status: StatusCode) -> Self {
+        let (tx, rx) = mpsc::channel(8);
+        let app = Router::new()
+            .route("/hook", post(capture_webhook))
+            .with_state(ReceiverState { status, tx });
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind receiver");
+        let url = format!(
+            "http://{}/hook",
+            listener.local_addr().expect("receiver addr")
+        );
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("serve receiver");
+        });
+        Self { url, received: rx }
+    }
+
+    fn url(&self) -> String {
+        self.url.clone()
+    }
+
+    async fn next(mut self) -> ReceivedWebhook {
+        self.received
+            .recv()
+            .await
+            .expect("webhook receiver should capture request")
+    }
+}
+
+#[derive(Debug, Clone)]
+struct ReceiverState {
+    status: StatusCode,
+    tx: mpsc::Sender<ReceivedWebhook>,
+}
+
+async fn capture_webhook(
+    State(state): State<ReceiverState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    state
+        .tx
+        .send(ReceivedWebhook { headers, body })
+        .await
+        .expect("send received webhook");
+    state.status
+}
+
+fn expected_signature(secret: &str, timestamp: &str, body: &[u8]) -> String {
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).expect("hmac key");
+    mac.update(timestamp.as_bytes());
+    mac.update(b".");
+    mac.update(body);
+    format!("sha256={}", hex::encode(mac.finalize().into_bytes()))
+}
+
+fn docker_available() -> bool {
+    std::env::var_os("DOCKER_HOST").is_some()
+        || std::path::Path::new("/var/run/docker.sock").exists()
+}

--- a/crates/au-kpis-db/tests/migrations.rs
+++ b/crates/au-kpis-db/tests/migrations.rs
@@ -221,6 +221,9 @@ async fn migration_creates_hypertable_and_compression_policy() {
         "parse_errors",
         "series",
         "sources",
+        "webhook_deliveries",
+        "webhook_delivery_attempts",
+        "webhook_subscriptions",
     ] {
         assert!(
             table_names.contains(&expected),

--- a/crates/au-kpis-loader/src/lib.rs
+++ b/crates/au-kpis-loader/src/lib.rs
@@ -15,6 +15,8 @@ use tracing::instrument;
 
 const DEFAULT_MAX_ROWS: usize = 1_000;
 const DEFAULT_MAX_BYTES: usize = 10 * 1024 * 1024;
+const WEBHOOK_EVENT_DATA_UPDATED: &str = "data.updated";
+const WEBHOOK_DELIVERY_MAX_ATTEMPTS: i32 = 5;
 
 /// A parsed observation paired with the series metadata needed by the loader.
 #[derive(Debug, Clone, PartialEq)]
@@ -573,7 +575,9 @@ async fn load_observation_batch(
     stats: &mut LoadStats,
 ) -> Result<(), LoadError> {
     let mut tx = pool.begin().await?;
+    create_series_staging_table(&mut tx).await?;
     create_observation_staging_table(&mut tx).await?;
+    copy_series(&mut tx, batch).await?;
     copy_observations(&mut tx, batch).await?;
     let observations_loaded = upsert_observations(&mut tx).await?;
     tx.commit().await?;
@@ -778,7 +782,65 @@ async fn upsert_observations(tx: &mut Transaction<'_, Postgres>) -> Result<u64, 
     .execute(&mut **tx)
     .await?;
 
-    Ok(result.rows_affected())
+    let observations_loaded = result.rows_affected();
+    let deliveries_enqueued = enqueue_webhook_deliveries_for_staging(tx).await?;
+    if deliveries_enqueued > 0 {
+        tracing::info!(
+            observations_loaded,
+            deliveries_enqueued,
+            "webhook deliveries enqueued for loaded observations"
+        );
+    }
+
+    Ok(observations_loaded)
+}
+
+async fn enqueue_webhook_deliveries_for_staging(
+    tx: &mut Transaction<'_, Postgres>,
+) -> Result<u64, LoadError> {
+    let rows = sqlx::query(
+        "WITH loaded_events AS (
+             SELECT series.dataflow_id,
+                    decode(observations.source_artifact_hex, 'hex') AS artifact_id,
+                    count(*)::BIGINT AS observations_loaded,
+                    max(observations.ingested_at) AS occurred_at
+             FROM staging_observations observations
+             JOIN staging_series series
+               ON series.series_key_hex = observations.series_key_hex
+             GROUP BY series.dataflow_id, observations.source_artifact_hex
+         ),
+         event_payloads AS (
+             SELECT dataflow_id,
+                    artifact_id,
+                    jsonb_build_object(
+                        'event', $1,
+                        'dataflow_id', dataflow_id,
+                        'artifact_id', encode(artifact_id, 'hex'),
+                        'observations_loaded', observations_loaded,
+                        'occurred_at', occurred_at
+                    ) AS payload
+             FROM loaded_events
+         )
+         INSERT INTO webhook_deliveries (
+             subscription_id, event_type, dataflow_id, artifact_id, payload,
+             status, attempts, max_attempts, next_attempt_at
+         )
+         SELECT subscriptions.id, $1, events.dataflow_id, events.artifact_id,
+                events.payload, 'pending', 0, $2, now()
+         FROM event_payloads events
+         JOIN webhook_subscriptions subscriptions
+           ON subscriptions.status = 'active'
+          AND (
+              cardinality(subscriptions.dataflow_ids) = 0
+              OR events.dataflow_id = ANY(subscriptions.dataflow_ids)
+          )",
+    )
+    .bind(WEBHOOK_EVENT_DATA_UPDATED)
+    .bind(WEBHOOK_DELIVERY_MAX_ATTEMPTS)
+    .execute(&mut **tx)
+    .await?;
+
+    Ok(rows.rows_affected())
 }
 
 /// Record a parser failure against the source artifact for audit and reprocessing.

--- a/crates/au-kpis-loader/tests/load_batch.rs
+++ b/crates/au-kpis-loader/tests/load_batch.rs
@@ -303,6 +303,57 @@ async fn validation_errors_are_recorded_without_failing_valid_rows() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn load_batch_enqueues_webhook_deliveries_for_matching_subscriptions() {
+    let _guard = TEST_LOCK.lock().await;
+    let db = test_db().await;
+    let pool = &db.pool;
+    let artifact_id = ArtifactId::of_content(b"loader webhook delivery fixture");
+    seed_reference_data(pool, artifact_id).await;
+    seed_webhook_subscriptions(pool).await;
+    let aus = descriptor("AUS");
+    let nsw = descriptor("NSW");
+
+    let stats = load_batch(
+        pool,
+        vec![
+            item(&aus, artifact_id, ts(2024, 3, 1), 0, 134.2),
+            item(&nsw, artifact_id, ts(2024, 6, 1), 0, 136.1),
+        ],
+    )
+    .await
+    .expect("load observations and enqueue webhook delivery");
+
+    assert_eq!(stats.observations_loaded, 2);
+
+    let rows = sqlx::query(
+        "SELECT dataflow_id, encode(artifact_id, 'hex') AS artifact_id_hex,
+                payload, status, attempts, max_attempts
+         FROM webhook_deliveries
+         ORDER BY id",
+    )
+    .fetch_all(pool)
+    .await
+    .expect("fetch webhook deliveries");
+
+    assert_eq!(rows.len(), 2, "matching dataflow and wildcard subscribers");
+    for row in rows {
+        assert_eq!(row.get::<String, _>("dataflow_id"), "abs.cpi");
+        assert_eq!(
+            row.get::<String, _>("artifact_id_hex"),
+            artifact_id.to_string()
+        );
+        assert_eq!(row.get::<String, _>("status"), "pending");
+        assert_eq!(row.get::<i32, _>("attempts"), 0);
+        assert_eq!(row.get::<i32, _>("max_attempts"), 5);
+        let payload = row.get::<serde_json::Value, _>("payload");
+        assert_eq!(payload["event"], "data.updated");
+        assert_eq!(payload["dataflow_id"], "abs.cpi");
+        assert_eq!(payload["artifact_id"], artifact_id.to_string());
+        assert_eq!(payload["observations_loaded"], 2);
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn staged_load_cleanup_returns_live_connection_to_pool() {
     let _guard = TEST_LOCK.lock().await;
     let timescale = start_timescale("au_kpis_loader_staged_connection_reuse")
@@ -593,4 +644,39 @@ async fn default_options_split_observations_at_one_thousand_rows() {
 
     assert_eq!(stats.observations_loaded, 1_001);
     assert_eq!(stats.batches, 2);
+}
+
+async fn seed_webhook_subscriptions(pool: &PgPool) {
+    sqlx::query(
+        "INSERT INTO api_keys (id, key_hash, name, scopes, rate_limit_tier)
+         VALUES
+             ('11111111-1111-1111-1111-111111111111', 'hash-a', 'webhooks a',
+              ARRAY['subscriptions:write'], 'free'),
+             ('22222222-2222-2222-2222-222222222222', 'hash-b', 'webhooks b',
+              ARRAY['subscriptions:write'], 'free'),
+             ('33333333-3333-3333-3333-333333333333', 'hash-c', 'webhooks c',
+              ARRAY['subscriptions:write'], 'free')",
+    )
+    .execute(pool)
+    .await
+    .expect("insert api keys");
+
+    sqlx::query(
+        "INSERT INTO webhook_subscriptions (
+             id, api_key_id, target_url, dataflow_ids, signing_secret
+         )
+         VALUES
+             ('aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+              '11111111-1111-1111-1111-111111111111',
+              'https://example.test/cpi', ARRAY['abs.cpi'], 'secret-a-secret-a-secret-a-secret-a'),
+             ('bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+              '22222222-2222-2222-2222-222222222222',
+              'https://example.test/all', ARRAY[]::TEXT[], 'secret-b-secret-b-secret-b-secret-b'),
+             ('cccccccc-cccc-cccc-cccc-cccccccccccc',
+              '33333333-3333-3333-3333-333333333333',
+              'https://example.test/wpi', ARRAY['abs.wpi'], 'secret-c-secret-c-secret-c-secret-c')",
+    )
+    .execute(pool)
+    .await
+    .expect("insert webhook subscriptions");
 }

--- a/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
+++ b/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
@@ -87,6 +87,39 @@ expression: emitted_spec()
         "description": "Identifier for a codelist (e.g. `CL_STATE_AU`).",
         "type": "string"
       },
+      "CreateSubscriptionRequest": {
+        "description": "Request body for `POST /v1/subscriptions`.",
+        "properties": {
+          "dataflow_ids": {
+            "description": "Optional dataflow filter. Empty means every dataflow update.",
+            "items": {
+              "$ref": "#/components/schemas/DataflowId"
+            },
+            "type": "array"
+          },
+          "url": {
+            "description": "Absolute HTTP(S) URL to receive webhook deliveries.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "url"
+        ],
+        "type": "object"
+      },
+      "CreateSubscriptionResponse": {
+        "description": "Response body for `POST /v1/subscriptions`.",
+        "properties": {
+          "subscription": {
+            "$ref": "#/components/schemas/SubscriptionDetails",
+            "description": "Created subscription."
+          }
+        },
+        "required": [
+          "subscription"
+        ],
+        "type": "object"
+      },
       "Dataflow": {
         "description": "A dataflow — a named collection of series sharing dimensions and measures.",
         "properties": {
@@ -852,6 +885,49 @@ expression: emitted_spec()
         "description": "Identifier for an upstream data source (e.g. `abs`, `rba`, `apra`).",
         "type": "string"
       },
+      "SubscriptionDetails": {
+        "description": "Created webhook subscription details.",
+        "properties": {
+          "created_at": {
+            "description": "UTC creation timestamp.",
+            "format": "date-time",
+            "type": "string"
+          },
+          "dataflow_ids": {
+            "description": "Dataflow filter attached to the subscription.",
+            "items": {
+              "$ref": "#/components/schemas/DataflowId"
+            },
+            "type": "array"
+          },
+          "id": {
+            "description": "Stable subscription id.",
+            "format": "uuid",
+            "type": "string"
+          },
+          "signing_secret": {
+            "description": "HMAC signing secret shown once at creation.",
+            "type": "string"
+          },
+          "status": {
+            "description": "Current subscription status.",
+            "type": "string"
+          },
+          "url": {
+            "description": "Delivery target URL.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "url",
+          "dataflow_ids",
+          "status",
+          "created_at",
+          "signing_secret"
+        ],
+        "type": "object"
+      },
       "TimePrecision": {
         "description": "Temporal granularity of an observation's timestamp. Matches the SDMX\n`@FREQ` facet on a coarse scale.",
         "enum": [
@@ -862,6 +938,13 @@ expression: emitted_spec()
           "year"
         ],
         "type": "string"
+      }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "in": "header",
+        "name": "X-API-Key",
+        "type": "apiKey"
       }
     }
   },
@@ -1514,6 +1597,72 @@ expression: emitted_spec()
           "series"
         ]
       }
+    },
+    "/v1/subscriptions": {
+      "post": {
+        "operationId": "createSubscription",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSubscriptionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateSubscriptionResponse"
+                }
+              }
+            },
+            "description": "Subscription created."
+          },
+          "400": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Invalid subscription request."
+          },
+          "401": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Missing or invalid API key."
+          },
+          "500": {
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            },
+            "description": "Internal error."
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ],
+        "summary": "`POST /v1/subscriptions`.",
+        "tags": [
+          "subscriptions"
+        ]
+      }
     }
   },
   "tags": [
@@ -1532,6 +1681,10 @@ expression: emitted_spec()
     {
       "description": "Series metadata lookups",
       "name": "series"
+    },
+    {
+      "description": "Webhook subscriptions",
+      "name": "subscriptions"
     }
   ]
 }

--- a/crates/bins/au-kpis-api/src/main.rs
+++ b/crates/bins/au-kpis-api/src/main.rs
@@ -6,7 +6,7 @@
 use std::{env, ffi::OsString, future::IntoFuture, sync::Arc, time::Duration};
 
 use anyhow::Context;
-use au_kpis_api_http::{AppState, router};
+use au_kpis_api_http::{AppState, router, spawn_webhook_delivery_worker};
 use au_kpis_cache::CacheClient;
 use au_kpis_config::load;
 use au_kpis_db::connect as connect_db;
@@ -27,6 +27,7 @@ async fn main() -> anyhow::Result<()> {
             .context("connect redis cache")?,
     );
     let shutdown = CancellationToken::new();
+    let webhook_worker = spawn_webhook_delivery_worker(db.clone(), shutdown.clone());
     let state = AppState::new(db, cache, config.clone(), telemetry, shutdown.clone());
 
     let app = router(state).context("build router")?;
@@ -42,7 +43,7 @@ async fn main() -> anyhow::Result<()> {
         .with_graceful_shutdown(shutdown.clone().cancelled_owned())
         .into_future();
     tokio::pin!(server);
-    let shutdown_listener = shutdown_signal(shutdown);
+    let shutdown_listener = shutdown_signal(shutdown.clone());
     tokio::pin!(shutdown_listener);
 
     tokio::select! {
@@ -60,6 +61,13 @@ async fn main() -> anyhow::Result<()> {
                     );
                 }
             }
+        }
+    }
+
+    shutdown.cancel();
+    if let Err(err) = webhook_worker.await {
+        if !err.is_cancelled() {
+            tracing::warn!(error = %err, "webhook delivery worker join failed");
         }
     }
 

--- a/crates/bins/au-kpis-api/tests/sigterm.rs
+++ b/crates/bins/au-kpis-api/tests/sigterm.rs
@@ -56,6 +56,7 @@ async fn api_binary_honors_configured_shutdown_grace_period() {
     stream
         .write_all(b"GET /v1/health HTTP/1.1\r\nHost: localhost\r\n")
         .expect("write partial request");
+    thread::sleep(Duration::from_millis(100));
 
     let started = Instant::now();
     harness.send_sigterm();

--- a/infra/migrations/0006_observation_rollups.down.sql
+++ b/infra/migrations/0006_observation_rollups.down.sql
@@ -1,6 +1,10 @@
 -- Drop rollup continuous aggregates. Timescale removes associated refresh
 -- jobs when the continuous aggregate views are dropped.
 
+SELECT remove_continuous_aggregate_policy('observations_rollup_quarterly', if_exists => TRUE);
+SELECT remove_continuous_aggregate_policy('observations_rollup_monthly', if_exists => TRUE);
+SELECT remove_continuous_aggregate_policy('observations_rollup_weekly', if_exists => TRUE);
+
 DROP MATERIALIZED VIEW IF EXISTS observations_rollup_quarterly CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS observations_rollup_monthly CASCADE;
 DROP MATERIALIZED VIEW IF EXISTS observations_rollup_weekly CASCADE;

--- a/infra/migrations/0007_webhook_subscriptions.down.sql
+++ b/infra/migrations/0007_webhook_subscriptions.down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS webhook_delivery_attempts;
+DROP TABLE IF EXISTS webhook_deliveries;
+DROP TABLE IF EXISTS webhook_subscriptions;

--- a/infra/migrations/0007_webhook_subscriptions.up.sql
+++ b/infra/migrations/0007_webhook_subscriptions.up.sql
@@ -1,0 +1,74 @@
+-- Webhook subscriptions and durable delivery attempts for phase-5 consumer
+-- notifications when new observations are loaded.
+
+CREATE TABLE webhook_subscriptions (
+    id             UUID PRIMARY KEY,
+    api_key_id     UUID NOT NULL REFERENCES api_keys(id) ON DELETE CASCADE,
+    target_url     TEXT NOT NULL CHECK (target_url ~ '^https?://'),
+    dataflow_ids   TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    signing_secret TEXT NOT NULL CHECK (char_length(signing_secret) >= 32),
+    status         TEXT NOT NULL DEFAULT 'active'
+                   CHECK (status IN ('active', 'paused', 'revoked')),
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX webhook_subscriptions_api_key_idx
+ON webhook_subscriptions (api_key_id, created_at DESC);
+
+CREATE INDEX webhook_subscriptions_dataflow_ids_gin
+ON webhook_subscriptions USING GIN (dataflow_ids);
+
+CREATE INDEX webhook_subscriptions_active_idx
+ON webhook_subscriptions (status)
+WHERE status = 'active';
+
+CREATE TABLE webhook_deliveries (
+    id               BIGSERIAL PRIMARY KEY,
+    subscription_id  UUID NOT NULL REFERENCES webhook_subscriptions(id) ON DELETE CASCADE,
+    event_type       TEXT NOT NULL CHECK (event_type IN ('data.updated')),
+    dataflow_id      TEXT NOT NULL REFERENCES dataflows(id),
+    artifact_id      BYTEA REFERENCES artifacts(id)
+                     CHECK (artifact_id IS NULL OR octet_length(artifact_id) = 32),
+    payload          JSONB NOT NULL,
+    status           TEXT NOT NULL DEFAULT 'pending'
+                     CHECK (status IN ('pending', 'delivering', 'delivered', 'failed')),
+    attempts         INTEGER NOT NULL DEFAULT 0 CHECK (attempts >= 0),
+    max_attempts     INTEGER NOT NULL DEFAULT 5 CHECK (max_attempts > 0),
+    next_attempt_at  TIMESTAMPTZ,
+    delivered_at     TIMESTAMPTZ,
+    last_status_code INTEGER CHECK (
+                         last_status_code IS NULL
+                         OR last_status_code BETWEEN 100 AND 599
+                     ),
+    last_error       TEXT,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at       TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX webhook_deliveries_due_idx
+ON webhook_deliveries (next_attempt_at, id)
+WHERE status = 'pending';
+
+CREATE INDEX webhook_deliveries_subscription_idx
+ON webhook_deliveries (subscription_id, created_at DESC);
+
+CREATE INDEX webhook_deliveries_dataflow_idx
+ON webhook_deliveries (dataflow_id, created_at DESC);
+
+CREATE TABLE webhook_delivery_attempts (
+    id             BIGSERIAL PRIMARY KEY,
+    delivery_id    BIGINT NOT NULL REFERENCES webhook_deliveries(id) ON DELETE CASCADE,
+    attempt_no     INTEGER NOT NULL CHECK (attempt_no > 0),
+    success        BOOLEAN NOT NULL,
+    status_code    INTEGER CHECK (
+                       status_code IS NULL OR status_code BETWEEN 100 AND 599
+                   ),
+    error_message  TEXT,
+    attempted_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    latency_ms     BIGINT CHECK (latency_ms IS NULL OR latency_ms >= 0),
+    UNIQUE (delivery_id, attempt_no)
+);
+
+CREATE INDEX webhook_delivery_attempts_delivery_idx
+ON webhook_delivery_attempts (delivery_id, attempt_no);

--- a/openapi.json
+++ b/openapi.json
@@ -636,6 +636,70 @@
           }
         }
       }
+    },
+    "/v1/subscriptions": {
+      "post": {
+        "tags": ["subscriptions"],
+        "summary": "`POST /v1/subscriptions`.",
+        "operationId": "createSubscription",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CreateSubscriptionRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Subscription created.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CreateSubscriptionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid subscription request.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Missing or invalid API key.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal error.",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "ApiKeyAuth": []
+          }
+        ]
+      }
     }
   },
   "components": {
@@ -707,6 +771,35 @@
       "CodelistId": {
         "type": "string",
         "description": "Identifier for a codelist (e.g. `CL_STATE_AU`)."
+      },
+      "CreateSubscriptionRequest": {
+        "type": "object",
+        "description": "Request body for `POST /v1/subscriptions`.",
+        "required": ["url"],
+        "properties": {
+          "dataflow_ids": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataflowId"
+            },
+            "description": "Optional dataflow filter. Empty means every dataflow update."
+          },
+          "url": {
+            "type": "string",
+            "description": "Absolute HTTP(S) URL to receive webhook deliveries."
+          }
+        }
+      },
+      "CreateSubscriptionResponse": {
+        "type": "object",
+        "description": "Response body for `POST /v1/subscriptions`.",
+        "required": ["subscription"],
+        "properties": {
+          "subscription": {
+            "$ref": "#/components/schemas/SubscriptionDetails",
+            "description": "Created subscription."
+          }
+        }
       },
       "Dataflow": {
         "type": "object",
@@ -1366,10 +1459,53 @@
         "type": "string",
         "description": "Identifier for an upstream data source (e.g. `abs`, `rba`, `apra`)."
       },
+      "SubscriptionDetails": {
+        "type": "object",
+        "description": "Created webhook subscription details.",
+        "required": ["id", "url", "dataflow_ids", "status", "created_at", "signing_secret"],
+        "properties": {
+          "created_at": {
+            "type": "string",
+            "format": "date-time",
+            "description": "UTC creation timestamp."
+          },
+          "dataflow_ids": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/DataflowId"
+            },
+            "description": "Dataflow filter attached to the subscription."
+          },
+          "id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Stable subscription id."
+          },
+          "signing_secret": {
+            "type": "string",
+            "description": "HMAC signing secret shown once at creation."
+          },
+          "status": {
+            "type": "string",
+            "description": "Current subscription status."
+          },
+          "url": {
+            "type": "string",
+            "description": "Delivery target URL."
+          }
+        }
+      },
       "TimePrecision": {
         "type": "string",
         "description": "Temporal granularity of an observation's timestamp. Matches the SDMX\n`@FREQ` facet on a coarse scale.",
         "enum": ["day", "week", "month", "quarter", "year"]
+      }
+    },
+    "securitySchemes": {
+      "ApiKeyAuth": {
+        "type": "apiKey",
+        "in": "header",
+        "name": "X-API-Key"
       }
     }
   },
@@ -1389,6 +1525,10 @@
     {
       "name": "series",
       "description": "Series metadata lookups"
+    },
+    {
+      "name": "subscriptions",
+      "description": "Webhook subscriptions"
     }
   ]
 }

--- a/packages/sdk-generated/src/client.ts
+++ b/packages/sdk-generated/src/client.ts
@@ -51,6 +51,24 @@ export interface Codelist {
  */
 export type CodelistId = string;
 
+/**
+ * Request body for `POST /v1/subscriptions`.
+ */
+export interface CreateSubscriptionRequest {
+  /** Optional dataflow filter. Empty means every dataflow update. */
+  dataflow_ids?: DataflowId[];
+  /** Absolute HTTP(S) URL to receive webhook deliveries. */
+  url: string;
+}
+
+/**
+ * Response body for `POST /v1/subscriptions`.
+ */
+export interface CreateSubscriptionResponse {
+  /** Created subscription. */
+  subscription: SubscriptionDetails;
+}
+
 export type DataflowDescription = string | null;
 
 /**
@@ -501,6 +519,24 @@ export interface SeriesRevisionMetadata {
 export type SourceId = string;
 
 /**
+ * Created webhook subscription details.
+ */
+export interface SubscriptionDetails {
+  /** UTC creation timestamp. */
+  created_at: string;
+  /** Dataflow filter attached to the subscription. */
+  dataflow_ids: DataflowId[];
+  /** Stable subscription id. */
+  id: string;
+  /** HMAC signing secret shown once at creation. */
+  signing_secret: string;
+  /** Current subscription status. */
+  status: string;
+  /** Delivery target URL. */
+  url: string;
+}
+
+/**
  * Temporal granularity of an observation's timestamp. Matches the SDMX
 `@FREQ` facet on a coarse scale.
  */
@@ -519,10 +555,14 @@ export const TimePrecision = {
 export type ListDataflowsParams = {
 /**
  * Optional source id filter, e.g. abs.
+ * @minLength 1
+ * @maxLength 128
  */
 source?: string;
 /**
  * Optional publication frequency filter.
+ * @minLength 1
+ * @pattern ^(annual|quarterly|monthly|weekly|daily|irregular)$
  */
 frequency?: string;
 };
@@ -530,6 +570,8 @@ frequency?: string;
 export type ListObservationsParams = {
 /**
  * Required dataflow id, e.g. abs.cpi.
+ * @minLength 1
+ * @maxLength 128
  */
 dataflow: string;
 /**
@@ -538,27 +580,36 @@ dataflow: string;
 'dimensions[]'?: string[];
 /**
  * Inclusive lower time bound as YYYY-MM-DD or RFC3339.
+ * @minLength 1
  */
 since?: string;
 /**
  * Inclusive upper time bound as YYYY-MM-DD or RFC3339.
+ * @minLength 1
  */
 until?: string;
 /**
  * Optional dataflow frequency filter, or weekly/monthly/quarterly rollup grain.
+ * @minLength 1
+ * @pattern ^(annual|quarterly|monthly|weekly|daily|irregular)$
  */
 frequency?: string;
 /**
  * Response format: json, csv, or parquet.
+ * @minLength 3
+ * @maxLength 7
+ * @pattern ^(json|csv|parquet)$
  */
 format?: string;
 /**
  * Opaque cursor from the previous page.
+ * @minLength 1
  */
 cursor?: string;
 /**
  * Page size, maximum 10000.
  * @minimum 0
+ * @maximum 10000
  */
 limit?: number;
 };
@@ -568,11 +619,13 @@ export type Openapi200 = { [key: string]: unknown };
 export type SearchCatalogParams = {
 /**
  * Search text.
+ * @minLength 1
  */
 q: string;
 /**
  * Maximum number of results, capped at 100.
  * @minimum 0
+ * @maximum 65535
  */
 limit?: number;
 };
@@ -646,6 +699,11 @@ export type getDataflowResponse200 = {
   status: 200
 }
 
+export type getDataflowResponse400 = {
+  data: ProblemDetails
+  status: 400
+}
+
 export type getDataflowResponse404 = {
   data: ProblemDetails
   status: 404
@@ -659,7 +717,7 @@ export type getDataflowResponse500 = {
 export type getDataflowResponseSuccess = (getDataflowResponse200) & {
   headers: Headers;
 };
-export type getDataflowResponseError = (getDataflowResponse404 | getDataflowResponse500) & {
+export type getDataflowResponseError = (getDataflowResponse400 | getDataflowResponse404 | getDataflowResponse500) & {
   headers: Headers;
 };
 
@@ -700,6 +758,11 @@ export type getDataflowCodelistResponse200 = {
   status: 200
 }
 
+export type getDataflowCodelistResponse400 = {
+  data: ProblemDetails
+  status: 400
+}
+
 export type getDataflowCodelistResponse404 = {
   data: ProblemDetails
   status: 404
@@ -713,7 +776,7 @@ export type getDataflowCodelistResponse500 = {
 export type getDataflowCodelistResponseSuccess = (getDataflowCodelistResponse200) & {
   headers: Headers;
 };
-export type getDataflowCodelistResponseError = (getDataflowCodelistResponse404 | getDataflowCodelistResponse500) & {
+export type getDataflowCodelistResponseError = (getDataflowCodelistResponse400 | getDataflowCodelistResponse404 | getDataflowCodelistResponse500) & {
   headers: Headers;
 };
 
@@ -1058,4 +1121,64 @@ export const getSeries = async (dataflow: string,
 
   const data: getSeriesResponse['data'] = body ? JSON.parse(body) : {}
   return { data, status: res.status, headers: res.headers } as getSeriesResponse
+}
+
+
+
+/**
+ * @summary `POST /v1/subscriptions`.
+ */
+export type createSubscriptionResponse201 = {
+  data: CreateSubscriptionResponse
+  status: 201
+}
+
+export type createSubscriptionResponse400 = {
+  data: ProblemDetails
+  status: 400
+}
+
+export type createSubscriptionResponse401 = {
+  data: ProblemDetails
+  status: 401
+}
+
+export type createSubscriptionResponse500 = {
+  data: ProblemDetails
+  status: 500
+}
+
+export type createSubscriptionResponseSuccess = (createSubscriptionResponse201) & {
+  headers: Headers;
+};
+export type createSubscriptionResponseError = (createSubscriptionResponse400 | createSubscriptionResponse401 | createSubscriptionResponse500) & {
+  headers: Headers;
+};
+
+export type createSubscriptionResponse = (createSubscriptionResponseSuccess | createSubscriptionResponseError)
+
+export const getCreateSubscriptionUrl = () => {
+
+
+
+
+  return `/v1/subscriptions`
+}
+
+export const createSubscription = async (createSubscriptionRequest: CreateSubscriptionRequest, options?: RequestInit): Promise<createSubscriptionResponse> => {
+
+  const res = await fetch(getCreateSubscriptionUrl(),
+  {
+    ...options,
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(
+      createSubscriptionRequest,)
+  }
+)
+
+  const body = [204, 205, 304].includes(res.status) ? null : await res.text();
+
+  const data: createSubscriptionResponse['data'] = body ? JSON.parse(body) : {}
+  return { data, status: res.status, headers: res.headers } as createSubscriptionResponse
 }

--- a/packages/sdk-generated/src/types.ts
+++ b/packages/sdk-generated/src/types.ts
@@ -140,6 +140,23 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/v1/subscriptions": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** `POST /v1/subscriptions`. */
+        post: operations["createSubscription"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
@@ -172,6 +189,18 @@ export interface components {
         };
         /** @description Identifier for a codelist (e.g. `CL_STATE_AU`). */
         CodelistId: string;
+        /** @description Request body for `POST /v1/subscriptions`. */
+        CreateSubscriptionRequest: {
+            /** @description Optional dataflow filter. Empty means every dataflow update. */
+            dataflow_ids?: components["schemas"]["DataflowId"][];
+            /** @description Absolute HTTP(S) URL to receive webhook deliveries. */
+            url: string;
+        };
+        /** @description Response body for `POST /v1/subscriptions`. */
+        CreateSubscriptionResponse: {
+            /** @description Created subscription. */
+            subscription: components["schemas"]["SubscriptionDetails"];
+        };
         /** @description A dataflow — a named collection of series sharing dimensions and measures. */
         Dataflow: {
             /** @description Required attribution string shown to end-users alongside derived charts. */
@@ -476,6 +505,27 @@ export interface components {
         };
         /** @description Identifier for an upstream data source (e.g. `abs`, `rba`, `apra`). */
         SourceId: string;
+        /** @description Created webhook subscription details. */
+        SubscriptionDetails: {
+            /**
+             * Format: date-time
+             * @description UTC creation timestamp.
+             */
+            created_at: string;
+            /** @description Dataflow filter attached to the subscription. */
+            dataflow_ids: components["schemas"]["DataflowId"][];
+            /**
+             * Format: uuid
+             * @description Stable subscription id.
+             */
+            id: string;
+            /** @description HMAC signing secret shown once at creation. */
+            signing_secret: string;
+            /** @description Current subscription status. */
+            status: string;
+            /** @description Delivery target URL. */
+            url: string;
+        };
         /**
          * @description Temporal granularity of an observation's timestamp. Matches the SDMX
          *     `@FREQ` facet on a coarse scale.
@@ -559,6 +609,15 @@ export interface operations {
                     "application/json": components["schemas"]["DataflowDetailResponse"];
                 };
             };
+            /** @description Invalid path parameter. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
             /** @description Dataflow not found. */
             404: {
                 headers: {
@@ -602,6 +661,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["DataflowCodelistResponse"];
+                };
+            };
+            /** @description Invalid path parameter. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
                 };
             };
             /** @description Dataflow or dimension not found. */
@@ -860,6 +928,57 @@ export interface operations {
             };
             /** @description Series not found. */
             404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Internal error. */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+        };
+    };
+    createSubscription: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CreateSubscriptionRequest"];
+            };
+        };
+        responses: {
+            /** @description Subscription created. */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CreateSubscriptionResponse"];
+                };
+            };
+            /** @description Invalid subscription request. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/problem+json": components["schemas"]["ProblemDetails"];
+                };
+            };
+            /** @description Missing or invalid API key. */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/packages/sdk-generated/src/zod.ts
+++ b/packages/sdk-generated/src/zod.ts
@@ -16,6 +16,22 @@ type Codelist = {
   id: CodelistId;
   name: string;
 };
+type CreateSubscriptionRequest = {
+  dataflow_ids?: Array<DataflowId> | undefined;
+  url: string;
+};
+type DataflowId = string;
+type CreateSubscriptionResponse = {
+  subscription: SubscriptionDetails;
+};
+type SubscriptionDetails = {
+  created_at: string;
+  dataflow_ids: Array<DataflowId>;
+  id: string;
+  signing_secret: string;
+  status: string;
+  url: string;
+};
 type Dataflow = {
   attribution: string;
   description?: (string | null) | undefined;
@@ -36,7 +52,6 @@ type Frequency =
   | "quarterly"
   | "annual"
   | "irregular";
-type DataflowId = string;
 type License =
   | "CC-BY-4.0"
   | "CC-BY-ND-4.0"
@@ -335,6 +350,22 @@ const SeriesLookupResponse: z.ZodType<SeriesLookupResponse> = z
     series: Series,
   })
   .passthrough();
+const CreateSubscriptionRequest: z.ZodType<CreateSubscriptionRequest> = z
+  .object({ dataflow_ids: z.array(DataflowId).optional(), url: z.string() })
+  .passthrough();
+const SubscriptionDetails: z.ZodType<SubscriptionDetails> = z
+  .object({
+    created_at: z.string().datetime({ offset: true }),
+    dataflow_ids: z.array(DataflowId),
+    id: z.string().uuid(),
+    signing_secret: z.string(),
+    status: z.string(),
+    url: z.string(),
+  })
+  .passthrough();
+const CreateSubscriptionResponse: z.ZodType<CreateSubscriptionResponse> = z
+  .object({ subscription: SubscriptionDetails })
+  .passthrough();
 const DataflowsQuery: z.ZodType<DataflowsQuery> = z
   .object({
     frequency: z.union([z.null(), Frequency]),
@@ -387,6 +418,9 @@ export const schemas = {
   SeriesRevisionMetadata,
   Series,
   SeriesLookupResponse,
+  CreateSubscriptionRequest,
+  SubscriptionDetails,
+  CreateSubscriptionResponse,
   DataflowsQuery,
   ProblemDetails,
   SearchQuery,


### PR DESCRIPTION
Closes #58

## Summary

- Add `POST /v1/subscriptions` with API-key auth, URL/dataflow validation, one-time HMAC signing secret return, and OpenAPI/SDK generation.
- Add durable webhook subscription, delivery, and delivery-attempt tables with retry state and migration rollback.
- Add delivery worker wiring, HMAC/timestamp headers, exponential backoff, bounded attempts, operational logs, and loader-side enqueue when observations are loaded.

## Pass requirements

- [x] `POST /v1/subscriptions` creates a subscription according to the API contract
- [x] Deliveries are HMAC-signed and include a timestamp
- [x] Failed deliveries retry with exponential backoff and bounded attempts
- [x] Delivery attempts and failures are observable through logs/metrics suitable for operations
- [x] Integration tests cover subscription creation, successful delivery, and retry-on-failure behavior

## Test plan

- `cargo fmt --all --check`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTC_WRAPPER= cargo test -p au-kpis-loader --test load_batch -- --test-threads=1`
- `RUSTC_WRAPPER= cargo test -p au-kpis-api-http --test subscriptions -- --test-threads=1`
- `RUSTC_WRAPPER= cargo test -p au-kpis-openapi`
- `RUSTC_WRAPPER= cargo test -p au-kpis-db --test migrations -- --test-threads=1`
- `RUSTC_WRAPPER= cargo nextest run --workspace --profile ci` plus retry log grep for `FLAKY`
- `DATABASE_URL=postgres://au_kpis:au_kpis@127.0.0.1:54320/<throwaway> SQLX_OFFLINE=false RUSTC_WRAPPER= cargo sqlx prepare --workspace`
- `pnpm run lint`
- `pnpm turbo run typecheck test`
- `pnpm --filter @au-kpis/docs test`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `pnpm audit --audit-level critical`
- `gitleaks protect --staged --config .gitleaks.toml`
- `git diff --check`

## Spec impact

No Spec changes required. `POST /v1/subscriptions` is already listed in `Spec.md § API surface` for phase 5, and the implementation refreshes the committed OpenAPI/SDK artifacts.
