### PR TITLE
feat(adapter-aemo): AEMO NEMWeb dispatch ingestion (#55)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,6 +375,26 @@ dependencies = [
 [[package]]
 name = "au-kpis-adapter-aemo"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "au-kpis-adapter",
+ "au-kpis-domain",
+ "au-kpis-error",
+ "au-kpis-storage",
+ "bytes",
+ "chrono",
+ "csv-async",
+ "futures",
+ "insta",
+ "object_store",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "zip",
+]
 
 [[package]]
 name = "au-kpis-adapter-apra"
@@ -644,6 +664,7 @@ dependencies = [
  "assert_cmd",
  "au-kpis-adapter",
  "au-kpis-adapter-abs",
+ "au-kpis-adapter-aemo",
  "au-kpis-adapter-apra",
  "au-kpis-adapter-rba",
  "au-kpis-adapter-state-budgets",

--- a/Spec.md
+++ b/Spec.md
@@ -471,6 +471,8 @@ pub struct Observation {
 
 Core types: `Source`, `Dataflow`, `Dimension`, `Codelist`, `Code`, `Measure`, `Series`, `Observation`, `Artifact`. `ToSchema` derive (utoipa) makes them OpenAPI-visible. `SeriesKey` is a newtype wrapping a hash — not `String` — for type-safety at all boundaries, and series dimensions stay typed in-memory (`DimensionId`/`CodeId`) while serializing to ordinary JSON object keys/values.
 
+`TimePrecision` covers `minute`, `day`, `week`, `month`, `quarter`, and `year`; the `minute` value is used for sub-hourly feeds such as AEMO DispatchIS five-minute observations.
+
 ### Database schema (key tables)
 
 - **`series`** — vanilla Postgres, GIN index on `dimensions` JSONB for dimensional queries like "all VIC observations". ~100K rows, small.

--- a/crates/adapters/aemo/Cargo.toml
+++ b/crates/adapters/aemo/Cargo.toml
@@ -8,3 +8,26 @@ repository.workspace = true
 description = "AEMO adapter (high-frequency CSV)."
 
 [dependencies]
+async-trait = "0.1"
+au-kpis-adapter = { workspace = true }
+au-kpis-domain = { workspace = true }
+au-kpis-error = { workspace = true }
+au-kpis-storage = { workspace = true }
+bytes = "1"
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+csv-async = { version = "1.3", default-features = false, features = ["tokio"] }
+futures = "0.3"
+tokio = { version = "1", features = ["rt", "sync"] }
+tokio-util = { version = "0.7", features = ["io"] }
+tracing = "0.1"
+zip = { version = "7.2", default-features = false, features = ["deflate"] }
+
+[dev-dependencies]
+async-trait = "0.1"
+bytes = "1"
+insta = { version = "1", features = ["json"] }
+object_store = "0.11"
+reqwest = { version = "0.12", default-features = false }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }

--- a/crates/adapters/aemo/src/lib.rs
+++ b/crates/adapters/aemo/src/lib.rs
@@ -594,7 +594,9 @@ fn metric_observation_rows(
     let mut rows = Vec::with_capacity(metrics.len());
 
     for metric in metrics {
-        let raw = row_required(row, metric.field)?;
+        let raw = row.get(metric.field).map(String::as_str).ok_or_else(|| {
+            AdapterError::FormatDrift(format!("AEMO DispatchIS row missing `{}`", metric.field))
+        })?;
         let value = parse_optional_f64(raw)?;
         let dimensions = BTreeMap::from([
             (

--- a/crates/adapters/aemo/src/lib.rs
+++ b/crates/adapters/aemo/src/lib.rs
@@ -1,1 +1,912 @@
-//! AEMO adapter (high-frequency CSV).
+//! AEMO adapter for high-frequency NEMWeb DispatchIS CSV ZIP artifacts.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::{
+    collections::BTreeMap,
+    io::{Cursor, Read},
+    time::Duration,
+};
+
+use async_trait::async_trait;
+use au_kpis_adapter::{
+    AdapterError, AdapterManifest, ArtifactRef, DiscoveredJob, DiscoveryCtx, FetchCtx,
+    ObservationStream, ParseCtx, RateLimit, SourceAdapter, UpstreamRevision,
+    capture_response_headers, retry_after_delta,
+};
+use au_kpis_domain::{
+    Artifact, CodeId, Dataflow, DataflowId, DimensionId, Frequency, License, MeasureId,
+    Observation, ObservationStatus, SeriesDescriptor, SeriesKey, SourceId, TimePrecision,
+};
+use au_kpis_error::CoreError;
+use au_kpis_storage::StorageKey;
+use bytes::Bytes;
+use chrono::{DateTime, FixedOffset, NaiveDateTime, SecondsFormat, TimeZone, Utc};
+use csv_async::AsyncReaderBuilder;
+use futures::{StreamExt, stream};
+use tokio_util::io::StreamReader;
+use zip::ZipArchive;
+
+const DEFAULT_DISPATCH_LISTING_URL: &str =
+    "https://www.nemweb.com.au/Reports/Current/DispatchIS_Reports/";
+const USER_AGENT: &str = concat!("au-kpis-adapter-aemo/", env!("CARGO_PKG_VERSION"));
+const DATAFLOW_ID: &str = "aemo.dispatch";
+const ATTRIBUTION: &str = "Source: Australian Energy Market Operator";
+const LICENSE_NAME: &str = "AEMO data terms";
+const DISPATCHIS_PREFIX: &str = "PUBLIC_DISPATCHIS_";
+const DISPATCHIS_SUFFIX: &str = ".zip";
+const CSV_PAYLOAD: &str = "aemo-csv-cid";
+const POLL_INTERVAL_SECONDS: i64 = 5 * 60;
+
+/// Freshness SLO for 5-minute AEMO dispatch data, in seconds.
+pub const FRESHNESS_SLO_SECONDS: i64 = 15 * 60;
+
+/// Alias used by tests and callers that persist AEMO upstream revisions.
+pub type AemoDispatchFileRevision = UpstreamRevision;
+
+/// One DispatchIS ZIP file exposed by the NEMWeb current reports listing.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AemoDispatchFile {
+    /// ZIP file name, e.g. `PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip`.
+    pub file_name: String,
+    /// Dispatch interval encoded in the file name.
+    pub dispatch_interval: DateTime<Utc>,
+    /// Listing timestamp shown by NEMWeb for the file.
+    pub published_at: DateTime<Utc>,
+    /// File size in bytes from the NEMWeb listing.
+    pub size_bytes: u64,
+    /// AEMO sequence number encoded in the file name.
+    pub sequence: String,
+    /// Absolute URL used to fetch the ZIP artifact.
+    pub source_url: String,
+}
+
+impl AemoDispatchFile {
+    /// Lag between a discovery start timestamp and the NEMWeb listing timestamp.
+    #[must_use]
+    pub fn freshness_lag_seconds(&self, started_at: DateTime<Utc>) -> i64 {
+        (started_at - self.published_at).num_seconds().max(0)
+    }
+
+    fn revision_key(&self) -> String {
+        format!(
+            "AEMO:DISPATCHIS:{}",
+            self.dispatch_interval
+                .with_timezone(&aemo_market_offset())
+                .format("%Y%m%d%H%M")
+        )
+    }
+
+    fn revision(&self) -> UpstreamRevision {
+        UpstreamRevision::new(self.sequence.clone(), Some(utc_rfc3339(self.published_at)))
+    }
+
+    fn to_discovered_job(
+        &self,
+        started_at: DateTime<Utc>,
+        trace_parent: Option<&str>,
+    ) -> DiscoveredJob {
+        let mut metadata = BTreeMap::new();
+        metadata.insert("artifact_format".into(), "zip".into());
+        metadata.insert("cadence".into(), "5min".into());
+        metadata.insert("csv_payload".into(), CSV_PAYLOAD.into());
+        metadata.insert(
+            "dispatch_interval".into(),
+            utc_rfc3339(self.dispatch_interval),
+        );
+        metadata.insert(
+            "freshness_lag_seconds".into(),
+            self.freshness_lag_seconds(started_at).to_string(),
+        );
+        metadata.insert(
+            "freshness_slo_seconds".into(),
+            FRESHNESS_SLO_SECONDS.to_string(),
+        );
+        metadata.insert(
+            "poll_interval_seconds".into(),
+            POLL_INTERVAL_SECONDS.to_string(),
+        );
+        metadata.insert("published_at".into(), utc_rfc3339(self.published_at));
+        metadata.insert("revision_key".into(), self.revision_key());
+        metadata.insert("revision_version".into(), self.sequence.clone());
+        metadata.insert("source_file".into(), self.file_name.clone());
+        metadata.insert("upstream_size_bytes".into(), self.size_bytes.to_string());
+
+        DiscoveredJob {
+            id: format!(
+                "aemo-dispatchis-{}-{}",
+                self.dispatch_interval
+                    .with_timezone(&aemo_market_offset())
+                    .format("%Y%m%d%H%M"),
+                self.sequence
+            ),
+            source_id: source_id(),
+            dataflow_id: dataflow_id(),
+            source_url: self.source_url.clone(),
+            trace_parent: trace_parent.map(str::to_string),
+            metadata,
+        }
+    }
+}
+
+/// AEMO NEMWeb DispatchIS adapter.
+#[derive(Debug, Clone)]
+pub struct AemoAdapter {
+    manifest: AdapterManifest,
+    dispatch_listing_url: String,
+}
+
+impl Default for AemoAdapter {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
+impl AemoAdapter {
+    /// Start building an AEMO adapter.
+    #[must_use]
+    pub fn builder() -> AemoAdapterBuilder {
+        AemoAdapterBuilder::default()
+    }
+
+    /// Parse the default NEMWeb DispatchIS listing format into ZIP files.
+    pub fn parse_dispatch_listing(body: &str) -> Result<Vec<AemoDispatchFile>, AdapterError> {
+        parse_dispatch_listing_with_base(body, DEFAULT_DISPATCH_LISTING_URL)
+    }
+
+    /// Convert current DispatchIS files into fetch jobs without known-revision filtering.
+    #[must_use]
+    pub fn current_jobs_with_started_at(
+        current: &[AemoDispatchFile],
+        started_at: DateTime<Utc>,
+    ) -> Vec<DiscoveredJob> {
+        Self::discoverable_jobs_with_started_at(current, &BTreeMap::new(), started_at, None)
+    }
+
+    /// Diff current DispatchIS files against stored upstream revisions.
+    #[must_use]
+    pub fn discoverable_jobs_with_started_at(
+        current: &[AemoDispatchFile],
+        known_revisions: &BTreeMap<String, UpstreamRevision>,
+        started_at: DateTime<Utc>,
+        trace_parent: Option<&str>,
+    ) -> Vec<DiscoveredJob> {
+        current
+            .iter()
+            .filter_map(|file| {
+                let revision = file.revision();
+                known_revisions
+                    .get(&file.revision_key())
+                    .is_none_or(|known| known != &revision)
+                    .then(|| file.to_discovered_job(started_at, trace_parent))
+            })
+            .collect()
+    }
+
+    /// Static metadata for the AEMO dispatch dataflow.
+    #[must_use]
+    pub fn dataflow_metadata(&self) -> Vec<Dataflow> {
+        vec![Dataflow {
+            id: dataflow_id(),
+            source_id: source_id(),
+            name: "AEMO NEM dispatch".into(),
+            description: Some(
+                "Five-minute NEM dispatch price and regional summary rows from NEMWeb DispatchIS reports."
+                    .into(),
+            ),
+            dimensions: vec![
+                DimensionId::new("region").expect("static dimension id is valid"),
+                DimensionId::new("metric").expect("static dimension id is valid"),
+            ],
+            measures: vec![MeasureId::new("value").expect("static measure id is valid")],
+            frequency: Frequency::Irregular,
+            license: License::Other(LICENSE_NAME.into()),
+            attribution: ATTRIBUTION.into(),
+            source_url: DEFAULT_DISPATCH_LISTING_URL.into(),
+        }]
+    }
+
+    fn dispatch_listing_url(&self) -> &str {
+        &self.dispatch_listing_url
+    }
+
+    fn validate_fetch_job(&self, job: &DiscoveredJob) -> Result<(), AdapterError> {
+        if job.source_id != self.manifest.source_id {
+            return Err(AdapterError::Validation(format!(
+                "AEMO fetch received job for source `{}`",
+                job.source_id.as_str()
+            )));
+        }
+        if job.dataflow_id != dataflow_id() {
+            return Err(AdapterError::Validation(format!(
+                "AEMO fetch received unsupported dataflow `{}`",
+                job.dataflow_id.as_str()
+            )));
+        }
+        dispatch_file_provenance(&job.source_url).ok_or_else(|| {
+            AdapterError::Validation(format!(
+                "AEMO fetch URL `{}` is not a NEMWeb DispatchIS ZIP artifact",
+                job.source_url
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+/// Builder for [`AemoAdapter`].
+#[derive(Debug, Clone)]
+pub struct AemoAdapterBuilder {
+    dispatch_listing_url: String,
+}
+
+impl Default for AemoAdapterBuilder {
+    fn default() -> Self {
+        Self {
+            dispatch_listing_url: DEFAULT_DISPATCH_LISTING_URL.into(),
+        }
+    }
+}
+
+impl AemoAdapterBuilder {
+    /// Override the DispatchIS current reports listing URL.
+    #[must_use]
+    pub fn dispatch_listing_url(mut self, url: impl Into<String>) -> Self {
+        self.dispatch_listing_url = url.into();
+        self
+    }
+
+    /// Build an adapter.
+    #[must_use]
+    pub fn build(self) -> AemoAdapter {
+        AemoAdapter {
+            manifest: AdapterManifest {
+                source_id: source_id(),
+                name: "Australian Energy Market Operator".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+                rate_limit: RateLimit::new(12, Duration::from_secs(60))
+                    .expect("static AEMO rate limit is valid"),
+                dataflows: vec![dataflow_id()],
+            },
+            dispatch_listing_url: self.dispatch_listing_url,
+        }
+    }
+}
+
+#[async_trait]
+impl SourceAdapter for AemoAdapter {
+    fn id(&self) -> &'static str {
+        "aemo"
+    }
+
+    fn manifest(&self) -> &AdapterManifest {
+        &self.manifest
+    }
+
+    #[tracing::instrument(skip(self, ctx), fields(source = self.id()))]
+    async fn discover(&self, ctx: &DiscoveryCtx) -> Result<Vec<DiscoveredJob>, AdapterError> {
+        if ctx
+            .requested_dataflow_id()
+            .is_some_and(|requested| requested != &dataflow_id())
+        {
+            return Ok(Vec::new());
+        }
+
+        let response = ctx
+            .http
+            .execute(
+                ctx.http
+                    .raw()
+                    .get(self.dispatch_listing_url())
+                    .header("user-agent", USER_AGENT)
+                    .header("accept", "text/html,application/xhtml+xml"),
+            )
+            .await?;
+        let response_headers = capture_response_headers(response.headers());
+        let status = response.status();
+        if !status.is_success() {
+            return Err(AdapterError::UpstreamStatus {
+                status,
+                retry_after: retry_after_delta(&response_headers),
+                response_headers,
+            });
+        }
+        let body = response.text().await?;
+        let files = parse_dispatch_listing_with_base(&body, self.dispatch_listing_url())?;
+        Ok(Self::discoverable_jobs_with_started_at(
+            &files,
+            ctx.known_revisions(),
+            ctx.started_at,
+            ctx.trace_parent(),
+        ))
+    }
+
+    #[tracing::instrument(skip(self, ctx), fields(source = self.id(), job_id = %job.id))]
+    async fn fetch(&self, job: DiscoveredJob, ctx: &FetchCtx) -> Result<ArtifactRef, AdapterError> {
+        self.validate_fetch_job(&job)?;
+        let response = ctx
+            .http
+            .execute(
+                ctx.http
+                    .raw_artifact()
+                    .get(&job.source_url)
+                    .header("user-agent", USER_AGENT)
+                    .header("accept", "application/zip,application/octet-stream"),
+            )
+            .await?;
+        let response_headers = capture_response_headers(response.headers());
+        let status = response.status();
+        if !status.is_success() {
+            return Err(AdapterError::UpstreamStatus {
+                status,
+                retry_after: retry_after_delta(&response_headers),
+                response_headers,
+            });
+        }
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .map_or_else(|| "application/zip".to_string(), str::to_string);
+
+        let staged = ctx
+            .blob_store
+            .stage_artifact_stream(response.bytes_stream().boxed())
+            .await?;
+        let id = staged.id();
+        let storage_key = StorageKey::canonical_for(&id).to_string();
+        let artifact = Artifact {
+            id,
+            source_id: job.source_id,
+            source_url: job.source_url,
+            content_type,
+            response_headers,
+            storage_key,
+            size_bytes: staged.size_bytes(),
+            fetched_at: Utc::now(),
+        };
+        ctx.blob_store.commit_staged_artifact(&staged).await?;
+        ctx.persist_artifact(artifact).await
+    }
+
+    fn parse<'a>(&'a self, artifact: ArtifactRef, ctx: &'a ParseCtx) -> ObservationStream<'a> {
+        parse_artifact_stream(artifact, ctx)
+    }
+}
+
+fn parse_artifact_stream(artifact: ArtifactRef, ctx: &ParseCtx) -> ObservationStream<'_> {
+    if let Err(err) = validate_parse_artifact(&artifact, ctx.expected_dataflow_id()) {
+        return Box::pin(stream::once(async move { Err(err) }));
+    }
+
+    let blob_store = ctx.blob_store.clone();
+    let started_at = ctx.started_at;
+    let metadata = ctx.metadata().clone();
+    let cancellation = ctx.cancellation().clone();
+    let (row_tx, row_rx) = tokio::sync::mpsc::channel(1024);
+
+    tokio::spawn(async move {
+        let error_tx = row_tx.clone();
+        let key = StorageKey::from_persisted(artifact.storage_key.clone());
+        let result = async {
+            if cancellation.is_cancelled() {
+                return Err(AdapterError::Validation("AEMO parse cancelled".into()));
+            }
+            if !blob_store.matches_artifact_id(&key, artifact.id).await? {
+                return Err(AdapterError::Validation(format!(
+                    "AEMO artifact storage key `{}` does not match artifact id `{}`",
+                    artifact.storage_key,
+                    artifact.id.to_hex()
+                )));
+            }
+
+            let mut byte_stream = blob_store.get(&key).await?;
+            let mut bytes = Vec::with_capacity(artifact.size_bytes.min(usize::MAX as u64) as usize);
+            while let Some(chunk) = byte_stream.next().await {
+                if cancellation.is_cancelled() {
+                    return Err(AdapterError::Validation("AEMO parse cancelled".into()));
+                }
+                bytes.extend_from_slice(&chunk?);
+            }
+            parse_dispatch_zip(&artifact, bytes, started_at, &metadata, row_tx).await
+        }
+        .await;
+
+        if let Err(err) = result {
+            let _ = error_tx.send(Err(err)).await;
+        }
+    });
+
+    Box::pin(stream::unfold(row_rx, |mut rx| async {
+        rx.recv().await.map(|item| (item, rx))
+    }))
+}
+
+async fn parse_dispatch_zip(
+    artifact: &ArtifactRef,
+    bytes: Vec<u8>,
+    started_at: DateTime<Utc>,
+    metadata: &BTreeMap<String, String>,
+    row_tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+) -> Result<(), AdapterError> {
+    let (csv_name, csv_bytes) = extract_single_dispatch_csv(bytes)?;
+    let published_at = metadata
+        .get("published_at")
+        .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+        .map(|value| value.with_timezone(&Utc));
+    let csv_stream = stream::iter(vec![Ok::<Bytes, std::io::Error>(Bytes::from(csv_bytes))]);
+    let reader = StreamReader::new(csv_stream);
+    let mut csv = AsyncReaderBuilder::new()
+        .has_headers(false)
+        .flexible(true)
+        .create_reader(reader);
+    let mut records = csv.records();
+    let mut headers: BTreeMap<(String, String, String), Vec<String>> = BTreeMap::new();
+    let mut csv_published_at = published_at;
+
+    while let Some(record) = records.next().await {
+        let record = record.map_err(|err| {
+            AdapterError::FormatDrift(format!("AEMO DispatchIS CSV is malformed: {err}"))
+        })?;
+        if record.is_empty() {
+            continue;
+        }
+        match record.get(0).unwrap_or_default() {
+            "C" => {
+                csv_published_at = parse_control_row_published_at(&record).or(csv_published_at);
+            }
+            "I" => {
+                if record.len() >= 5 {
+                    let key = table_key(&record);
+                    let fields = record.iter().skip(4).map(str::to_string).collect();
+                    headers.insert(key, fields);
+                }
+            }
+            "D" => {
+                let key = table_key(&record);
+                let Some(header) = headers.get(&key) else {
+                    return Err(AdapterError::FormatDrift(format!(
+                        "AEMO DispatchIS row for {}/{}/{} appeared before its header",
+                        record.get(1).unwrap_or_default(),
+                        record.get(2).unwrap_or_default(),
+                        record.get(3).unwrap_or_default()
+                    )));
+                };
+                let row = values_by_header(header, &record);
+                let mut observations = observations_for_dispatch_row(
+                    artifact,
+                    &csv_name,
+                    &record,
+                    &row,
+                    started_at,
+                    csv_published_at,
+                )?;
+                for item in observations.drain(..) {
+                    if row_tx.send(Ok(item)).await.is_err() {
+                        return Ok(());
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    Ok(())
+}
+
+fn extract_single_dispatch_csv(bytes: Vec<u8>) -> Result<(String, Vec<u8>), AdapterError> {
+    let mut archive = ZipArchive::new(Cursor::new(bytes)).map_err(|err| {
+        AdapterError::FormatDrift(format!("AEMO DispatchIS ZIP is unreadable: {err}"))
+    })?;
+    let mut csv_entry = None;
+    for index in 0..archive.len() {
+        let mut entry = archive.by_index(index).map_err(|err| {
+            AdapterError::FormatDrift(format!("AEMO DispatchIS ZIP entry is unreadable: {err}"))
+        })?;
+        if entry.name().to_ascii_uppercase().ends_with(".CSV") {
+            if csv_entry.is_some() {
+                return Err(AdapterError::FormatDrift(
+                    "AEMO DispatchIS ZIP contains more than one CSV payload".into(),
+                ));
+            }
+            let mut bytes = Vec::new();
+            entry.read_to_end(&mut bytes).map_err(CoreError::Io)?;
+            csv_entry = Some((entry.name().to_string(), bytes));
+        }
+    }
+    csv_entry.ok_or_else(|| {
+        AdapterError::FormatDrift("AEMO DispatchIS ZIP did not contain a CSV payload".into())
+    })
+}
+
+fn observations_for_dispatch_row(
+    artifact: &ArtifactRef,
+    csv_name: &str,
+    record: &csv_async::StringRecord,
+    row: &BTreeMap<String, String>,
+    started_at: DateTime<Utc>,
+    published_at: Option<DateTime<Utc>>,
+) -> Result<Vec<(SeriesDescriptor, Observation)>, AdapterError> {
+    let table = record.get(2).unwrap_or_default();
+    match table {
+        "PRICE" => metric_observation_rows(
+            artifact,
+            csv_name,
+            record,
+            row,
+            started_at,
+            published_at,
+            &[MetricSpec {
+                field: "RRP",
+                code: "rrp",
+                unit: "AUD/MWh",
+            }],
+        ),
+        "REGIONSUM" => metric_observation_rows(
+            artifact,
+            csv_name,
+            record,
+            row,
+            started_at,
+            published_at,
+            &[
+                MetricSpec {
+                    field: "TOTALDEMAND",
+                    code: "total_demand",
+                    unit: "MW",
+                },
+                MetricSpec {
+                    field: "AVAILABLEGENERATION",
+                    code: "available_generation",
+                    unit: "MW",
+                },
+                MetricSpec {
+                    field: "NETINTERCHANGE",
+                    code: "net_interchange",
+                    unit: "MW",
+                },
+            ],
+        ),
+        _ => Ok(Vec::new()),
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct MetricSpec {
+    field: &'static str,
+    code: &'static str,
+    unit: &'static str,
+}
+
+fn metric_observation_rows(
+    artifact: &ArtifactRef,
+    csv_name: &str,
+    record: &csv_async::StringRecord,
+    row: &BTreeMap<String, String>,
+    started_at: DateTime<Utc>,
+    published_at: Option<DateTime<Utc>>,
+    metrics: &[MetricSpec],
+) -> Result<Vec<(SeriesDescriptor, Observation)>, AdapterError> {
+    let settlement = row_required(row, "SETTLEMENTDATE")?;
+    let time = parse_aemo_timestamp(settlement, "%Y/%m/%d %H:%M:%S")?;
+    let region = row_required(row, "REGIONID")?;
+    let table = record.get(2).unwrap_or_default();
+    let record_version = record.get(3).unwrap_or_default();
+    let mut rows = Vec::with_capacity(metrics.len());
+
+    for metric in metrics {
+        let raw = row_required(row, metric.field)?;
+        let value = parse_optional_f64(raw)?;
+        let dimensions = BTreeMap::from([
+            (
+                DimensionId::new("metric").expect("static dimension id is valid"),
+                CodeId::new(metric.code).map_err(|err| {
+                    AdapterError::Validation(format!("invalid AEMO metric code: {err}"))
+                })?,
+            ),
+            (
+                DimensionId::new("region").expect("static dimension id is valid"),
+                CodeId::new(region.to_ascii_uppercase()).map_err(|err| {
+                    AdapterError::Validation(format!("invalid AEMO region code: {err}"))
+                })?,
+            ),
+        ]);
+        let dataflow_id = dataflow_id();
+        let series_key = SeriesKey::derive(
+            &dataflow_id,
+            dimensions
+                .iter()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+        );
+        let series = SeriesDescriptor {
+            series_key,
+            dataflow_id,
+            measure_id: MeasureId::new("value").expect("static measure id is valid"),
+            dimensions,
+            unit: metric.unit.into(),
+        };
+
+        let mut attributes = BTreeMap::new();
+        attributes.insert("csv_file".into(), csv_name.into());
+        attributes.insert("dispatch_interval".into(), time.to_rfc3339());
+        if let Some(value) = row
+            .get("DISPATCHINTERVAL")
+            .filter(|value| !value.is_empty())
+        {
+            attributes.insert("dispatch_interval_no".into(), value.clone());
+        }
+        attributes.insert(
+            "freshness_slo_seconds".into(),
+            FRESHNESS_SLO_SECONDS.to_string(),
+        );
+        if let Some(value) = row.get("INTERVENTION").filter(|value| !value.is_empty()) {
+            attributes.insert("intervention".into(), value.clone());
+        }
+        if let Some(value) = row.get("LASTCHANGED").filter(|value| !value.is_empty()) {
+            attributes.insert("last_changed".into(), value.clone());
+        }
+        attributes.insert("metric".into(), metric.code.into());
+        if let Some(published_at) = published_at {
+            attributes.insert("published_at".into(), utc_rfc3339(published_at));
+        }
+        attributes.insert("record_version".into(), record_version.into());
+        if let Some(value) = row.get("RUNNO").filter(|value| !value.is_empty()) {
+            attributes.insert("run_no".into(), value.clone());
+        }
+        attributes.insert("table".into(), table.into());
+        if let Some(value) = row.get("PRICE_STATUS").filter(|value| !value.is_empty()) {
+            attributes.insert("price_status".into(), value.clone());
+        }
+
+        let observation = Observation {
+            series_key,
+            time,
+            time_precision: TimePrecision::Minute,
+            value,
+            status: if value.is_some() {
+                ObservationStatus::Normal
+            } else {
+                ObservationStatus::Missing
+            },
+            revision_no: 0,
+            attributes,
+            ingested_at: started_at,
+            source_artifact_id: artifact.id,
+        };
+        rows.push((series, observation));
+    }
+
+    Ok(rows)
+}
+
+fn table_key(record: &csv_async::StringRecord) -> (String, String, String) {
+    (
+        record.get(1).unwrap_or_default().to_string(),
+        record.get(2).unwrap_or_default().to_string(),
+        record.get(3).unwrap_or_default().to_string(),
+    )
+}
+
+fn values_by_header(
+    header: &[String],
+    record: &csv_async::StringRecord,
+) -> BTreeMap<String, String> {
+    header
+        .iter()
+        .zip(record.iter().skip(4))
+        .map(|(key, value)| (key.clone(), value.trim_matches('"').trim().to_string()))
+        .collect()
+}
+
+fn row_required<'a>(
+    row: &'a BTreeMap<String, String>,
+    field: &str,
+) -> Result<&'a str, AdapterError> {
+    row.get(field)
+        .map(String::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| AdapterError::FormatDrift(format!("AEMO DispatchIS row missing `{field}`")))
+}
+
+fn parse_optional_f64(value: &str) -> Result<Option<f64>, AdapterError> {
+    let value = value.trim();
+    if value.is_empty() {
+        return Ok(None);
+    }
+    value.parse::<f64>().map(Some).map_err(|err| {
+        AdapterError::FormatDrift(format!(
+            "AEMO DispatchIS numeric value `{value}` is invalid: {err}"
+        ))
+    })
+}
+
+fn parse_control_row_published_at(record: &csv_async::StringRecord) -> Option<DateTime<Utc>> {
+    let date = record.get(5)?;
+    let time = record.get(6)?;
+    parse_aemo_timestamp(&format!("{date} {time}"), "%Y/%m/%d %H:%M:%S").ok()
+}
+
+fn validate_parse_artifact(
+    artifact: &ArtifactRef,
+    expected_dataflow: Option<&DataflowId>,
+) -> Result<(), AdapterError> {
+    if artifact.source_id != source_id() {
+        return Err(AdapterError::Validation(format!(
+            "AEMO parse received artifact for source `{}`",
+            artifact.source_id.as_str()
+        )));
+    }
+    if let Some(expected) = expected_dataflow {
+        if expected != &dataflow_id() {
+            return Err(AdapterError::Validation(format!(
+                "AEMO parse expected dataflow `{}`",
+                expected.as_str()
+            )));
+        }
+    }
+    dispatch_file_provenance(&artifact.source_url).ok_or_else(|| {
+        AdapterError::Validation(format!(
+            "AEMO parse URL `{}` is not a trusted NEMWeb DispatchIS ZIP artifact",
+            artifact.source_url
+        ))
+    })?;
+    Ok(())
+}
+
+fn parse_dispatch_listing_with_base(
+    body: &str,
+    base_url: &str,
+) -> Result<Vec<AemoDispatchFile>, AdapterError> {
+    let mut files = Vec::new();
+    for raw_line in body.lines() {
+        let Some(href) = extract_href(raw_line) else {
+            continue;
+        };
+        let Some(file_name) = href.rsplit('/').next() else {
+            continue;
+        };
+        let Some((dispatch_interval, sequence)) = dispatch_file_name_parts(file_name) else {
+            continue;
+        };
+        let Some(prefix) = raw_line.split("<A ").next() else {
+            continue;
+        };
+        let Some((published_at, size_bytes)) = parse_listing_prefix(prefix)? else {
+            continue;
+        };
+        files.push(AemoDispatchFile {
+            file_name: file_name.to_string(),
+            dispatch_interval,
+            published_at,
+            size_bytes,
+            sequence,
+            source_url: resolve_listing_href(base_url, &href),
+        });
+    }
+    files.sort_by(|left, right| left.dispatch_interval.cmp(&right.dispatch_interval));
+    Ok(files)
+}
+
+fn extract_href(line: &str) -> Option<String> {
+    for marker in ["HREF=\"", "href=\""] {
+        if let Some(start) = line.find(marker) {
+            let value_start = start + marker.len();
+            let value_end = line[value_start..].find('"')? + value_start;
+            return Some(html_unescape_minimal(&line[value_start..value_end]));
+        }
+    }
+    None
+}
+
+fn parse_listing_prefix(prefix: &str) -> Result<Option<(DateTime<Utc>, u64)>, AdapterError> {
+    let tokens = prefix.split_whitespace().collect::<Vec<_>>();
+    if tokens.len() < 7 {
+        return Ok(None);
+    }
+    let Some(size_token) = tokens.last() else {
+        return Ok(None);
+    };
+    let Ok(size_bytes) = size_token.parse::<u64>() else {
+        return Ok(None);
+    };
+    let datetime = tokens[..tokens.len() - 1].join(" ");
+    let naive =
+        NaiveDateTime::parse_from_str(&datetime, "%A, %B %e, %Y %I:%M %p").map_err(|err| {
+            AdapterError::FormatDrift(format!(
+                "AEMO listing timestamp `{datetime}` is invalid: {err}"
+            ))
+        })?;
+    Ok(Some((market_time_to_utc(naive)?, size_bytes)))
+}
+
+fn dispatch_file_name_parts(file_name: &str) -> Option<(DateTime<Utc>, String)> {
+    let upper = file_name.to_ascii_uppercase();
+    if !upper.starts_with(DISPATCHIS_PREFIX)
+        || !upper.ends_with(&DISPATCHIS_SUFFIX.to_ascii_uppercase())
+    {
+        return None;
+    }
+    let stem = file_name.strip_suffix(DISPATCHIS_SUFFIX)?;
+    let rest = stem.strip_prefix(DISPATCHIS_PREFIX)?;
+    let (timestamp, sequence) = rest.split_once('_')?;
+    if timestamp.len() != 12 || !timestamp.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    if sequence.is_empty() || !sequence.bytes().all(|byte| byte.is_ascii_digit()) {
+        return None;
+    }
+    let naive = NaiveDateTime::parse_from_str(timestamp, "%Y%m%d%H%M").ok()?;
+    let dispatch_interval = market_time_to_utc(naive).ok()?;
+    Some((dispatch_interval, sequence.to_string()))
+}
+
+fn dispatch_file_provenance(source_url: &str) -> Option<(DateTime<Utc>, String)> {
+    let file_name = source_url.rsplit('/').next()?;
+    if !source_url.contains("/DispatchIS_Reports/") {
+        return None;
+    }
+    let trusted_host = source_url.contains("nemweb.com.au")
+        || source_url.starts_with("http://127.0.0.1:")
+        || source_url.starts_with("http://localhost:");
+    if !trusted_host {
+        return None;
+    }
+    dispatch_file_name_parts(file_name)
+}
+
+fn resolve_listing_href(base_url: &str, href: &str) -> String {
+    if href.starts_with("http://") || href.starts_with("https://") {
+        return href.to_string();
+    }
+    if href.starts_with('/') {
+        let Some(scheme_end) = base_url.find("://") else {
+            return href.to_string();
+        };
+        let origin_start = scheme_end + 3;
+        let origin_end = base_url[origin_start..]
+            .find('/')
+            .map_or(base_url.len(), |offset| origin_start + offset);
+        return format!("{}{}", &base_url[..origin_end], href);
+    }
+    format!("{}/{}", base_url.trim_end_matches('/'), href)
+}
+
+fn html_unescape_minimal(value: &str) -> String {
+    value
+        .replace("&amp;", "&")
+        .replace("&lt;", "<")
+        .replace("&gt;", ">")
+        .replace("&quot;", "\"")
+}
+
+fn parse_aemo_timestamp(value: &str, format: &str) -> Result<DateTime<Utc>, AdapterError> {
+    let naive = NaiveDateTime::parse_from_str(value.trim_matches('"'), format).map_err(|err| {
+        AdapterError::FormatDrift(format!("AEMO timestamp `{value}` is invalid: {err}"))
+    })?;
+    market_time_to_utc(naive)
+}
+
+fn market_time_to_utc(naive: NaiveDateTime) -> Result<DateTime<Utc>, AdapterError> {
+    aemo_market_offset()
+        .from_local_datetime(&naive)
+        .single()
+        .map(|value| value.with_timezone(&Utc))
+        .ok_or_else(|| {
+            AdapterError::FormatDrift(format!("AEMO market timestamp `{naive}` is ambiguous"))
+        })
+}
+
+fn aemo_market_offset() -> FixedOffset {
+    FixedOffset::east_opt(10 * 60 * 60).expect("static AEMO market offset is valid")
+}
+
+fn utc_rfc3339(value: DateTime<Utc>) -> String {
+    value.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn source_id() -> SourceId {
+    SourceId::new("aemo").expect("static source id is valid")
+}
+
+fn dataflow_id() -> DataflowId {
+    DataflowId::new(DATAFLOW_ID).expect("static dataflow id is valid")
+}

--- a/crates/adapters/aemo/tests/discover.rs
+++ b/crates/adapters/aemo/tests/discover.rs
@@ -1,0 +1,211 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use au_kpis_adapter::{AdapterError, AdapterHttpClient, DiscoveryCtx, SourceAdapter};
+use au_kpis_adapter_aemo::{AemoAdapter, AemoDispatchFileRevision, FRESHNESS_SLO_SECONDS};
+use chrono::{TimeZone, Utc};
+use serde_json::json;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+const TRACE_PARENT: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+const DISPATCH_LISTING: &str = r#"
+<html>
+  <body>
+    <pre><A HREF="/Reports/CURRENT">[To Parent Directory]</A><br><br>
+       Friday, May 8, 2026 05:16 AM        &lt;dir&gt; <A HREF="/Reports/CURRENT/DispatchIS_Reports/DUPLICATE">DUPLICATE</A><br>
+      Friday, May 29, 2026 10:51 AM        20468 <A HREF="/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291055_0000000519884398.zip">PUBLIC_DISPATCHIS_202605291055_0000000519884398.zip</A><br>
+      Friday, May 29, 2026 10:57 AM        20660 <A HREF="/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291100_0000000519884840.zip">PUBLIC_DISPATCHIS_202605291100_0000000519884840.zip</A><br>
+      Friday, May 29, 2026 11:02 AM        20628 <A HREF="/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291105_0000000519885422.zip">PUBLIC_DISPATCHIS_202605291105_0000000519885422.zip</A><br>
+      Friday, May 29, 2026 11:06 AM        20654 <A HREF="/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip">PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip</A><br>
+      Friday, May 29, 2026 11:07 AM         1024 <A HREF="/Reports/CURRENT/DispatchIS_Reports/README.txt">README.txt</A><br>
+    </pre>
+  </body>
+</html>
+"#;
+
+async fn serve_once(
+    status: &'static str,
+    headers: &'static [(&'static str, &'static str)],
+    body: &'static str,
+) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fixture server");
+    let addr = listener.local_addr().expect("fixture server address");
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).await.expect("read request");
+        let request = String::from_utf8_lossy(&request[..read]);
+        assert!(request.starts_with("GET /Reports/CURRENT/DispatchIS_Reports/ HTTP/1.1"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("user-agent: au-kpis-adapter-aemo/")
+        );
+
+        let mut response = format!(
+            "HTTP/1.1 {status}\r\ncontent-type: text/html\r\ncontent-length: {}\r\n",
+            body.len(),
+        );
+        for (name, value) in headers {
+            response.push_str(&format!("{name}: {value}\r\n"));
+        }
+        response.push_str("\r\n");
+        response.push_str(body);
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response");
+    });
+
+    format!("http://{addr}/Reports/CURRENT/DispatchIS_Reports/")
+}
+
+#[test]
+fn parse_dispatch_listing_discovers_five_minute_zip_files() {
+    let files =
+        AemoAdapter::parse_dispatch_listing(DISPATCH_LISTING).expect("parse NEMWeb listing");
+
+    let snapshot = files
+        .iter()
+        .map(|file| {
+            json!({
+                "file_name": file.file_name,
+                "dispatch_interval": file.dispatch_interval.to_rfc3339(),
+                "published_at": file.published_at.to_rfc3339(),
+                "size_bytes": file.size_bytes,
+                "sequence": file.sequence,
+                "freshness_lag_seconds_at_1110": file.freshness_lag_seconds(
+                    Utc.with_ymd_and_hms(2026, 5, 29, 1, 10, 0).unwrap()
+                ),
+                "source_url": file.source_url,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(files.len(), 4);
+    assert!(
+        files[2].freshness_lag_seconds(Utc.with_ymd_and_hms(2026, 5, 29, 1, 10, 0).unwrap())
+            <= FRESHNESS_SLO_SECONDS
+    );
+    insta::assert_json_snapshot!(snapshot);
+}
+
+#[test]
+fn discoverable_jobs_skip_known_revisions_and_carry_freshness_metadata() {
+    let files =
+        AemoAdapter::parse_dispatch_listing(DISPATCH_LISTING).expect("parse NEMWeb listing");
+    let known_revisions = BTreeMap::from([(
+        "AEMO:DISPATCHIS:202605291055".to_string(),
+        AemoDispatchFileRevision::new("0000000519884398", Some("2026-05-29T00:51:00Z")),
+    )]);
+
+    let jobs = AemoAdapter::discoverable_jobs_with_started_at(
+        &files,
+        &known_revisions,
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 10, 0).unwrap(),
+        Some(TRACE_PARENT),
+    );
+
+    assert_eq!(jobs.len(), 3);
+    assert!(jobs.iter().all(|job| job.source_id.as_str() == "aemo"));
+    assert!(
+        jobs.iter()
+            .all(|job| job.dataflow_id.as_str() == "aemo.dispatch")
+    );
+    assert!(
+        jobs.iter()
+            .all(|job| job.trace_parent.as_deref() == Some(TRACE_PARENT))
+    );
+    assert!(jobs.iter().all(|job| job.metadata["cadence"] == "5min"));
+    assert!(
+        jobs.iter()
+            .all(|job| job.metadata["poll_interval_seconds"] == "300")
+    );
+    assert!(
+        jobs.iter()
+            .all(|job| job.metadata["freshness_slo_seconds"] == "900")
+    );
+    assert_eq!(
+        jobs[0].metadata["revision_key"],
+        "AEMO:DISPATCHIS:202605291100"
+    );
+    assert_eq!(jobs[0].metadata["revision_version"], "0000000519884840");
+    assert_eq!(jobs[0].metadata["published_at"], "2026-05-29T00:57:00Z");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn discover_scrapes_nemweb_listing_over_http() {
+    let listing_url = serve_once("200 OK", &[], DISPATCH_LISTING).await;
+    let adapter = AemoAdapter::builder()
+        .dispatch_listing_url(&listing_url)
+        .build();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = DiscoveryCtx::new(http, Utc.with_ymd_and_hms(2026, 5, 29, 1, 10, 0).unwrap())
+        .with_trace_parent(TRACE_PARENT);
+
+    let jobs = adapter.discover(&ctx).await.expect("discover AEMO files");
+
+    assert_eq!(jobs.len(), 4);
+    assert_eq!(jobs[0].metadata["artifact_format"], "zip");
+    assert_eq!(jobs[0].metadata["csv_payload"], "aemo-csv-cid");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn discover_returns_retry_after_when_nemweb_rate_limits() {
+    let listing_url = serve_once("429 Too Many Requests", &[("Retry-After", "7")], "").await;
+    let adapter = AemoAdapter::builder()
+        .dispatch_listing_url(&listing_url)
+        .build();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = DiscoveryCtx::new(http, Utc.with_ymd_and_hms(2026, 5, 29, 1, 10, 0).unwrap());
+
+    let err = adapter
+        .discover(&ctx)
+        .await
+        .expect_err("rate limit should be surfaced as retryable upstream status");
+
+    match err {
+        AdapterError::UpstreamStatus {
+            status,
+            retry_after,
+            ..
+        } => {
+            assert_eq!(status, reqwest::StatusCode::TOO_MANY_REQUESTS);
+            assert_eq!(retry_after, Some(Duration::from_secs(7)));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn manifest_declares_aemo_rate_limit_and_dispatch_dataflow_metadata() {
+    let adapter = AemoAdapter::default();
+    let manifest = adapter.manifest();
+
+    assert_eq!(manifest.source_id.as_str(), "aemo");
+    assert_eq!(manifest.rate_limit.max_requests, 12);
+    assert_eq!(manifest.rate_limit.per, Duration::from_secs(60));
+    assert_eq!(
+        manifest.dataflows,
+        vec![au_kpis_domain::DataflowId::new("aemo.dispatch").unwrap()]
+    );
+
+    let dataflows = adapter.dataflow_metadata();
+    assert_eq!(dataflows.len(), 1);
+    assert_eq!(dataflows[0].id.as_str(), "aemo.dispatch");
+    assert_eq!(dataflows[0].frequency, au_kpis_domain::Frequency::Irregular);
+    assert_eq!(
+        dataflows[0].attribution,
+        "Source: Australian Energy Market Operator"
+    );
+    assert_eq!(
+        dataflows[0].source_url,
+        "https://www.nemweb.com.au/Reports/Current/DispatchIS_Reports/"
+    );
+}

--- a/crates/adapters/aemo/tests/fetch.rs
+++ b/crates/adapters/aemo/tests/fetch.rs
@@ -1,0 +1,234 @@
+use std::{sync::Arc, time::Duration};
+
+use async_trait::async_trait;
+use au_kpis_adapter::{AdapterError, AdapterHttpClient, ArtifactRecorder, FetchCtx, SourceAdapter};
+use au_kpis_adapter_aemo::AemoAdapter;
+use au_kpis_domain::{Artifact, ArtifactId};
+use au_kpis_storage::{BlobStore, StorageKey};
+use bytes::Bytes;
+use chrono::{TimeZone, Utc};
+use object_store::{ObjectStore, memory::InMemory, path::Path as ObjectPath};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+const DISPATCH_CSV: &[u8] = b"C,NEMP.WORLD,DISPATCHIS,AEMO,PUBLIC,2026/05/29,11:05:12,0000000519886550,DISPATCHIS,0000000519886549\r\n";
+
+#[derive(Debug, Default)]
+struct RecordingArtifactRecorder {
+    artifacts: tokio::sync::Mutex<Vec<Artifact>>,
+}
+
+#[async_trait]
+impl ArtifactRecorder for RecordingArtifactRecorder {
+    async fn get(&self, id: ArtifactId) -> Result<Option<Artifact>, AdapterError> {
+        Ok(self
+            .artifacts
+            .lock()
+            .await
+            .iter()
+            .find(|artifact| artifact.id == id)
+            .cloned())
+    }
+
+    async fn record(&self, artifact: &Artifact) -> Result<Artifact, AdapterError> {
+        self.artifacts.lock().await.push(artifact.clone());
+        Ok(artifact.clone())
+    }
+
+    async fn repair_storage_key(
+        &self,
+        artifact: &Artifact,
+        _observed_storage_key: &str,
+    ) -> Result<Artifact, AdapterError> {
+        Ok(artifact.clone())
+    }
+}
+
+fn recording_recorder() -> Arc<RecordingArtifactRecorder> {
+    Arc::new(RecordingArtifactRecorder::default())
+}
+
+fn zip_fixture() -> Vec<u8> {
+    let cursor = std::io::Cursor::new(Vec::new());
+    let mut writer = zip::ZipWriter::new(cursor);
+    writer
+        .start_file(
+            "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+            zip::write::SimpleFileOptions::default(),
+        )
+        .expect("start zip file");
+    std::io::Write::write_all(&mut writer, DISPATCH_CSV).expect("write zip csv");
+    writer.finish().expect("finish zip").into_inner()
+}
+
+async fn serve_artifact_once(status: &'static str, body: Vec<u8>) -> (String, String) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fixture server");
+    let addr = listener.local_addr().expect("fixture server address");
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).await.expect("read request");
+        let request = String::from_utf8_lossy(&request[..read]);
+        assert!(
+            request.starts_with(
+                "GET /Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip HTTP/1.1"
+            ),
+            "{request}"
+        );
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("user-agent: au-kpis-adapter-aemo/")
+        );
+
+        let response = format!(
+            "HTTP/1.1 {status}\r\ncontent-type: application/zip\r\nx-aemo-fixture: dispatchis\r\ncontent-length: {}\r\n\r\n",
+            body.len(),
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response headers");
+        stream.write_all(&body).await.expect("write response body");
+    });
+
+    let listing_url = format!("http://{addr}/Reports/CURRENT/DispatchIS_Reports/");
+    let source_url = format!("{listing_url}PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip");
+    (listing_url, source_url)
+}
+
+async fn serve_rate_limited_artifact_once() -> (String, String) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fixture server");
+    let addr = listener.local_addr().expect("fixture server address");
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let mut request = [0_u8; 4096];
+        let _ = stream.read(&mut request).await.expect("read request");
+        stream
+            .write_all(
+                b"HTTP/1.1 429 Too Many Requests\r\nretry-after: 11\r\ncontent-length: 0\r\n\r\n",
+            )
+            .await
+            .expect("write rate-limit response");
+    });
+
+    let listing_url = format!("http://{addr}/Reports/CURRENT/DispatchIS_Reports/");
+    let source_url = format!("{listing_url}PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip");
+    (listing_url, source_url)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fetch_persists_raw_aemo_dispatch_zip_with_response_headers() {
+    let zip = zip_fixture();
+    let (listing_url, source_url) = serve_artifact_once("200 OK", zip.clone()).await;
+    let adapter = AemoAdapter::builder()
+        .dispatch_listing_url(&listing_url)
+        .build();
+    let file = AemoAdapter::parse_dispatch_listing(&format!(
+        r#"Friday, May 29, 2026 11:06 AM        {} <A HREF="{source_url}">PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip</A>"#,
+        zip.len()
+    ))
+    .expect("parse fixture listing")
+    .into_iter()
+    .next()
+    .expect("dispatch file discovered");
+    let job = AemoAdapter::current_jobs_with_started_at(
+        &[file],
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 10, 0).unwrap(),
+    )
+    .into_iter()
+    .next()
+    .expect("job emitted");
+    let recorder = recording_recorder();
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let blob_store = BlobStore::from_arc(object_store.clone());
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = FetchCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 11, 0).unwrap(),
+        recorder.clone(),
+    );
+
+    let artifact = adapter
+        .fetch(job.clone(), &ctx)
+        .await
+        .expect("fetch AEMO ZIP");
+
+    assert_eq!(artifact.source_id.as_str(), "aemo");
+    assert_eq!(artifact.source_url, job.source_url);
+    assert_eq!(artifact.content_type, "application/zip");
+    assert_eq!(
+        artifact.response_headers["x-aemo-fixture"],
+        vec!["dispatchis"]
+    );
+    assert_eq!(artifact.size_bytes, zip.len() as u64);
+    assert_eq!(artifact.id, ArtifactId::of_content(&zip));
+    assert_eq!(
+        artifact.storage_key,
+        StorageKey::canonical_for(&artifact.id).to_string()
+    );
+
+    let stored = object_store
+        .get(&ObjectPath::from(artifact.storage_key.clone()))
+        .await
+        .expect("stored artifact")
+        .bytes()
+        .await
+        .expect("artifact bytes");
+    assert_eq!(stored, Bytes::from(zip));
+    assert_eq!(recorder.artifacts.lock().await.len(), 1);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fetch_returns_retry_after_when_nemweb_rate_limits() {
+    let (listing_url, source_url) = serve_rate_limited_artifact_once().await;
+    let adapter = AemoAdapter::builder()
+        .dispatch_listing_url(&listing_url)
+        .build();
+    let file = AemoAdapter::parse_dispatch_listing(&format!(
+        r#"Friday, May 29, 2026 11:06 AM        1234 <A HREF="{source_url}">PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip</A>"#,
+    ))
+    .expect("parse fixture listing")
+    .into_iter()
+    .next()
+    .expect("dispatch file discovered");
+    let job = AemoAdapter::current_jobs_with_started_at(
+        &[file],
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 10, 0).unwrap(),
+    )
+    .into_iter()
+    .next()
+    .expect("job emitted");
+    let ctx = FetchCtx::new(
+        AdapterHttpClient::new(adapter.manifest().rate_limit),
+        BlobStore::from_arc(Arc::new(InMemory::new())),
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 11, 0).unwrap(),
+        recording_recorder(),
+    );
+
+    let err = adapter
+        .fetch(job, &ctx)
+        .await
+        .expect_err("rate limit should be surfaced as retryable upstream status");
+
+    match err {
+        AdapterError::UpstreamStatus {
+            status,
+            retry_after,
+            ..
+        } => {
+            assert_eq!(status, reqwest::StatusCode::TOO_MANY_REQUESTS);
+            assert_eq!(retry_after, Some(Duration::from_secs(11)));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}

--- a/crates/adapters/aemo/tests/parse.rs
+++ b/crates/adapters/aemo/tests/parse.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use au_kpis_adapter::{AdapterHttpClient, ArtifactRef, ParseCtx, SourceAdapter};
 use au_kpis_adapter_aemo::AemoAdapter;
-use au_kpis_domain::{ArtifactId, SourceId, TimePrecision};
+use au_kpis_domain::{ArtifactId, ObservationStatus, SourceId, TimePrecision};
 use au_kpis_storage::{BlobStore, StorageKey};
 use bytes::Bytes;
 use chrono::{TimeZone, Utc};
@@ -17,6 +17,14 @@ D,DISPATCH,PRICE,5,"2026/05/29 11:10:00",1,QLD1,20260529086,0,40.02,0,40.02,0,0,
 I,DISPATCH,REGIONSUM,9,SETTLEMENTDATE,RUNNO,REGIONID,DISPATCHINTERVAL,INTERVENTION,TOTALDEMAND,AVAILABLEGENERATION,AVAILABLELOAD,DEMANDFORECAST,DISPATCHABLEGENERATION,DISPATCHABLELOAD,NETINTERCHANGE,LASTCHANGED
 D,DISPATCH,REGIONSUM,9,"2026/05/29 11:10:00",1,NSW1,20260529086,0,7989.37,13499.68147,1746,-29,7537.17,492.58,-944.77,"2026/05/29 11:05:08"
 D,DISPATCH,REGIONSUM,9,"2026/05/29 11:10:00",1,QLD1,20260529086,0,4750.84,11744.2721,2484,-17,6683.77,1158.67,774.26,"2026/05/29 11:05:08"
+"#;
+
+const BLANK_PRICE_CSV: &[u8] = br#"I,DISPATCH,PRICE,5,SETTLEMENTDATE,RUNNO,REGIONID,DISPATCHINTERVAL,INTERVENTION,RRP,EEP,ROP,APCFLAG,MARKETSUSPENDEDFLAG,LASTCHANGED,PRICE_STATUS
+D,DISPATCH,PRICE,5,"2026/05/29 11:10:00",1,VIC1,20260529086,0,,0,0,0,0,"2026/05/29 11:05:08",FIRM
+"#;
+
+const DATA_BEFORE_HEADER_CSV: &[u8] =
+    br#"D,DISPATCH,PRICE,5,"2026/05/29 11:10:00",1,NSW1,20260529086,0,91.89
 "#;
 
 #[derive(Debug, Serialize)]
@@ -41,15 +49,21 @@ struct SnapshotRow {
 }
 
 fn zip_fixture() -> Vec<u8> {
+    zip_files(&[(
+        "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+        DISPATCH_CSV,
+    )])
+}
+
+fn zip_files(files: &[(&str, &[u8])]) -> Vec<u8> {
     let cursor = std::io::Cursor::new(Vec::new());
     let mut writer = zip::ZipWriter::new(cursor);
-    writer
-        .start_file(
-            "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
-            zip::write::SimpleFileOptions::default(),
-        )
-        .expect("start zip file");
-    std::io::Write::write_all(&mut writer, DISPATCH_CSV).expect("write zip csv");
+    for (name, bytes) in files {
+        writer
+            .start_file(*name, zip::write::SimpleFileOptions::default())
+            .expect("start zip file");
+        std::io::Write::write_all(&mut writer, bytes).expect("write zip entry");
+    }
     writer.finish().expect("finish zip").into_inner()
 }
 
@@ -220,4 +234,141 @@ async fn parse_rejects_artifact_id_storage_key_mismatch() {
         err.to_string().contains("does not match artifact id"),
         "{err}"
     );
+}
+
+#[tokio::test]
+async fn parse_rejects_zip_without_csv_payload() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let artifact = artifact_for(
+        &blob_store,
+        zip_files(&[("README.txt", b"not dispatch data")]),
+        "https://www.nemweb.com.au/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip",
+    )
+    .await;
+    let adapter = AemoAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 12, 0).unwrap(),
+    );
+
+    let err = adapter
+        .parse(artifact, &ctx)
+        .next()
+        .await
+        .expect("one parse result")
+        .expect_err("missing CSV should fail");
+
+    assert!(
+        err.to_string().contains("did not contain a CSV payload"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn parse_rejects_zip_with_multiple_csv_payloads() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let artifact = artifact_for(
+        &blob_store,
+        zip_files(&[
+            (
+                "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+                DISPATCH_CSV,
+            ),
+            (
+                "PUBLIC_DISPATCHIS_202605291115_0000000519886551.CSV",
+                BLANK_PRICE_CSV,
+            ),
+        ]),
+        "https://www.nemweb.com.au/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip",
+    )
+    .await;
+    let adapter = AemoAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 12, 0).unwrap(),
+    );
+
+    let err = adapter
+        .parse(artifact, &ctx)
+        .next()
+        .await
+        .expect("one parse result")
+        .expect_err("multiple CSVs should fail");
+
+    assert!(
+        err.to_string().contains("more than one CSV payload"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn parse_rejects_data_rows_before_headers() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let artifact = artifact_for(
+        &blob_store,
+        zip_files(&[(
+            "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+            DATA_BEFORE_HEADER_CSV,
+        )]),
+        "https://www.nemweb.com.au/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip",
+    )
+    .await;
+    let adapter = AemoAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 12, 0).unwrap(),
+    );
+
+    let err = adapter
+        .parse(artifact, &ctx)
+        .next()
+        .await
+        .expect("one parse result")
+        .expect_err("data before header should fail");
+
+    assert!(
+        err.to_string().contains("appeared before its header"),
+        "{err}"
+    );
+}
+
+#[tokio::test]
+async fn parse_emits_missing_observation_for_blank_numeric_value() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let artifact = artifact_for(
+        &blob_store,
+        zip_files(&[(
+            "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+            BLANK_PRICE_CSV,
+        )]),
+        "https://www.nemweb.com.au/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip",
+    )
+    .await;
+    let adapter = AemoAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 12, 0).unwrap(),
+    );
+
+    let rows = adapter
+        .parse(artifact, &ctx)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("blank price should parse as missing observation");
+
+    assert_eq!(rows.len(), 1);
+    let (_, observation) = &rows[0];
+    assert_eq!(observation.value, None);
+    assert_eq!(observation.status, ObservationStatus::Missing);
+    assert!(!observation.attributes.contains_key("published_at"));
 }

--- a/crates/adapters/aemo/tests/parse.rs
+++ b/crates/adapters/aemo/tests/parse.rs
@@ -1,0 +1,223 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use au_kpis_adapter::{AdapterHttpClient, ArtifactRef, ParseCtx, SourceAdapter};
+use au_kpis_adapter_aemo::AemoAdapter;
+use au_kpis_domain::{ArtifactId, SourceId, TimePrecision};
+use au_kpis_storage::{BlobStore, StorageKey};
+use bytes::Bytes;
+use chrono::{TimeZone, Utc};
+use futures::StreamExt;
+use object_store::memory::InMemory;
+use serde::Serialize;
+
+const DISPATCH_CSV: &[u8] = br#"C,NEMP.WORLD,DISPATCHIS,AEMO,PUBLIC,2026/05/29,11:05:12,0000000519886550,DISPATCHIS,0000000519886549
+I,DISPATCH,PRICE,5,SETTLEMENTDATE,RUNNO,REGIONID,DISPATCHINTERVAL,INTERVENTION,RRP,EEP,ROP,APCFLAG,MARKETSUSPENDEDFLAG,LASTCHANGED,PRICE_STATUS
+D,DISPATCH,PRICE,5,"2026/05/29 11:10:00",1,NSW1,20260529086,0,91.89,0,91.89,0,0,"2026/05/29 11:05:08",FIRM
+D,DISPATCH,PRICE,5,"2026/05/29 11:10:00",1,QLD1,20260529086,0,40.02,0,40.02,0,0,"2026/05/29 11:05:08",FIRM
+I,DISPATCH,REGIONSUM,9,SETTLEMENTDATE,RUNNO,REGIONID,DISPATCHINTERVAL,INTERVENTION,TOTALDEMAND,AVAILABLEGENERATION,AVAILABLELOAD,DEMANDFORECAST,DISPATCHABLEGENERATION,DISPATCHABLELOAD,NETINTERCHANGE,LASTCHANGED
+D,DISPATCH,REGIONSUM,9,"2026/05/29 11:10:00",1,NSW1,20260529086,0,7989.37,13499.68147,1746,-29,7537.17,492.58,-944.77,"2026/05/29 11:05:08"
+D,DISPATCH,REGIONSUM,9,"2026/05/29 11:10:00",1,QLD1,20260529086,0,4750.84,11744.2721,2484,-17,6683.77,1158.67,774.26,"2026/05/29 11:05:08"
+"#;
+
+#[derive(Debug, Serialize)]
+struct FixtureSnapshot {
+    observation_count: usize,
+    series_count: usize,
+    first_rows: Vec<SnapshotRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct SnapshotRow {
+    dataflow_id: String,
+    measure_id: String,
+    dimensions: BTreeMap<String, String>,
+    unit: String,
+    time: String,
+    time_precision: String,
+    value: Option<f64>,
+    status: String,
+    attributes: BTreeMap<String, String>,
+    source_artifact_id: String,
+}
+
+fn zip_fixture() -> Vec<u8> {
+    let cursor = std::io::Cursor::new(Vec::new());
+    let mut writer = zip::ZipWriter::new(cursor);
+    writer
+        .start_file(
+            "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+            zip::write::SimpleFileOptions::default(),
+        )
+        .expect("start zip file");
+    std::io::Write::write_all(&mut writer, DISPATCH_CSV).expect("write zip csv");
+    writer.finish().expect("finish zip").into_inner()
+}
+
+async fn artifact_for(blob_store: &BlobStore, bytes: Vec<u8>, source_url: &str) -> ArtifactRef {
+    let size_bytes = bytes.len() as u64;
+    let id = blob_store
+        .put_artifact(Bytes::from(bytes))
+        .await
+        .expect("store fixture artifact");
+    ArtifactRef {
+        id,
+        source_id: SourceId::new("aemo").unwrap(),
+        source_url: source_url.into(),
+        content_type: "application/zip".into(),
+        response_headers: BTreeMap::new(),
+        storage_key: StorageKey::canonical_for(&id).to_string(),
+        size_bytes,
+        fetched_at: Utc.with_ymd_and_hms(2026, 5, 29, 1, 6, 0).unwrap(),
+    }
+}
+
+async fn snapshot_fixture(artifact: ArtifactRef, blob_store: BlobStore) -> FixtureSnapshot {
+    let adapter = AemoAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 12, 0).unwrap(),
+    )
+    .with_expected_dataflow(
+        au_kpis_domain::DataflowId::new("aemo.dispatch").unwrap(),
+        BTreeMap::from([
+            ("dispatch_interval".into(), "2026-05-29T01:10:00Z".into()),
+            ("published_at".into(), "2026-05-29T01:05:12Z".into()),
+            ("freshness_slo_seconds".into(), "900".into()),
+        ]),
+    );
+    let rows = adapter
+        .parse(artifact, &ctx)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("parse AEMO dispatch fixture");
+
+    assert!(
+        rows.iter()
+            .all(|(_, observation)| observation.time_precision == TimePrecision::Minute)
+    );
+    let series_count = rows
+        .iter()
+        .map(|(series, _)| series.series_key)
+        .collect::<BTreeSet<_>>()
+        .len();
+    let first_rows = rows
+        .iter()
+        .take(8)
+        .map(|(series, observation)| SnapshotRow {
+            dataflow_id: series.dataflow_id.as_str().to_string(),
+            measure_id: series.measure_id.as_str().to_string(),
+            dimensions: series
+                .dimensions
+                .iter()
+                .map(|(key, value)| (key.as_str().to_string(), value.as_str().to_string()))
+                .collect(),
+            unit: series.unit.clone(),
+            time: observation.time.to_rfc3339(),
+            time_precision: format!("{:?}", observation.time_precision),
+            value: observation.value,
+            status: format!("{:?}", observation.status),
+            attributes: observation.attributes.clone(),
+            source_artifact_id: observation.source_artifact_id.to_hex(),
+        })
+        .collect();
+
+    FixtureSnapshot {
+        observation_count: rows.len(),
+        series_count,
+        first_rows,
+    }
+}
+
+#[tokio::test]
+async fn parses_aemo_dispatch_zip_fixture_with_region_price_and_summary_rows() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let artifact = artifact_for(
+        &blob_store,
+        zip_fixture(),
+        "https://www.nemweb.com.au/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip",
+    )
+    .await;
+
+    let snapshot = snapshot_fixture(artifact, blob_store.clone()).await;
+
+    assert_eq!(snapshot.observation_count, 8);
+    assert_eq!(snapshot.series_count, 8);
+    insta::assert_json_snapshot!("dispatchis_region_price_and_summary", snapshot);
+}
+
+#[tokio::test]
+async fn parse_rejects_ambiguous_aemo_provenance() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let mut artifact = artifact_for(
+        &blob_store,
+        zip_fixture(),
+        "https://mirror.example.invalid/PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip",
+    )
+    .await;
+    artifact.source_id = SourceId::new("rba").unwrap();
+
+    let adapter = AemoAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 12, 0).unwrap(),
+    );
+    let err = adapter
+        .parse(artifact, &ctx)
+        .next()
+        .await
+        .expect("one parse result")
+        .expect_err("invalid provenance should fail");
+
+    assert!(
+        err.to_string()
+            .contains("AEMO parse received artifact for source")
+    );
+}
+
+#[tokio::test]
+async fn parse_rejects_artifact_id_storage_key_mismatch() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let bytes = zip_fixture();
+    let actual_id = blob_store
+        .put_artifact(Bytes::from(bytes.clone()))
+        .await
+        .expect("store fixture artifact");
+    let wrong_id = ArtifactId::of_content(b"different AEMO artifact");
+    assert_ne!(actual_id, wrong_id);
+
+    let artifact = ArtifactRef {
+        id: wrong_id,
+        source_id: SourceId::new("aemo").unwrap(),
+        source_url: "https://www.nemweb.com.au/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip".into(),
+        content_type: "application/zip".into(),
+        response_headers: BTreeMap::new(),
+        storage_key: StorageKey::canonical_for(&actual_id).to_string(),
+        size_bytes: bytes.len() as u64,
+        fetched_at: Utc.with_ymd_and_hms(2026, 5, 29, 1, 6, 0).unwrap(),
+    };
+    let adapter = AemoAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 1, 12, 0).unwrap(),
+    );
+
+    let err = adapter
+        .parse(artifact, &ctx)
+        .next()
+        .await
+        .expect("one parse result")
+        .expect_err("mismatched storage key should fail");
+
+    assert!(
+        err.to_string().contains("does not match artifact id"),
+        "{err}"
+    );
+}

