### PR TITLE
ci: add merge queue workflow (#15)

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -1,0 +1,43 @@
+name: Merge Queue
+
+on:
+  merge_group:
+    types:
+      - checks_requested
+
+concurrency:
+  group: merge-queue-${{ github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  full-pr-flow:
+    name: Full PR Flow
+    uses: ./.github/workflows/pr.yml
+    permissions:
+      contents: read
+      id-token: write
+      issues: write
+      pull-requests: write
+      security-events: write
+    secrets: inherit
+
+  # `main` requires one status check named `CI OK`. On merge-group
+  # events this job makes that status belong to the merge queue workflow
+  # while the reusable PR workflow supplies the full gate set.
+  ci-ok:
+    name: CI OK
+    runs-on: ubuntu-latest
+    needs:
+      - full-pr-flow
+    if: always()
+    steps:
+      - name: Enforce merge-queue result
+        env:
+          FULL_PR_FLOW_RESULT: ${{ needs.full-pr-flow.result }}
+        run: |
+          set -euo pipefail
+          echo "Full PR flow result: ${FULL_PR_FLOW_RESULT}"
+          if [ "${FULL_PR_FLOW_RESULT}" != "success" ]; then
+            echo "::error::merge queue batch failed; GitHub merge queue will eject the batch."
+            exit 1
+          fi

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -7,12 +7,10 @@ on:
       - reopened
       - synchronize
       - ready_for_review
-  merge_group:
-    types:
-      - checks_requested
+  workflow_call:
 
 concurrency:
-  group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('merge-{0}', github.sha) }}
+  group: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('workflow-call-{0}', github.sha) }}
   cancel-in-progress: true
 
 env:
@@ -421,9 +419,12 @@ jobs:
             target/openapi/generated-normalized.json
 
       - name: Compare against base branch OpenAPI
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref || github.base_ref || 'main' }}
         run: |
           set -euo pipefail
-          git show "origin/${{ github.event.pull_request.base.ref }}:openapi.json" > target/openapi/base-openapi.json
+          git fetch --depth=1 origin "${BASE_REF}"
+          git show "origin/${BASE_REF}:openapi.json" > target/openapi/base-openapi.json
           oasdiff breaking target/openapi/base-openapi.json target/openapi/openapi.json
 
   supply-chain:
@@ -528,36 +529,16 @@ jobs:
             echo "K6_OUT=${LOCAL_K6_OUT}" >> "$GITHUB_ENV"
           fi
 
-      - name: Configure local smoke target
-        if: github.event_name != 'merge_group'
+      - name: Configure smoke target
         run: |
           set -euo pipefail
           echo "AU_KPIS_BASE_URL=http://127.0.0.1:3000" >> "$GITHUB_ENV"
           echo "K6_ENVIRONMENT=pr-compose" >> "$GITHUB_ENV"
 
-      - name: Configure staging smoke target
-        if: github.event_name == 'merge_group'
-        env:
-          AU_KPIS_STAGING_BASE_URL: ${{ vars.AU_KPIS_STAGING_BASE_URL }}
-        run: |
-          set -euo pipefail
-          if [ -z "${AU_KPIS_STAGING_BASE_URL:-}" ]; then
-            echo "AU_KPIS_STAGING_BASE_URL repository variable is required for merge queue smoke." >&2
-            exit 1
-          fi
-          echo "AU_KPIS_BASE_URL=${AU_KPIS_STAGING_BASE_URL}" >> "$GITHUB_ENV"
-          echo "K6_ENVIRONMENT=staging" >> "$GITHUB_ENV"
-
       - name: Start compose smoke dependencies
-        if: github.event_name != 'merge_group'
         run: docker compose -f infra/compose/docker-compose.yml up -d --wait --wait-timeout 120 postgres redis minio pdf-extractor influxdb
 