--- a/crates/adapters/aemo/tests/snapshots/discover__parse_dispatch_listing_discovers_five_minute_zip_files.snap
+++ b/crates/adapters/aemo/tests/snapshots/discover__parse_dispatch_listing_discovers_five_minute_zip_files.snap
@@ -1,0 +1,42 @@
+---
+source: crates/adapters/aemo/tests/discover.rs
+expression: snapshot
+---
+[
+  {
+    "dispatch_interval": "2026-05-29T00:55:00+00:00",
+    "file_name": "PUBLIC_DISPATCHIS_202605291055_0000000519884398.zip",
+    "freshness_lag_seconds_at_1110": 1140,
+    "published_at": "2026-05-29T00:51:00+00:00",
+    "sequence": "0000000519884398",
+    "size_bytes": 20468,
+    "source_url": "https://www.nemweb.com.au/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291055_0000000519884398.zip"
+  },
+  {
+    "dispatch_interval": "2026-05-29T01:00:00+00:00",
+    "file_name": "PUBLIC_DISPATCHIS_202605291100_0000000519884840.zip",
+    "freshness_lag_seconds_at_1110": 780,
+    "published_at": "2026-05-29T00:57:00+00:00",
+    "sequence": "0000000519884840",
+    "size_bytes": 20660,
+    "source_url": "https://www.nemweb.com.au/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291100_0000000519884840.zip"
+  },
+  {
+    "dispatch_interval": "2026-05-29T01:05:00+00:00",
+    "file_name": "PUBLIC_DISPATCHIS_202605291105_0000000519885422.zip",
+    "freshness_lag_seconds_at_1110": 480,
+    "published_at": "2026-05-29T01:02:00+00:00",
+    "sequence": "0000000519885422",
+    "size_bytes": 20628,
+    "source_url": "https://www.nemweb.com.au/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291105_0000000519885422.zip"
+  },
+  {
+    "dispatch_interval": "2026-05-29T01:10:00+00:00",
+    "file_name": "PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip",
+    "freshness_lag_seconds_at_1110": 240,
+    "published_at": "2026-05-29T01:06:00+00:00",
+    "sequence": "0000000519886550",
+    "size_bytes": 20654,
+    "source_url": "https://www.nemweb.com.au/Reports/CURRENT/DispatchIS_Reports/PUBLIC_DISPATCHIS_202605291110_0000000519886550.zip"
+  }
+]

--- a/crates/adapters/aemo/tests/snapshots/parse__dispatchis_region_price_and_summary.snap
+++ b/crates/adapters/aemo/tests/snapshots/parse__dispatchis_region_price_and_summary.snap
@@ -1,0 +1,228 @@
+---
+source: crates/adapters/aemo/tests/parse.rs
+expression: snapshot
+---
+{
+  "observation_count": 8,
+  "series_count": 8,
+  "first_rows": [
+    {
+      "dataflow_id": "aemo.dispatch",
+      "measure_id": "value",
+      "dimensions": {
+        "metric": "rrp",
+        "region": "NSW1"
+      },
+      "unit": "AUD/MWh",
+      "time": "2026-05-29T01:10:00+00:00",
+      "time_precision": "Minute",
+      "value": 91.89,
+      "status": "Normal",
+      "attributes": {
+        "csv_file": "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+        "dispatch_interval": "2026-05-29T01:10:00+00:00",
+        "dispatch_interval_no": "20260529086",
+        "freshness_slo_seconds": "900",
+        "intervention": "0",
+        "last_changed": "2026/05/29 11:05:08",
+        "metric": "rrp",
+        "price_status": "FIRM",
+        "published_at": "2026-05-29T01:05:12Z",
+        "record_version": "5",
+        "run_no": "1",
+        "table": "PRICE"
+      },
+      "source_artifact_id": "3d21f25c897f3b73fad13d1df5d1c79dbcb7b58cc41e6edd874fd2d77a077713"
+    },
+    {
+      "dataflow_id": "aemo.dispatch",
+      "measure_id": "value",
+      "dimensions": {
+        "metric": "rrp",
+        "region": "QLD1"
+      },
+      "unit": "AUD/MWh",
+      "time": "2026-05-29T01:10:00+00:00",
+      "time_precision": "Minute",
+      "value": 40.02,
+      "status": "Normal",
+      "attributes": {
+        "csv_file": "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+        "dispatch_interval": "2026-05-29T01:10:00+00:00",
+        "dispatch_interval_no": "20260529086",
+        "freshness_slo_seconds": "900",
+        "intervention": "0",
+        "last_changed": "2026/05/29 11:05:08",
+        "metric": "rrp",
+        "price_status": "FIRM",
+        "published_at": "2026-05-29T01:05:12Z",
+        "record_version": "5",
+        "run_no": "1",
+        "table": "PRICE"
+      },
+      "source_artifact_id": "3d21f25c897f3b73fad13d1df5d1c79dbcb7b58cc41e6edd874fd2d77a077713"
+    },
+    {
+      "dataflow_id": "aemo.dispatch",
+      "measure_id": "value",
+      "dimensions": {
+        "metric": "total_demand",
+        "region": "NSW1"
+      },
+      "unit": "MW",
+      "time": "2026-05-29T01:10:00+00:00",
+      "time_precision": "Minute",
+      "value": 7989.37,
+      "status": "Normal",
+      "attributes": {
+        "csv_file": "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+        "dispatch_interval": "2026-05-29T01:10:00+00:00",
+        "dispatch_interval_no": "20260529086",
+        "freshness_slo_seconds": "900",
+        "intervention": "0",
+        "last_changed": "2026/05/29 11:05:08",
+        "metric": "total_demand",
+        "published_at": "2026-05-29T01:05:12Z",
+        "record_version": "9",
+        "run_no": "1",
+        "table": "REGIONSUM"
+      },
+      "source_artifact_id": "3d21f25c897f3b73fad13d1df5d1c79dbcb7b58cc41e6edd874fd2d77a077713"
+    },
+    {
+      "dataflow_id": "aemo.dispatch",
+      "measure_id": "value",
+      "dimensions": {
+        "metric": "available_generation",
+        "region": "NSW1"
+      },
+      "unit": "MW",
+      "time": "2026-05-29T01:10:00+00:00",
+      "time_precision": "Minute",
+      "value": 13499.68147,
+      "status": "Normal",
+      "attributes": {
+        "csv_file": "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+        "dispatch_interval": "2026-05-29T01:10:00+00:00",
+        "dispatch_interval_no": "20260529086",
+        "freshness_slo_seconds": "900",
+        "intervention": "0",
+        "last_changed": "2026/05/29 11:05:08",
+        "metric": "available_generation",
+        "published_at": "2026-05-29T01:05:12Z",
+        "record_version": "9",
+        "run_no": "1",
+        "table": "REGIONSUM"
+      },
+      "source_artifact_id": "3d21f25c897f3b73fad13d1df5d1c79dbcb7b58cc41e6edd874fd2d77a077713"
+    },
+    {
+      "dataflow_id": "aemo.dispatch",
+      "measure_id": "value",
+      "dimensions": {
+        "metric": "net_interchange",
+        "region": "NSW1"
+      },
+      "unit": "MW",
+      "time": "2026-05-29T01:10:00+00:00",
+      "time_precision": "Minute",
+      "value": -944.77,
+      "status": "Normal",
+      "attributes": {
+        "csv_file": "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+        "dispatch_interval": "2026-05-29T01:10:00+00:00",
+        "dispatch_interval_no": "20260529086",
+        "freshness_slo_seconds": "900",
+        "intervention": "0",
+        "last_changed": "2026/05/29 11:05:08",
+        "metric": "net_interchange",
+        "published_at": "2026-05-29T01:05:12Z",
+        "record_version": "9",
+        "run_no": "1",
+        "table": "REGIONSUM"
+      },
+      "source_artifact_id": "3d21f25c897f3b73fad13d1df5d1c79dbcb7b58cc41e6edd874fd2d77a077713"
+    },
+    {
+      "dataflow_id": "aemo.dispatch",
+      "measure_id": "value",
+      "dimensions": {
+        "metric": "total_demand",
+        "region": "QLD1"
+      },
+      "unit": "MW",
+      "time": "2026-05-29T01:10:00+00:00",
+      "time_precision": "Minute",
+      "value": 4750.84,
+      "status": "Normal",
+      "attributes": {
+        "csv_file": "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+        "dispatch_interval": "2026-05-29T01:10:00+00:00",
+        "dispatch_interval_no": "20260529086",
+        "freshness_slo_seconds": "900",
+        "intervention": "0",
+        "last_changed": "2026/05/29 11:05:08",
+        "metric": "total_demand",
+        "published_at": "2026-05-29T01:05:12Z",
+        "record_version": "9",
+        "run_no": "1",
+        "table": "REGIONSUM"
+      },
+      "source_artifact_id": "3d21f25c897f3b73fad13d1df5d1c79dbcb7b58cc41e6edd874fd2d77a077713"
+    },
+    {
+      "dataflow_id": "aemo.dispatch",
+      "measure_id": "value",
+      "dimensions": {
+        "metric": "available_generation",
+        "region": "QLD1"
+      },
+      "unit": "MW",
+      "time": "2026-05-29T01:10:00+00:00",
+      "time_precision": "Minute",
+      "value": 11744.2721,
+      "status": "Normal",
+      "attributes": {
+        "csv_file": "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+        "dispatch_interval": "2026-05-29T01:10:00+00:00",
+        "dispatch_interval_no": "20260529086",
+        "freshness_slo_seconds": "900",
+        "intervention": "0",
+        "last_changed": "2026/05/29 11:05:08",
+        "metric": "available_generation",
+        "published_at": "2026-05-29T01:05:12Z",
+        "record_version": "9",
+        "run_no": "1",
+        "table": "REGIONSUM"
+      },
+      "source_artifact_id": "3d21f25c897f3b73fad13d1df5d1c79dbcb7b58cc41e6edd874fd2d77a077713"
+    },
+    {
+      "dataflow_id": "aemo.dispatch",
+      "measure_id": "value",
+      "dimensions": {
+        "metric": "net_interchange",
+        "region": "QLD1"
+      },
+      "unit": "MW",
+      "time": "2026-05-29T01:10:00+00:00",
+      "time_precision": "Minute",
+      "value": 774.26,
+      "status": "Normal",
+      "attributes": {
+        "csv_file": "PUBLIC_DISPATCHIS_202605291110_0000000519886550.CSV",
+        "dispatch_interval": "2026-05-29T01:10:00+00:00",
+        "dispatch_interval_no": "20260529086",
+        "freshness_slo_seconds": "900",
+        "intervention": "0",
+        "last_changed": "2026/05/29 11:05:08",
+        "metric": "net_interchange",
+        "published_at": "2026-05-29T01:05:12Z",
+        "record_version": "9",
+        "run_no": "1",
+        "table": "REGIONSUM"
+      },
+      "source_artifact_id": "3d21f25c897f3b73fad13d1df5d1c79dbcb7b58cc41e6edd874fd2d77a077713"
+    }
+  ]
+}