-      - name: Start merge-queue metrics store
-        if: github.event_name == 'merge_group'
-        run: docker compose -f infra/compose/docker-compose.yml up -d influxdb
-
       - name: Apply migrations
-        if: github.event_name != 'merge_group'
         run: |
           set -euo pipefail
           ready=0
@@ -578,18 +559,15 @@ jobs:
                 psql -v ON_ERROR_STOP=1 -U au_kpis -d au_kpis
 
       - name: Seed smoke fixture data
-        if: github.event_name != 'merge_group'
         run: |
           docker compose -f infra/compose/docker-compose.yml exec -T postgres \
             psql -v ON_ERROR_STOP=1 -U au_kpis -d au_kpis \
             < apps/web/e2e/fixtures/explorer.sql
 
       - name: Start local smoke API
-        if: github.event_name != 'merge_group'
         run: docker compose -f infra/compose/docker-compose.yml up -d --build api
 
       - name: Wait for local API readiness
-        if: github.event_name != 'merge_group'
         run: |
           set -euo pipefail
           for _ in $(seq 1 120); do
@@ -966,6 +944,7 @@ jobs:
 
   codex-review:
     name: Codex Structured Review
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -1479,7 +1458,7 @@ jobs:
       - contract
       - snapshots
       - codex-review
-    if: always()
+    if: always() && github.event_name == 'pull_request'
     steps:
       - name: Enforce required job results
         env:

--- a/crates/testing/tests/bench_scaffold.rs
+++ b/crates/testing/tests/bench_scaffold.rs
@@ -90,9 +90,12 @@ fn issue_37_benchmark_contract_is_wired() {
 
     let pr_workflow =
         fs::read_to_string(root.join(".github/workflows/pr.yml")).expect("read pr workflow");
+    let merge_workflow =
+        fs::read_to_string(root.join(".github/workflows/merge.yml")).expect("read merge workflow");
     assert!(
-        pr_workflow.contains("merge_group:"),
-        "benchmark regression gate should run for merge queue batches"
+        merge_workflow.contains("merge_group:")
+            && merge_workflow.contains("uses: ./.github/workflows/pr.yml"),
+        "benchmark regression gate should run for merge queue batches through merge.yml"
     );
     assert!(
         pr_workflow.contains("name: Bench Regression"),
@@ -127,6 +130,8 @@ fn issue_38_k6_smoke_contract_is_wired() {
         fs::read_to_string(root.join("apps/bench/smoke.js")).expect("read k6 smoke script");
     let pr_workflow =
         fs::read_to_string(root.join(".github/workflows/pr.yml")).expect("read pr workflow");
+    let merge_workflow =
+        fs::read_to_string(root.join(".github/workflows/merge.yml")).expect("read merge workflow");
 
     for expected in [
         "duration: '30s'",
@@ -177,9 +182,10 @@ fn issue_38_k6_smoke_contract_is_wired() {
         "smoke workflow should publish k6 results to InfluxDB for Grafana trending"
     );
     assert!(
-        pr_workflow.contains("AU_KPIS_STAGING_BASE_URL")
-            && pr_workflow.contains("github.event_name == 'merge_group'"),
-        "merge-queue smoke flow should target the configured staging API"
+        merge_workflow.contains("merge_group:")
+            && merge_workflow.contains("uses: ./.github/workflows/pr.yml")
+            && pr_workflow.contains("AU_KPIS_BASE_URL=http://127.0.0.1:3000"),
+        "merge-queue smoke flow should reuse the docker-compose k6 gate"
     );
 
     let compose = fs::read_to_string(root.join("infra/compose/docker-compose.yml"))
@@ -325,6 +331,8 @@ fn issue_39_schemathesis_contract_is_wired() {
 
     let pr_workflow =
         fs::read_to_string(root.join(".github/workflows/pr.yml")).expect("read pr workflow");
+    let merge_workflow =
+        fs::read_to_string(root.join(".github/workflows/merge.yml")).expect("read merge workflow");
     let contract_config = fs::read_to_string(root.join("tests/contract/schemathesis.toml"))
         .expect("read schemathesis PR config");
     let deep_config = fs::read_to_string(root.join("tests/contract/schemathesis.deep.toml"))
@@ -352,8 +360,12 @@ fn issue_39_schemathesis_contract_is_wired() {
         "PR contract workflow should emit a JUnit report artifact"
     );
     assert!(
-        pr_workflow.contains("merge_group:") && pr_workflow.contains("- contract"),
-        "contract checks should remain blocking in merge queue batches through CI OK"
+        pr_workflow.contains("  contract:")
+            && merge_workflow.contains("merge_group:")
+            && merge_workflow.contains("uses: ./.github/workflows/pr.yml")
+            && merge_workflow.contains("name: CI OK")
+            && merge_workflow.contains("FULL_PR_FLOW_RESULT"),
+        "contract checks should remain blocking in merge queue batches through merge.yml CI OK"
     );
 
     for expected in [

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -2,7 +2,8 @@
 
 `Spec.md` is the source of truth for required gates. The pull request workflow
 groups those gates into parallel GitHub Actions jobs and aggregates them through
-the single `CI OK` status check.
+the single `CI OK` status check. The merge-queue workflow reuses the same gate
+set and reports its own `CI OK` status for merge-group batches.
 
 ## Pull request workflow
 
@@ -19,27 +20,64 @@ the single `CI OK` status check.
 - Supply-chain and secret scans: `cargo deny`, `cargo audit`,
   `pnpm audit --audit-level critical`, and gitleaks over full history
 - API container build plus Trivy HIGH/CRITICAL image scan
-- k6 smoke checks against the docker-compose stack on pull requests and the
-  configured staging API in merge queue
+- k6 smoke checks against the docker-compose stack
 - Advisory Criterion bench comparison through `critcmp`
 - Advisory Codex structured review when repository secrets allow it
 
 Rust jobs install `sccache` and use the GitHub Actions backend. TypeScript jobs
 restore the pnpm store and `.turbo` cache before running Turborepo tasks.
 
+## Merge-queue workflow
+
+`.github/workflows/merge.yml` triggers only on GitHub `merge_group` events. It
+calls `.github/workflows/pr.yml` through `workflow_call`, so each queued batch
+runs the full PR gate set: compile, typecheck, lint/format, nextest, coverage,
+snapshots, OpenAPI drift, schemathesis contract checks, supply-chain scans,
+container scan, k6 smoke against the docker-compose stack, bench regression, and
+the currently available Playwright suite.
+
+The merge workflow has a final `CI OK` job that depends on the called full PR
+flow. Branch rules require that status check, so any failed upstream gate fails
+the whole merge group.
+
+## Protected `main` configuration
+
+`main` is governed by the repository ruleset named `merge` (GitHub ruleset ID
+`15487251`), targeting `~DEFAULT_BRANCH`, with active enforcement and no bypass
+actors. The currently enforced rules are:
+
+- Block branch deletion and non-fast-forward pushes.
+- Require signed commits.
+- Require pull requests with CODEOWNERS review and at least one approving
+  review.
+- Require the `CI OK` status check.
+
+The intended merge-queue rule is blocked while this repository is owned by the
+`ponderingdemocritus` user account. GitHub merge queues are available for public
+repositories owned by organizations, or private repositories owned by
+organizations using GitHub Enterprise Cloud. The GitHub REST API rejects a
+`merge_queue` ruleset rule on this repository with HTTP 422
+`Invalid rule 'merge_queue'`.
+
+After the repository is transferred to an eligible organization, add a
+`merge_queue` rule to ruleset `15487251` with `HEADGREEN` grouping, `MERGE`
+merge method, build concurrency of 3, maximum batch size of 5, minimum batch
+size of 1, no minimum wait, and 60-minute status-check timeout. `HEADGREEN`
+validates the head of the merge group that contains every queued PR in the
+batch. If a required check fails, no subset lands; the failed batch is ejected
+and PRs must be re-queued after fixes.
+
 ## k6 smoke gate
 
 The smoke job starts the compose API stack and an InfluxDB v1 metrics store for
-pull requests, applies migrations, seeds `apps/web/e2e/fixtures/explorer.sql`,
-and runs `apps/bench/smoke.js`. Merge-queue runs use
-`AU_KPIS_STAGING_BASE_URL` from repository variables as the API target and still
-publish k6 samples through the configured InfluxDB output.
+pull requests and merge groups, applies migrations, seeds
+`apps/web/e2e/fixtures/explorer.sql`, and runs `apps/bench/smoke.js`.
 
 Set `K6_INFLUXDB_ADDR` as a repository variable when CI should post trend data
 to a shared InfluxDB/Grafana environment. If it is not set, the job posts to the
 local compose InfluxDB database at `http://127.0.0.1:8086/k6`. Set
-`AU_KPIS_SMOKE_API_KEY` as a repository secret when staging should run the smoke
-scenario with an API-key tier instead of anonymous quotas.
+`AU_KPIS_SMOKE_API_KEY` as a repository secret when the smoke scenario should
+use an API-key tier instead of anonymous quotas.
 
 ## Nightly k6 load tests
 


### PR DESCRIPTION
## Context

Adds the dedicated merge-queue workflow required by `Spec.md § CI/CD pipeline -> Merge-queue flow`, keeps the PR gate set reusable, and documents the exact protected-main settings.

This is draft because GitHub rejected enabling the `merge_queue` ruleset rule on this repository. The repo is currently owned by the `ponderingdemocritus` user account (`owner.type = User`), and GitHub documents merge queues as available for public repositories owned by organizations or private repositories owned by organizations using GitHub Enterprise Cloud: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue

Refs #15. Not `Closes #15` until the repository is transferred to an eligible organization or GitHub enables merge queue for user-owned repositories.

## Pass requirements

- [x] `merge.yml` runs the merge-queue-only blocking checks described by the spec: full PR flow, k6 smoke, schemathesis contract fuzz, bench regression, and the currently available full Playwright suite
- [ ] GitHub merge queue is enabled on `main`
  - Blocked: `PUT /repos/ponderingdemocritus/australian-kpis/rulesets/15487251` with a `merge_queue` rule returned HTTP 422: `Invalid rule 'merge_queue'`.
- [x] Required CODEOWNERS review is enforced on `main`
- [x] Signed commits are required on `main`
- [ ] A failed merge-queue batch ejects the full batch rather than partially landing
  - Blocked with the merge-queue rule above. The intended `HEADGREEN` configuration is documented in `docs/ci.md`.
- [x] Repository settings or ops notes document the exact branch-protection and merge-queue configuration

## Test plan

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 -color=false .github/workflows/pr.yml .github/workflows/merge.yml`
- `cargo fmt --all --check`
- `RUSTC_WRAPPER= cargo clippy --workspace --all-targets --locked -- -D warnings`
- `RUSTC_WRAPPER= cargo test -p au-kpis-testing --test bench_scaffold -- --nocapture`
- `RUSTC_WRAPPER= cargo nextest run --workspace --profile ci -E 'not test(loads_ten_thousand_observations_with_copy_batches)'`
- `pnpm run lint`
- `pnpm turbo run typecheck test --cache-dir=.turbo`
- `cargo deny check`
- `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- `gitleaks protect --staged`
- Repository ruleset readback confirms ruleset `15487251` enforces `CI OK`, CODEOWNERS review with one approval, signed commits, branch deletion block, and non-fast-forward block.

## Spec impact

No `Spec.md` change. The implementation follows the spec’s merge-queue workflow shape, but the repository setting is blocked by GitHub availability for user-owned repositories.