--- a/crates/au-kpis-api-http/src/observations.rs
+++ b/crates/au-kpis-api-http/src/observations.rs
@@ -1261,6 +1261,7 @@ fn json_map(value: serde_json::Value) -> Result<BTreeMap<String, String>, ApiErr
 
 fn parse_time_precision(value: &str) -> Result<TimePrecision, ApiError> {
     match value {
+        "minute" => Ok(TimePrecision::Minute),
         "day" => Ok(TimePrecision::Day),
         "week" => Ok(TimePrecision::Week),
         "month" => Ok(TimePrecision::Month),
@@ -1372,6 +1373,7 @@ fn csv_escape(value: &str) -> String {
 
 fn time_precision_label(value: TimePrecision) -> &'static str {
     match value {
+        TimePrecision::Minute => "minute",
         TimePrecision::Day => "day",
         TimePrecision::Week => "week",
         TimePrecision::Month => "month",

--- a/crates/au-kpis-api-http/src/series.rs
+++ b/crates/au-kpis-api-http/src/series.rs
@@ -205,6 +205,7 @@ fn json_map(value: Option<serde_json::Value>) -> Result<BTreeMap<String, String>
 
 fn parse_time_precision(value: &str) -> Result<TimePrecision, ApiError> {
     match value {
+        "minute" => Ok(TimePrecision::Minute),
         "day" => Ok(TimePrecision::Day),
         "week" => Ok(TimePrecision::Week),
         "month" => Ok(TimePrecision::Month),

--- a/crates/au-kpis-api-http/tests/subscriptions.rs
+++ b/crates/au-kpis-api-http/tests/subscriptions.rs
@@ -170,7 +170,7 @@ async fn due_webhook_deliveries_are_hmac_signed_and_marked_delivered() {
     let outcome = deliver_due_webhooks(
         &ctx.pool,
         &reqwest::Client::new(),
-        Utc.with_ymd_and_hms(2026, 5, 29, 10, 0, 1).unwrap(),
+        Utc::now() + ChronoDuration::seconds(5),
         DeliveryOptions {
             max_attempts: 3,
             base_backoff: Duration::from_secs(10),
@@ -242,7 +242,7 @@ async fn failed_webhook_deliveries_retry_with_exponential_backoff_and_stop_after
         .await
         .expect("enqueue delivery");
 
-    let now = Utc.with_ymd_and_hms(2026, 5, 29, 11, 0, 1).unwrap();
+    let now = Utc::now() + ChronoDuration::seconds(5);
     let options = DeliveryOptions {
         max_attempts: 2,
         base_backoff: Duration::from_secs(10),

--- a/crates/au-kpis-domain/src/observation.rs
+++ b/crates/au-kpis-domain/src/observation.rs
@@ -13,6 +13,7 @@ use crate::ids::{ArtifactId, SeriesKey};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum TimePrecision {
+    Minute,
     Day,
     Week,
     Month,
@@ -133,6 +134,7 @@ mod tests {
 
     fn arb_time_precision() -> impl Strategy<Value = TimePrecision> {
         prop_oneof![
+            Just(TimePrecision::Minute),
             Just(TimePrecision::Day),
             Just(TimePrecision::Week),
             Just(TimePrecision::Month),

--- a/crates/au-kpis-loader/src/lib.rs
+++ b/crates/au-kpis-loader/src/lib.rs
@@ -998,6 +998,7 @@ fn escape_copy_field(payload: &mut String, field: &str) {
 
 fn time_precision_db(value: TimePrecision) -> &'static str {
     match value {
+        TimePrecision::Minute => "minute",
         TimePrecision::Day => "day",
         TimePrecision::Week => "week",
         TimePrecision::Month => "month",

--- a/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
+++ b/crates/au-kpis-openapi/tests/snapshots/emitter__openapi.snap
@@ -931,6 +931,7 @@ expression: emitted_spec()
       "TimePrecision": {
         "description": "Temporal granularity of an observation's timestamp. Matches the SDMX\n`@FREQ` facet on a coarse scale.",
         "enum": [
+          "minute",
           "day",
           "week",
           "month",

--- a/crates/bins/au-kpis-ingestion/Cargo.toml
+++ b/crates/bins/au-kpis-ingestion/Cargo.toml
@@ -11,6 +11,7 @@ description = "Ingestion worker binary."
 anyhow = "1"
 au-kpis-adapter = { workspace = true }
 au-kpis-adapter-abs = { path = "../../adapters/abs" }
+au-kpis-adapter-aemo = { path = "../../adapters/aemo" }
 au-kpis-adapter-apra = { path = "../../adapters/apra" }
 au-kpis-adapter-rba = { path = "../../adapters/rba" }
 au-kpis-adapter-state-budgets = { path = "../../adapters/state-budgets" }

--- a/crates/bins/au-kpis-ingestion/src/main.rs
+++ b/crates/bins/au-kpis-ingestion/src/main.rs
@@ -19,6 +19,7 @@ use std::{
 use anyhow::{Context, bail};
 use au_kpis_adapter::{AdapterError, AdapterHttpClient, Adapters, DiscoveryCtx, ParseCtx};
 use au_kpis_adapter_abs::AbsAdapter;
+use au_kpis_adapter_aemo::AemoAdapter;
 use au_kpis_adapter_apra::ApraAdapter;
 use au_kpis_adapter_rba::RbaAdapter;
 use au_kpis_adapter_state_budgets::StateBudgetsAdapter;
@@ -39,6 +40,8 @@ use tokio_util::sync::CancellationToken;
 
 const ABS_CPI_DATAFLOW_SLUG: &str = "cpi";
 const ABS_CPI_DATAFLOW_ID: &str = "abs.cpi";
+const AEMO_DISPATCH_DATAFLOW_SLUG: &str = "dispatch";
+const AEMO_DISPATCH_DATAFLOW_ID: &str = "aemo.dispatch";
 const APRA_QUARTERLY_DATAFLOW_SLUG: &str = "quarterly-statistics";
 const APRA_QUARTERLY_DATAFLOW_ID: &str = "apra.quarterly_statistics";
 const RBA_STAT_TABLES_DATAFLOW_SLUG: &str = "statistical-tables";
@@ -585,6 +588,13 @@ fn build_adapters() -> anyhow::Result<Adapters> {
         Err(_) => ApraAdapter::default(),
     };
     builder.register(apra).context("register APRA adapter")?;
+    let aemo = match env::var("AU_KPIS_AEMO_DISPATCH_LISTING_URL") {
+        Ok(dispatch_listing_url) => AemoAdapter::builder()
+            .dispatch_listing_url(dispatch_listing_url)
+            .build(),
+        Err(_) => AemoAdapter::default(),
+    };
+    builder.register(aemo).context("register AEMO adapter")?;
     let rba = match env::var("AU_KPIS_RBA_INDEX_URL") {
         Ok(index_url) => RbaAdapter::builder().index_url(index_url).build(),
         Err(_) => RbaAdapter::default(),
@@ -687,6 +697,7 @@ fn validate_once_target(source: &str, dataflow: &str) -> anyhow::Result<()> {
     validate_supported_source(source)?;
     match source {
         "abs" if dataflow == ABS_CPI_DATAFLOW_SLUG => Ok(()),
+        "aemo" if dataflow == AEMO_DISPATCH_DATAFLOW_SLUG => Ok(()),
         "apra" if dataflow == APRA_QUARTERLY_DATAFLOW_SLUG => Ok(()),
         "rba" if dataflow == RBA_STAT_TABLES_DATAFLOW_SLUG => Ok(()),
         "state-budgets"
@@ -702,6 +713,9 @@ fn validate_once_target(source: &str, dataflow: &str) -> anyhow::Result<()> {
         "treasury" if dataflow == TREASURY_BUDGET_DATAFLOW_SLUG => Ok(()),
         "abs" => bail!(
             "unsupported dataflow `{dataflow}` for source `abs`; supported dataflow: {ABS_CPI_DATAFLOW_SLUG}"
+        ),
+        "aemo" => bail!(
+            "unsupported dataflow `{dataflow}` for source `aemo`; supported dataflow: {AEMO_DISPATCH_DATAFLOW_SLUG}"
         ),
         "apra" => bail!(
             "unsupported dataflow `{dataflow}` for source `apra`; supported dataflow: {APRA_QUARTERLY_DATAFLOW_SLUG}"
@@ -723,6 +737,7 @@ fn once_run_request(source: &str, dataflow: &str) -> anyhow::Result<RunRequest> 
     validate_once_target(source, dataflow)?;
     let dataflow_id = match source {
         "abs" => ABS_CPI_DATAFLOW_ID,
+        "aemo" => AEMO_DISPATCH_DATAFLOW_ID,
         "apra" => APRA_QUARTERLY_DATAFLOW_ID,
         "rba" => RBA_STAT_TABLES_DATAFLOW_ID,
         "state-budgets" if dataflow == STATE_BUDGETS_NSW_DATAFLOW_SLUG => {
@@ -779,10 +794,10 @@ fn job_run_request(kind: &JobKind, trace_parent: Option<&str>) -> anyhow::Result
 fn validate_supported_source(source: &str) -> anyhow::Result<()> {
     if !matches!(
         source,
-        "abs" | "apra" | "rba" | "state-budgets" | "treasury"
+        "abs" | "aemo" | "apra" | "rba" | "state-budgets" | "treasury"
     ) {
         bail!(
-            "unsupported source `{source}`; supported sources: abs, apra, rba, state-budgets, treasury"
+            "unsupported source `{source}`; supported sources: abs, aemo, apra, rba, state-budgets, treasury"
         );
     }
     Ok(())
@@ -790,6 +805,9 @@ fn validate_supported_source(source: &str) -> anyhow::Result<()> {
 
 fn validate_supported_dataflow_id(source: &str, dataflow_id: &str) -> anyhow::Result<()> {
     if source == "abs" && dataflow_id == ABS_CPI_DATAFLOW_ID {
+        return Ok(());
+    }
+    if source == "aemo" && dataflow_id == AEMO_DISPATCH_DATAFLOW_ID {
         return Ok(());
     }
     if source == "apra" && dataflow_id == APRA_QUARTERLY_DATAFLOW_ID {
@@ -811,7 +829,7 @@ fn validate_supported_dataflow_id(source: &str, dataflow_id: &str) -> anyhow::Re
         return Ok(());
     }
     bail!(
-        "unsupported dataflow `{dataflow_id}` for source `{source}`; supported dataflows: {ABS_CPI_DATAFLOW_ID}, {APRA_QUARTERLY_DATAFLOW_ID}, {RBA_STAT_TABLES_DATAFLOW_ID}, {STATE_BUDGETS_NSW_DATAFLOW_ID}, {STATE_BUDGETS_VIC_DATAFLOW_ID}, {STATE_BUDGETS_QLD_DATAFLOW_ID}, {TREASURY_BUDGET_DATAFLOW_ID}"
+        "unsupported dataflow `{dataflow_id}` for source `{source}`; supported dataflows: {ABS_CPI_DATAFLOW_ID}, {AEMO_DISPATCH_DATAFLOW_ID}, {APRA_QUARTERLY_DATAFLOW_ID}, {RBA_STAT_TABLES_DATAFLOW_ID}, {STATE_BUDGETS_NSW_DATAFLOW_ID}, {STATE_BUDGETS_VIC_DATAFLOW_ID}, {STATE_BUDGETS_QLD_DATAFLOW_ID}, {TREASURY_BUDGET_DATAFLOW_ID}"
     );
 }
 
@@ -991,11 +1009,22 @@ mod tests {
 
     #[test]
     fn unsupported_source_reports_specific_error() {
-        let err = validate_once_target("aemo", "cpi")
+        let err = validate_once_target("asx", "prices")
             .expect_err("unsupported source should fail")
             .to_string();
         assert!(err.contains("unsupported source"));
-        assert!(err.contains("abs, apra, rba, state-budgets, treasury"));
+        assert!(err.contains("abs, aemo, apra, rba, state-budgets, treasury"));
+    }
+
+    #[test]
+    fn aemo_once_mode_resolves_dispatch_dataflow() {
+        let request = once_run_request("aemo", "dispatch").expect("AEMO dispatch is supported");
+
+        assert_eq!(request.source_id.as_str(), "aemo");
+        assert_eq!(
+            request.dataflow_id.as_ref(),
+            Some(&DataflowId::new("aemo.dispatch").unwrap())
+        );
     }
 
     #[test]

--- a/crates/bins/au-kpis-scheduler/src/main.rs
+++ b/crates/bins/au-kpis-scheduler/src/main.rs
@@ -35,10 +35,12 @@ use tokio_util::sync::CancellationToken;
 const SCHEDULER_LEADER_LOCK_ID: i64 = 30_000_030;
 const DEFAULT_TICK_MS: u64 = 1_000;
 const DEFAULT_ABS_INTERVAL_MS: u64 = 60 * 60 * 1_000;
+const DEFAULT_AEMO_INTERVAL_MS: u64 = 5 * 60 * 1_000;
 const DEFAULT_APRA_INTERVAL_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
 const DEFAULT_RBA_INTERVAL_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
 const DEFAULT_TREASURY_INTERVAL_MS: u64 = 24 * 60 * 60 * 1_000;
 const ABS_DISCOVERY_CRON: &str = "0 * * * *";
+const AEMO_DISCOVERY_CRON: &str = "*/5 * * * *";
 const APRA_DISCOVERY_CRON: &str = "0 0 * * 1";
 const RBA_DISCOVERY_CRON: &str = "0 0 * * 1";
 const TREASURY_DISCOVERY_CRON: &str = "0 0 * * *";
@@ -64,6 +66,14 @@ struct Cli {
         default_value_t = DEFAULT_ABS_INTERVAL_MS
     )]
     abs_interval_ms: u64,
+
+    /// Test/ops override for the AEMO DispatchIS discovery cadence.
+    #[arg(
+        long,
+        env = "AU_KPIS_SCHEDULER_AEMO_INTERVAL_MS",
+        default_value_t = DEFAULT_AEMO_INTERVAL_MS
+    )]
+    aemo_interval_ms: u64,
 
     /// Test/ops override for the APRA discovery cadence.
     #[arg(
@@ -257,6 +267,7 @@ async fn main() -> anyhow::Result<()> {
             Duration::from_millis(cli.rba_interval_ms),
             Duration::from_millis(cli.apra_interval_ms),
             Duration::from_millis(cli.treasury_interval_ms),
+            Duration::from_millis(cli.aemo_interval_ms),
         ),
         worker_id: cli.worker_id.unwrap_or_else(default_worker_id),
     };
@@ -471,6 +482,7 @@ fn default_discovery_schedules(
     rba_interval: Duration,
     apra_interval: Duration,
     treasury_interval: Duration,
+    aemo_interval: Duration,
 ) -> Vec<DiscoverySchedule> {
     vec![
         DiscoverySchedule {
@@ -496,6 +508,12 @@ fn default_discovery_schedules(
             cron_expression: TREASURY_DISCOVERY_CRON,
             emit_every: treasury_interval,
             job: Job::discover(SourceId::new("treasury").expect("static source id is valid")),
+        },
+        DiscoverySchedule {
+            id: "aemo-dispatch-discovery",
+            cron_expression: AEMO_DISCOVERY_CRON,
+            emit_every: aemo_interval,
+            job: Job::discover(SourceId::new("aemo").expect("static source id is valid")),
         },
     ]
 }
@@ -618,9 +636,10 @@ mod tests {
             Duration::from_secs(604_800),
             Duration::from_secs(604_800),
             Duration::from_secs(86_400),
+            Duration::from_secs(300),
         );
 
-        assert_eq!(schedules.len(), 4);
+        assert_eq!(schedules.len(), 5);
         assert_eq!(schedules[0].id, "abs-discovery");
         assert_eq!(schedules[0].cron_expression, "0 * * * *");
         assert_eq!(schedules[0].emit_every, Duration::from_secs(3600));
@@ -648,6 +667,13 @@ mod tests {
         assert!(matches!(
             schedules[3].job.kind(),
             JobKind::Discover { source_id } if source_id.as_str() == "treasury"
+        ));
+        assert_eq!(schedules[4].id, "aemo-dispatch-discovery");
+        assert_eq!(schedules[4].cron_expression, "*/5 * * * *");
+        assert_eq!(schedules[4].emit_every, Duration::from_secs(300));
+        assert!(matches!(
+            schedules[4].job.kind(),
+            JobKind::Discover { source_id } if source_id.as_str() == "aemo"
         ));
     }
 

--- a/crates/testing/tests/observability_scaffold.rs
+++ b/crates/testing/tests/observability_scaffold.rs
@@ -84,6 +84,8 @@ fn issue_47_observability_stack_contract_is_wired() {
         "AuKpisApiLatencySlowBurn",
         "AuKpisFreshnessFastBurn",
         "AuKpisFreshnessSlowBurn",
+        "aemo.dispatch",
+        "900",
         "AuKpisIngestionErrorFastBurn",
         "AuKpisIngestionErrorSlowBurn",
         "AuKpisSchemaHashDrift",

--- a/infra/observability/prometheus/rules/slo-burn-rates.yml
+++ b/infra/observability/prometheus/rules/slo-burn-rates.yml
@@ -92,6 +92,32 @@ groups:
           summary: Dataflow freshness slow burn
           description: Dataflow {{ $labels.dataflow }} has stayed stale across the slow burn window.
 
+      - alert: AuKpisAemoDispatchFreshnessFastBurn
+        expr: max(au_kpis_ingestion_lag_seconds{dataflow="aemo.dispatch"}) > 900
+        for: 5m
+        labels:
+          severity: page
+          team: data-platform
+          slo: data-freshness
+          dataflow: aemo.dispatch
+          window: fast
+        annotations:
+          summary: AEMO DispatchIS freshness fast burn
+          description: AEMO DispatchIS observations are more than 15 minutes behind publication.
+
+      - alert: AuKpisAemoDispatchFreshnessSlowBurn
+        expr: max(avg_over_time(au_kpis_ingestion_lag_seconds{dataflow="aemo.dispatch"}[15m])) > 900
+        for: 15m
+        labels:
+          severity: page
+          team: data-platform
+          slo: data-freshness
+          dataflow: aemo.dispatch
+          window: slow
+        annotations:
+          summary: AEMO DispatchIS freshness slow burn
+          description: AEMO DispatchIS freshness has stayed above the 15-minute SLO.
+
       - alert: AuKpisIngestionErrorFastBurn
         expr: |
           (

--- a/openapi.json
+++ b/openapi.json
@@ -1498,7 +1498,7 @@
       "TimePrecision": {
         "type": "string",
         "description": "Temporal granularity of an observation's timestamp. Matches the SDMX\n`@FREQ` facet on a coarse scale.",
-        "enum": ["day", "week", "month", "quarter", "year"]
+        "enum": ["minute", "day", "week", "month", "quarter", "year"]
       }
     },
     "securitySchemes": {

--- a/packages/sdk-generated/src/client.ts
+++ b/packages/sdk-generated/src/client.ts
@@ -545,6 +545,7 @@ export type TimePrecision = typeof TimePrecision[keyof typeof TimePrecision];
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export const TimePrecision = {
+  minute: 'minute',
   day: 'day',
   week: 'week',
   month: 'month',

--- a/packages/sdk-generated/src/types.ts
+++ b/packages/sdk-generated/src/types.ts
@@ -531,7 +531,7 @@ export interface components {
          *     `@FREQ` facet on a coarse scale.
          * @enum {string}
          */
-        TimePrecision: "day" | "week" | "month" | "quarter" | "year";
+        TimePrecision: "minute" | "day" | "week" | "month" | "quarter" | "year";
     };
     responses: never;
     parameters: never;

--- a/packages/sdk-generated/src/zod.ts
+++ b/packages/sdk-generated/src/zod.ts
@@ -107,7 +107,7 @@ type ObservationStatus =
   | "provisional"
   | "revised"
   | "break";
-type TimePrecision = "day" | "week" | "month" | "quarter" | "year";
+type TimePrecision = "minute" | "day" | "week" | "month" | "quarter" | "year";
 type ObservationsMetadata = {
   attribution: string;
   dataflow: DataflowId;
@@ -267,7 +267,14 @@ const ObservationStatus = z.enum([
   "revised",
   "break",
 ]);
-const TimePrecision = z.enum(["day", "week", "month", "quarter", "year"]);
+const TimePrecision = z.enum([
+  "minute",
+  "day",
+  "week",
+  "month",
+  "quarter",
+  "year",
+]);
 const ObservationsRow: z.ZodType<ObservationsRow> = z
   .object({
     attributes: z.record(z.string()),


### PR DESCRIPTION
## Summary

- Implements the AEMO NEMWeb DispatchIS adapter for 5-minute ZIP/CSV polling, fetch, parse, provenance validation, rate-limit handling, and `insta` snapshots.
- Wires `aemo.dispatch` into ingestion once-mode, scheduler discovery cadence, freshness SLO alerts, OpenAPI, and generated TypeScript SDK types.
- Stabilizes webhook subscription delivery tests that used a fixed delivery clock earlier than database enqueue time.

Closes #55

## Pass requirements

- [x] NEMWeb polling (new files every 5 min)
- [x] Sub-hourly ingestion pipeline
- [x] Freshness SLO met (<15 min after publish)
- [x] `insta` snapshots
- [x] Handles NEMWeb rate limits gracefully

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace --test-threads 1`
- [x] `pnpm run lint`
- [x] `pnpm turbo run typecheck test`
- [x] `cargo deny check`
- [x] `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- [x] `pnpm audit --audit-level critical`
- [x] `gitleaks protect --staged`

## Spec impact

Spec updated to include minute-level `TimePrecision` for AEMO DispatchIS observations; OpenAPI and generated SDK types were regenerated.