### PR TITLE
feat(adapter-asx): announcements and eod ingestion (#56)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,25 @@ dependencies = [
 [[package]]
 name = "au-kpis-adapter-asx"
 version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "au-kpis-adapter",
+ "au-kpis-domain",
+ "au-kpis-error",
+ "au-kpis-storage",
+ "bytes",
+ "chrono",
+ "csv-async",
+ "futures",
+ "insta",
+ "object_store",
+ "quick-xml 0.39.4",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
 
 [[package]]
 name = "au-kpis-adapter-rba"
@@ -645,6 +664,7 @@ dependencies = [
  "au-kpis-adapter",
  "au-kpis-adapter-abs",
  "au-kpis-adapter-apra",
+ "au-kpis-adapter-asx",
  "au-kpis-adapter-rba",
  "au-kpis-adapter-state-budgets",
  "au-kpis-adapter-treasury",

--- a/crates/adapters/asx/Cargo.toml
+++ b/crates/adapters/asx/Cargo.toml
@@ -8,3 +8,24 @@ repository.workspace = true
 description = "ASX adapter (announcements + EOD)."
 
 [dependencies]
+async-trait = "0.1"
+au-kpis-adapter = { workspace = true }
+au-kpis-domain = { workspace = true }
+au-kpis-error = { workspace = true }
+au-kpis-storage = { workspace = true }
+chrono = { version = "0.4", default-features = false, features = ["std", "serde", "clock"] }
+csv-async = { version = "1.3", default-features = false, features = ["tokio"] }
+futures = "0.3"
+quick-xml = { version = "0.39", features = ["encoding"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["rt", "sync"] }
+tokio-util = { version = "0.7", features = ["io"] }
+tracing = "0.1"
+
+[dev-dependencies]
+async-trait = "0.1"
+bytes = "1"
+insta = { version = "1", features = ["json"] }
+object_store = "0.11"
+tokio = { version = "1", features = ["io-util", "macros", "net", "rt-multi-thread", "sync"] }

--- a/crates/adapters/asx/src/lib.rs
+++ b/crates/adapters/asx/src/lib.rs
@@ -1,1 +1,1338 @@
-//! ASX adapter (announcements + EOD).
+//! ASX adapter for market announcements feeds and end-of-day CSV artifacts.
+
+#![forbid(unsafe_code)]
+#![deny(missing_docs, missing_debug_implementations)]
+
+use std::{borrow::Cow, collections::BTreeMap, io, time::Duration};
+
+use async_trait::async_trait;
+use au_kpis_adapter::{
+    AdapterError, AdapterManifest, ArtifactRef, DiscoveredJob, DiscoveryCtx, FetchCtx,
+    ObservationStream, ParseCtx, RateLimit, SourceAdapter, UpstreamRevision,
+    capture_response_headers, retry_after_delta,
+};
+use au_kpis_domain::{
+    Artifact, CodeId, Dataflow, DataflowId, DimensionId, Frequency, License, MeasureId,
+    Observation, ObservationStatus, SeriesDescriptor, SeriesKey, SourceId, TimePrecision,
+};
+use au_kpis_error::CoreError;
+use au_kpis_storage::{BlobStore, StorageKey};
+use chrono::{DateTime, NaiveDate, SecondsFormat, TimeZone, Utc};
+use csv_async::AsyncReaderBuilder;
+use futures::{StreamExt, TryStreamExt, stream};
+use quick_xml::{Reader as XmlReader, escape::unescape, events::Event};
+use serde::Deserialize;
+use tokio_util::io::StreamReader;
+
+const DEFAULT_ANNOUNCEMENTS_FEED_URL: &str = "https://asx.api.markitdigital.com/asx-research/1.0/markets/announcements?itemsPerPage=100&page=0";
+const DEFAULT_EOD_FILE_URL: &str = "https://www.asxonline.com/referencepoint/eod/latest.csv";
+const ANNOUNCEMENT_FILE_BASE_URL: &str = "https://asx.api.markitdigital.com/asx-research/1.0/file";
+const USER_AGENT: &str = concat!("au-kpis-adapter-asx/", env!("CARGO_PKG_VERSION"));
+const ANNOUNCEMENTS_DATAFLOW_ID: &str = "asx.announcements";
+const EOD_DATAFLOW_ID: &str = "asx.eod";
+const ATTRIBUTION: &str = "Source: ASX";
+const LICENSE_NAME: &str = "ASX market data terms";
+const LICENSE_URL: &str = "https://www.asx.com.au/about/terms-use";
+
+/// Stored revision type for ASX feed and file jobs.
+pub type AsxRevision = UpstreamRevision;
+
+/// One announcement item parsed from the ASX announcements feed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AsxAnnouncement {
+    /// Stable announcement id from RSS `guid` or the linked PDF stem.
+    pub announcement_id: String,
+    /// Resolved ASX ticker code.
+    pub ticker: String,
+    /// Announcement title.
+    pub title: String,
+    /// Optional announcement category.
+    pub category: Option<String>,
+    /// Published timestamp from the announcement feed.
+    pub published_at: DateTime<Utc>,
+    /// Optional market-sensitive marker exposed by the feed.
+    pub market_sensitive: Option<bool>,
+    /// Announcement PDF or canonical announcement URL.
+    pub source_url: String,
+    /// Optional announcement description.
+    pub description: Option<String>,
+}
+
+/// One end-of-day CSV file to fetch and parse.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AsxEodFile {
+    /// CSV source URL.
+    pub source_url: String,
+    /// Trading date covered by the CSV file.
+    pub trading_date: NaiveDate,
+    /// Timestamp used as the upstream revision marker.
+    pub published_at: DateTime<Utc>,
+}
+
+impl AsxEodFile {
+    /// Construct one ASX EOD CSV file descriptor.
+    #[must_use]
+    pub fn new(
+        source_url: impl Into<String>,
+        trading_date: NaiveDate,
+        published_at: DateTime<Utc>,
+    ) -> Self {
+        Self {
+            source_url: source_url.into(),
+            trading_date,
+            published_at,
+        }
+    }
+
+    fn revision_key(&self) -> String {
+        format!("ASX:EOD:{}", self.trading_date)
+    }
+
+    fn revision(&self) -> UpstreamRevision {
+        UpstreamRevision::new(
+            utc_rfc3339(self.published_at),
+            Some(utc_rfc3339(self.published_at)),
+        )
+    }
+
+    fn to_discovered_job(&self, trace_parent: Option<&str>) -> DiscoveredJob {
+        let revision = self.revision();
+        let revision_version = revision.version().to_string();
+        let revision_key = self.revision_key();
+        DiscoveredJob {
+            id: format!("asx-eod-{}", self.trading_date),
+            source_id: source_id(),
+            dataflow_id: eod_dataflow_id(),
+            source_url: self.source_url.clone(),
+            trace_parent: trace_parent.map(str::to_owned),
+            metadata: BTreeMap::from([
+                ("adapter".into(), "asx".into()),
+                ("artifact_kind".into(), "eod_csv".into()),
+                ("attribution".into(), ATTRIBUTION.into()),
+                ("cadence".into(), "daily".into()),
+                ("dataflow_id".into(), EOD_DATAFLOW_ID.into()),
+                ("license".into(), LICENSE_NAME.into()),
+                ("license_url".into(), LICENSE_URL.into()),
+                ("published_at".into(), utc_rfc3339(self.published_at)),
+                ("revision_key".into(), revision_key),
+                ("revision_version".into(), revision_version),
+                ("trading_date".into(), self.trading_date.to_string()),
+            ]),
+        }
+    }
+}
+
+/// ASX announcements and end-of-day pricing adapter.
+#[derive(Debug, Clone)]
+pub struct AsxAdapter {
+    manifest: AdapterManifest,
+    announcements_feed_url: String,
+    eod_file_url: String,
+}
+
+impl Default for AsxAdapter {
+    fn default() -> Self {
+        Self::builder().build()
+    }
+}
+
+impl AsxAdapter {
+    /// Start building an ASX adapter.
+    #[must_use]
+    pub fn builder() -> AsxAdapterBuilder {
+        AsxAdapterBuilder::default()
+    }
+
+    /// Parse an ASX announcements feed into announcement items.
+    pub fn parse_announcements_feed(body: &str) -> Result<Vec<AsxAnnouncement>, AdapterError> {
+        parse_announcements_feed(body)
+    }
+
+    /// Convert current ASX feed/file state into jobs without known-revision filtering.
+    #[must_use]
+    pub fn current_jobs_with_started_at(
+        announcements: &[AsxAnnouncement],
+        eod_files: &[AsxEodFile],
+        started_at: DateTime<Utc>,
+    ) -> Vec<DiscoveredJob> {
+        Self::discoverable_jobs_with_started_at(
+            announcements,
+            eod_files,
+            &BTreeMap::new(),
+            started_at,
+            None,
+        )
+    }
+
+    /// Diff current ASX feed/file state against stored upstream revisions.
+    #[must_use]
+    pub fn discoverable_jobs_with_started_at(
+        announcements: &[AsxAnnouncement],
+        eod_files: &[AsxEodFile],
+        known_revisions: &BTreeMap<String, UpstreamRevision>,
+        started_at: DateTime<Utc>,
+        trace_parent: Option<&str>,
+    ) -> Vec<DiscoveredJob> {
+        let mut jobs = Vec::new();
+        if let Some(job) =
+            announcements_feed_job(announcements, known_revisions, started_at, trace_parent)
+        {
+            jobs.push(job);
+        }
+        jobs.extend(
+            eod_files
+                .iter()
+                .filter_map(|file| {
+                    let revision = file.revision();
+                    known_revisions
+                        .get(&file.revision_key())
+                        .is_none_or(|known| known != &revision)
+                        .then(|| file.to_discovered_job(trace_parent))
+                })
+                .collect::<Vec<_>>(),
+        );
+        jobs
+    }
+
+    /// Static metadata for the dataflows emitted by the ASX adapter.
+    #[must_use]
+    pub fn dataflow_metadata(&self) -> Vec<Dataflow> {
+        vec![
+            Dataflow {
+                id: announcements_dataflow_id(),
+                source_id: source_id(),
+                name: "ASX market announcements".into(),
+                description: Some(
+                    "Market announcement events parsed from the ASX announcements feed.".into(),
+                ),
+                dimensions: vec![
+                    DimensionId::new("ticker").expect("static dimension id is valid"),
+                    DimensionId::new("announcement_id").expect("static dimension id is valid"),
+                    DimensionId::new("category").expect("static dimension id is valid"),
+                ],
+                measures: vec![MeasureId::new("event_count").expect("static measure id is valid")],
+                frequency: Frequency::Irregular,
+                license: License::Other(LICENSE_NAME.into()),
+                attribution: ATTRIBUTION.into(),
+                source_url: self.announcements_feed_url.clone(),
+            },
+            Dataflow {
+                id: eod_dataflow_id(),
+                source_id: source_id(),
+                name: "ASX end-of-day prices".into(),
+                description: Some(
+                    "Daily OHLCV rows parsed from the configured ASX end-of-day CSV file feed."
+                        .into(),
+                ),
+                dimensions: vec![
+                    DimensionId::new("ticker").expect("static dimension id is valid"),
+                    DimensionId::new("entity_name").expect("static dimension id is valid"),
+                    DimensionId::new("metric").expect("static dimension id is valid"),
+                ],
+                measures: vec![MeasureId::new("value").expect("static measure id is valid")],
+                frequency: Frequency::Daily,
+                license: License::Other(LICENSE_NAME.into()),
+                attribution: ATTRIBUTION.into(),
+                source_url: self.eod_file_url.clone(),
+            },
+        ]
+    }
+
+    fn announcements_feed_url(&self) -> &str {
+        &self.announcements_feed_url
+    }
+
+    fn eod_file_url(&self) -> &str {
+        &self.eod_file_url
+    }
+
+    fn eod_file_for_started_at(&self, started_at: DateTime<Utc>) -> AsxEodFile {
+        AsxEodFile::new(self.eod_file_url(), started_at.date_naive(), started_at)
+    }
+
+    fn validate_fetch_job(&self, job: &DiscoveredJob) -> Result<(), AdapterError> {
+        if job.source_id != self.manifest.source_id {
+            return Err(AdapterError::Validation(format!(
+                "ASX fetch received job for source `{}`",
+                job.source_id.as_str()
+            )));
+        }
+        if !self
+            .manifest
+            .dataflows
+            .iter()
+            .any(|dataflow_id| dataflow_id == &job.dataflow_id)
+        {
+            return Err(AdapterError::Validation(format!(
+                "ASX fetch received unsupported dataflow `{}`",
+                job.dataflow_id.as_str()
+            )));
+        }
+        let expected_kind = artifact_kind_for_dataflow(&job.dataflow_id)?;
+        if job.metadata.get("artifact_kind").map(String::as_str) != Some(expected_kind) {
+            return Err(AdapterError::Validation(format!(
+                "ASX fetch job `{}` is missing `{expected_kind}` provenance",
+                job.id
+            )));
+        }
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl SourceAdapter for AsxAdapter {
+    fn id(&self) -> &'static str {
+        "asx"
+    }
+
+    fn manifest(&self) -> &AdapterManifest {
+        &self.manifest
+    }
+
+    #[tracing::instrument(skip(self, ctx), fields(source = self.id()))]
+    async fn discover(&self, ctx: &DiscoveryCtx) -> Result<Vec<DiscoveredJob>, AdapterError> {
+        let want_announcements = requested_or_all(ctx, ANNOUNCEMENTS_DATAFLOW_ID);
+        let want_eod = requested_or_all(ctx, EOD_DATAFLOW_ID);
+        let mut announcements = Vec::new();
+        if want_announcements {
+            let response = ctx
+                .http
+                .execute(
+                    ctx.http
+                        .raw()
+                        .get(self.announcements_feed_url())
+                        .header("user-agent", USER_AGENT)
+                        .header(
+                            "accept",
+                            "application/rss+xml,application/xml,text/xml,application/json",
+                        ),
+                )
+                .await?;
+            let response_headers = capture_response_headers(response.headers());
+            let status = response.status();
+            if !status.is_success() {
+                return Err(AdapterError::UpstreamStatus {
+                    status,
+                    retry_after: retry_after_delta(&response_headers),
+                    response_headers,
+                });
+            }
+            let body = response.text().await?;
+            announcements = parse_announcements_feed(&body)?;
+        }
+
+        let eod_files = want_eod
+            .then(|| self.eod_file_for_started_at(ctx.started_at))
+            .into_iter()
+            .collect::<Vec<_>>();
+        let mut jobs = Self::discoverable_jobs_with_started_at(
+            &announcements,
+            &eod_files,
+            ctx.known_revisions(),
+            ctx.started_at,
+            ctx.trace_parent(),
+        );
+        for job in &mut jobs {
+            if job.dataflow_id.as_str() == ANNOUNCEMENTS_DATAFLOW_ID {
+                job.source_url.clone_from(&self.announcements_feed_url);
+            }
+        }
+        Ok(jobs)
+    }
+
+    #[tracing::instrument(skip(self, ctx), fields(source = self.id(), job_id = %job.id))]
+    async fn fetch(&self, job: DiscoveredJob, ctx: &FetchCtx) -> Result<ArtifactRef, AdapterError> {
+        self.validate_fetch_job(&job)?;
+        let response = ctx
+            .http
+            .execute(
+                ctx.http
+                    .raw_artifact()
+                    .get(&job.source_url)
+                    .header("user-agent", USER_AGENT)
+                    .header("accept", accept_for_job(&job)),
+            )
+            .await?;
+        let response_headers = capture_response_headers(response.headers());
+        let status = response.status();
+        if !status.is_success() {
+            return Err(AdapterError::UpstreamStatus {
+                status,
+                retry_after: retry_after_delta(&response_headers),
+                response_headers,
+            });
+        }
+        let content_type = response
+            .headers()
+            .get("content-type")
+            .and_then(|value| value.to_str().ok())
+            .map_or_else(|| content_type_for_job(&job).to_string(), str::to_string);
+
+        let staged = ctx
+            .blob_store
+            .stage_artifact_stream(response.bytes_stream().boxed())
+            .await?;
+        let id = staged.id();
+        let storage_key = StorageKey::canonical_for(&id).to_string();
+        let artifact = Artifact {
+            id,
+            source_id: job.source_id,
+            source_url: job.source_url,
+            content_type,
+            response_headers,
+            storage_key,
+            size_bytes: staged.size_bytes(),
+            fetched_at: Utc::now(),
+        };
+        ctx.blob_store.commit_staged_artifact(&staged).await?;
+        ctx.persist_artifact(artifact).await
+    }
+
+    fn parse<'a>(&'a self, artifact: ArtifactRef, ctx: &'a ParseCtx) -> ObservationStream<'a> {
+        parse_artifact_stream(artifact, ctx)
+    }
+}
+
+fn parse_artifact_stream(artifact: ArtifactRef, ctx: &ParseCtx) -> ObservationStream<'_> {
+    let kind = match validate_parse_artifact(&artifact, ctx) {
+        Ok(kind) => kind,
+        Err(err) => return Box::pin(stream::once(async move { Err(err) })),
+    };
+
+    let blob_store = ctx.blob_store.clone();
+    let started_at = ctx.started_at;
+    let cancellation = ctx.cancellation().clone();
+    let (row_tx, row_rx) = tokio::sync::mpsc::channel(1024);
+
+    tokio::spawn(async move {
+        let key = StorageKey::from_persisted(artifact.storage_key.clone());
+        let identity = tokio::select! {
+            () = cancellation.cancelled() => Err(cancelled_parse_error()),
+            result = verify_parse_artifact_identity(&blob_store, &key, &artifact) => result,
+        };
+        if let Err(err) = identity {
+            let _ = row_tx.send(Err(err)).await;
+            return;
+        }
+
+        let result = match kind {
+            AsxArtifactKind::AnnouncementsRss => {
+                parse_announcements_artifact(
+                    blob_store,
+                    key,
+                    artifact,
+                    started_at,
+                    cancellation,
+                    row_tx.clone(),
+                )
+                .await
+            }
+            AsxArtifactKind::EodCsv => {
+                parse_eod_artifact(
+                    blob_store,
+                    key,
+                    artifact,
+                    started_at,
+                    cancellation,
+                    row_tx.clone(),
+                )
+                .await
+            }
+        };
+        if let Err(err) = result {
+            let _ = row_tx.send(Err(err)).await;
+        }
+    });
+
+    Box::pin(stream::unfold(row_rx, |mut row_rx| async {
+        row_rx.recv().await.map(|item| (item, row_rx))
+    }))
+}
+
+async fn parse_announcements_artifact(
+    blob_store: BlobStore,
+    key: StorageKey,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    cancellation: tokio_util::sync::CancellationToken,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+) -> Result<(), AdapterError> {
+    let bytes = read_artifact_bytes(blob_store, key, cancellation).await?;
+    let body = std::str::from_utf8(&bytes)
+        .map_err(|err| AdapterError::FormatDrift(format!("ASX RSS is not UTF-8: {err}")))?;
+    for row in parse_announcement_rows(parse_announcements_feed(body)?, &artifact, ingested_at)? {
+        if tx.send(Ok(row)).await.is_err() {
+            return Ok(());
+        }
+    }
+    Ok(())
+}
+
+async fn parse_eod_artifact(
+    blob_store: BlobStore,
+    key: StorageKey,
+    artifact: ArtifactRef,
+    ingested_at: DateTime<Utc>,
+    cancellation: tokio_util::sync::CancellationToken,
+    tx: tokio::sync::mpsc::Sender<Result<(SeriesDescriptor, Observation), AdapterError>>,
+) -> Result<(), AdapterError> {
+    let chunks = tokio::select! {
+        () = cancellation.cancelled() => return Err(cancelled_parse_error()),
+        chunks = blob_store.get(&key) => chunks?,
+    };
+    let io_stream = chunks.map_err(|err| io::Error::other(err.to_string()));
+    let reader = StreamReader::new(io_stream);
+    let mut csv = AsyncReaderBuilder::new()
+        .has_headers(true)
+        .flexible(true)
+        .create_reader(reader);
+    let header = csv
+        .headers()
+        .await
+        .map_err(|err| AdapterError::FormatDrift(err.to_string()))?
+        .iter()
+        .map(|value| value.trim().to_ascii_lowercase())
+        .collect::<Vec<_>>();
+    let header = EodHeader::from_header(&header)?;
+    let mut records = csv.records();
+    while let Some(record) = tokio::select! {
+        () = cancellation.cancelled() => return Err(cancelled_parse_error()),
+        record = records.next() => record,
+    } {
+        let record = record.map_err(|err| AdapterError::FormatDrift(err.to_string()))?;
+        for row in parse_eod_record(&record, &header, &artifact, ingested_at)? {
+            if tx.send(Ok(row)).await.is_err() {
+                return Ok(());
+            }
+        }
+    }
+    Ok(())
+}
+
+async fn read_artifact_bytes(
+    blob_store: BlobStore,
+    key: StorageKey,
+    cancellation: tokio_util::sync::CancellationToken,
+) -> Result<Vec<u8>, AdapterError> {
+    let mut chunks = tokio::select! {
+        () = cancellation.cancelled() => return Err(cancelled_parse_error()),
+        chunks = blob_store.get(&key) => chunks?,
+    };
+    let mut bytes = Vec::new();
+    while let Some(chunk) = tokio::select! {
+        () = cancellation.cancelled() => return Err(cancelled_parse_error()),
+        chunk = chunks.next() => chunk,
+    } {
+        bytes.extend_from_slice(&chunk?);
+    }
+    Ok(bytes)
+}
+
+fn parse_announcements_feed(body: &str) -> Result<Vec<AsxAnnouncement>, AdapterError> {
+    if body.trim_start().starts_with('{') {
+        return parse_announcements_json_feed(body);
+    }
+    parse_announcements_rss_feed(body)
+}
+
+fn parse_announcements_rss_feed(body: &str) -> Result<Vec<AsxAnnouncement>, AdapterError> {
+    let mut reader = XmlReader::from_str(body);
+    reader.config_mut().trim_text(true);
+    let mut current = None::<AnnouncementBuilder>;
+    let mut field = None::<String>;
+    let mut announcements = Vec::new();
+
+    loop {
+        match reader.read_event() {
+            Ok(Event::Start(element)) => {
+                let name = local_name(element.local_name().as_ref());
+                if name == "item" {
+                    current = Some(AnnouncementBuilder::default());
+                } else if current.is_some() {
+                    field = Some(name);
+                }
+            }
+            Ok(Event::End(element)) => {
+                let name = local_name(element.local_name().as_ref());
+                if name == "item" {
+                    let builder = current.take().ok_or_else(|| {
+                        AdapterError::FormatDrift("ASX RSS closed item before opening it".into())
+                    })?;
+                    announcements.push(builder.finish()?);
+                }
+                if field.as_deref() == Some(name.as_str()) {
+                    field = None;
+                }
+            }
+            Ok(Event::Text(text)) => {
+                if let (Some(builder), Some(name)) = (&mut current, field.as_deref()) {
+                    builder.push(name, decode_xml_text(text.decode())?);
+                }
+            }
+            Ok(Event::CData(text)) => {
+                if let (Some(builder), Some(name)) = (&mut current, field.as_deref()) {
+                    builder.push(name, decode_xml_cdata(text.decode())?);
+                }
+            }
+            Ok(Event::Eof) => break,
+            Ok(_) => {}
+            Err(err) => {
+                return Err(AdapterError::FormatDrift(format!(
+                    "ASX RSS XML is malformed: {err}"
+                )));
+            }
+        }
+    }
+    sort_announcements(&mut announcements);
+    Ok(announcements)
+}
+
+fn parse_announcements_json_feed(body: &str) -> Result<Vec<AsxAnnouncement>, AdapterError> {
+    let envelope: MarketAnnouncementsEnvelope = serde_json::from_str(body).map_err(|err| {
+        AdapterError::FormatDrift(format!("ASX announcements JSON is malformed: {err}"))
+    })?;
+    let mut announcements = envelope
+        .data
+        .items
+        .into_iter()
+        .map(MarketAnnouncementItem::into_announcement)
+        .collect::<Result<Vec<_>, _>>()?;
+    sort_announcements(&mut announcements);
+    Ok(announcements)
+}
+
+fn sort_announcements(announcements: &mut [AsxAnnouncement]) {
+    announcements.sort_by(|left, right| {
+        right
+            .published_at
+            .cmp(&left.published_at)
+            .then(left.ticker.cmp(&right.ticker))
+            .then(left.announcement_id.cmp(&right.announcement_id))
+    });
+}
+
+#[derive(Debug, Deserialize)]
+struct MarketAnnouncementsEnvelope {
+    data: MarketAnnouncementsData,
+}
+
+#[derive(Debug, Deserialize)]
+struct MarketAnnouncementsData {
+    items: Vec<MarketAnnouncementItem>,
+}
+
+#[derive(Debug, Deserialize)]
+struct MarketAnnouncementCompany {
+    #[serde(default, rename = "symbolDisplay")]
+    symbol_display: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct MarketAnnouncementItem {
+    #[serde(default, rename = "announcementTypes")]
+    announcement_types: Vec<String>,
+    #[serde(default)]
+    companies: Vec<MarketAnnouncementCompany>,
+    date: String,
+    #[serde(rename = "documentKey")]
+    document_key: String,
+    headline: String,
+    #[serde(default, rename = "isPriceSensitive")]
+    is_price_sensitive: Option<bool>,
+    #[serde(default)]
+    symbol: String,
+    #[serde(default)]
+    url: String,
+}
+
+impl MarketAnnouncementItem {
+    fn into_announcement(self) -> Result<AsxAnnouncement, AdapterError> {
+        let title = self.headline.trim();
+        if title.is_empty() {
+            return Err(AdapterError::FormatDrift(
+                "ASX announcement JSON item is missing headline".into(),
+            ));
+        }
+        let announcement_id = self.document_key.trim();
+        if announcement_id.is_empty() {
+            return Err(AdapterError::FormatDrift(
+                "ASX announcement JSON item is missing documentKey".into(),
+            ));
+        }
+        let ticker = normalize_ticker(&self.symbol)
+            .or_else(|| {
+                self.companies
+                    .iter()
+                    .find_map(|company| normalize_ticker(&company.symbol_display))
+            })
+            .ok_or_else(|| {
+                AdapterError::FormatDrift(format!(
+                    "ASX announcement `{title}` is missing resolvable ticker"
+                ))
+            })?;
+        let category = (!self.announcement_types.is_empty())
+            .then(|| self.announcement_types.join(", "))
+            .filter(|value| !value.trim().is_empty());
+        let source_url = if self.url.trim().is_empty() {
+            format!("{ANNOUNCEMENT_FILE_BASE_URL}/{announcement_id}")
+        } else {
+            self.url.trim().to_string()
+        };
+        Ok(AsxAnnouncement {
+            announcement_id: announcement_id.to_string(),
+            ticker,
+            title: title.to_string(),
+            category,
+            published_at: parse_json_datetime(&self.date)?,
+            market_sensitive: self.is_price_sensitive,
+            source_url,
+            description: None,
+        })
+    }
+}
+
+#[derive(Debug, Default)]
+struct AnnouncementBuilder {
+    title: String,
+    link: String,
+    guid: String,
+    pub_date: String,
+    category: Option<String>,
+    code: Option<String>,
+    market_sensitive: Option<String>,
+    description: Option<String>,
+}
+
+impl AnnouncementBuilder {
+    fn push(&mut self, name: &str, value: String) {
+        let value = value.trim();
+        if value.is_empty() {
+            return;
+        }
+        match name {
+            "title" => append_text(&mut self.title, value),
+            "link" => append_text(&mut self.link, value),
+            "guid" => append_text(&mut self.guid, value),
+            "pubdate" | "published" | "updated" => append_text(&mut self.pub_date, value),
+            "category" => append_option_text(&mut self.category, value),
+            "code" | "ticker" | "asxcode" => append_option_text(&mut self.code, value),
+            "marketsensitive" | "market_sensitive" => {
+                append_option_text(&mut self.market_sensitive, value);
+            }
+            "description" | "summary" => append_option_text(&mut self.description, value),
+            _ => {}
+        }
+    }
+
+    fn finish(self) -> Result<AsxAnnouncement, AdapterError> {
+        if self.title.trim().is_empty() {
+            return Err(AdapterError::FormatDrift(
+                "ASX RSS item is missing title".into(),
+            ));
+        }
+        if self.link.trim().is_empty() {
+            return Err(AdapterError::FormatDrift(
+                "ASX RSS item is missing link".into(),
+            ));
+        }
+        let published_at = parse_xml_datetime(&self.pub_date)?;
+        let announcement_id = if self.guid.trim().is_empty() {
+            announcement_id_from_url(&self.link)?
+        } else {
+            self.guid.trim().to_string()
+        };
+        let ticker = self
+            .code
+            .as_deref()
+            .and_then(normalize_ticker)
+            .or_else(|| extract_ticker_from_title(&self.title))
+            .ok_or_else(|| {
+                AdapterError::FormatDrift(format!(
+                    "ASX announcement `{}` is missing resolvable ticker",
+                    self.title
+                ))
+            })?;
+        let market_sensitive = self
+            .market_sensitive
+            .as_deref()
+            .map(parse_bool)
+            .transpose()?;
+        Ok(AsxAnnouncement {
+            announcement_id,
+            ticker,
+            title: self.title.trim().to_string(),
+            category: self.category.map(|value| value.trim().to_string()),
+            published_at,
+            market_sensitive,
+            source_url: self.link.trim().to_string(),
+            description: self.description.map(|value| value.trim().to_string()),
+        })
+    }
+}
+
+fn append_text(target: &mut String, value: &str) {
+    if !target.is_empty() {
+        target.push(' ');
+    }
+    target.push_str(value);
+}
+
+fn append_option_text(target: &mut Option<String>, value: &str) {
+    match target {
+        Some(existing) => append_text(existing, value),
+        None => *target = Some(value.to_string()),
+    }
+}
+
+fn decode_xml_text(
+    decoded: Result<Cow<'_, str>, quick_xml::encoding::EncodingError>,
+) -> Result<String, AdapterError> {
+    let decoded = decoded.map_err(|err| AdapterError::FormatDrift(err.to_string()))?;
+    unescape(&decoded)
+        .map(Cow::into_owned)
+        .map_err(|err| AdapterError::FormatDrift(err.to_string()))
+}
+
+fn decode_xml_cdata(
+    decoded: Result<Cow<'_, str>, quick_xml::encoding::EncodingError>,
+) -> Result<String, AdapterError> {
+    decoded
+        .map(Cow::into_owned)
+        .map_err(|err| AdapterError::FormatDrift(err.to_string()))
+}
+
+fn local_name(name: &[u8]) -> String {
+    let value = std::str::from_utf8(name).unwrap_or_default();
+    value
+        .rsplit(':')
+        .next()
+        .unwrap_or(value)
+        .to_ascii_lowercase()
+}
+
+fn parse_xml_datetime(value: &str) -> Result<DateTime<Utc>, AdapterError> {
+    if value.trim().is_empty() {
+        return Err(AdapterError::FormatDrift(
+            "ASX RSS item is missing pubDate".into(),
+        ));
+    }
+    DateTime::parse_from_rfc2822(value)
+        .or_else(|_| DateTime::parse_from_rfc3339(value))
+        .map(|time| time.with_timezone(&Utc))
+        .map_err(|_| AdapterError::FormatDrift(format!("invalid ASX RSS pubDate `{value}`")))
+}
+
+fn parse_json_datetime(value: &str) -> Result<DateTime<Utc>, AdapterError> {
+    DateTime::parse_from_rfc3339(value.trim())
+        .map(|time| time.with_timezone(&Utc))
+        .map_err(|_| AdapterError::FormatDrift(format!("invalid ASX announcement date `{value}`")))
+}
+
+fn parse_bool(value: &str) -> Result<bool, AdapterError> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "true" | "t" | "yes" | "y" | "1" => Ok(true),
+        "false" | "f" | "no" | "n" | "0" => Ok(false),
+        _ => Err(AdapterError::FormatDrift(format!(
+            "invalid ASX boolean `{value}`"
+        ))),
+    }
+}
+
+fn announcement_id_from_url(source_url: &str) -> Result<String, AdapterError> {
+    let path = source_url.split(['?', '#']).next().unwrap_or(source_url);
+    let filename = path.rsplit('/').next().unwrap_or(path);
+    let stem = filename.split('.').next().unwrap_or(filename).trim();
+    if stem.is_empty() {
+        Err(AdapterError::FormatDrift(format!(
+            "ASX announcement URL `{source_url}` has no announcement id"
+        )))
+    } else {
+        Ok(stem.to_string())
+    }
+}
+
+fn extract_ticker_from_title(title: &str) -> Option<String> {
+    let prefix = title
+        .split_once(':')
+        .map(|(prefix, _)| prefix)
+        .or_else(|| title.split_once('-').map(|(prefix, _)| prefix))?;
+    normalize_ticker(prefix)
+}
+
+fn normalize_ticker(value: &str) -> Option<String> {
+    let ticker = value
+        .trim()
+        .trim_start_matches("ASX")
+        .trim_start_matches(':')
+        .trim()
+        .to_ascii_uppercase();
+    let valid = (2..=6).contains(&ticker.len())
+        && ticker
+            .bytes()
+            .all(|byte| byte.is_ascii_uppercase() || byte.is_ascii_digit());
+    valid.then_some(ticker)
+}
+
+fn announcements_feed_job(
+    announcements: &[AsxAnnouncement],
+    known_revisions: &BTreeMap<String, UpstreamRevision>,
+    _started_at: DateTime<Utc>,
+    trace_parent: Option<&str>,
+) -> Option<DiscoveredJob> {
+    let latest = announcements.iter().max_by(|left, right| {
+        left.published_at
+            .cmp(&right.published_at)
+            .then(left.announcement_id.cmp(&right.announcement_id))
+    })?;
+    let revision_key = "ASX:ANNOUNCEMENTS:FEED".to_string();
+    let revision_version = format!(
+        "{}:{}",
+        utc_rfc3339(latest.published_at),
+        latest.announcement_id
+    );
+    let revision = UpstreamRevision::new(
+        revision_version.clone(),
+        Some(utc_rfc3339(latest.published_at)),
+    );
+    if known_revisions.get(&revision_key) == Some(&revision) {
+        return None;
+    }
+    Some(DiscoveredJob {
+        id: format!("asx-announcements-{revision_version}"),
+        source_id: source_id(),
+        dataflow_id: announcements_dataflow_id(),
+        source_url: DEFAULT_ANNOUNCEMENTS_FEED_URL.into(),
+        trace_parent: trace_parent.map(str::to_owned),
+        metadata: BTreeMap::from([
+            ("adapter".into(), "asx".into()),
+            ("artifact_kind".into(), "announcements_rss".into()),
+            ("attribution".into(), ATTRIBUTION.into()),
+            ("cadence".into(), "realtime".into()),
+            ("dataflow_id".into(), ANNOUNCEMENTS_DATAFLOW_ID.into()),
+            ("item_count".into(), announcements.len().to_string()),
+            (
+                "latest_announcement_id".into(),
+                latest.announcement_id.clone(),
+            ),
+            (
+                "latest_published_at".into(),
+                utc_rfc3339(latest.published_at),
+            ),
+            ("latest_source_url".into(), latest.source_url.clone()),
+            ("latest_ticker".into(), latest.ticker.clone()),
+            ("license".into(), LICENSE_NAME.into()),
+            ("license_url".into(), LICENSE_URL.into()),
+            ("revision_key".into(), revision_key),
+            ("revision_version".into(), revision_version),
+        ]),
+    })
+}
+
+fn parse_announcement_rows(
+    announcements: Vec<AsxAnnouncement>,
+    artifact: &ArtifactRef,
+    ingested_at: DateTime<Utc>,
+) -> Result<Vec<(SeriesDescriptor, Observation)>, AdapterError> {
+    announcements
+        .into_iter()
+        .map(|announcement| announcement_row(announcement, artifact, ingested_at))
+        .collect()
+}
+
+fn announcement_row(
+    announcement: AsxAnnouncement,
+    artifact: &ArtifactRef,
+    ingested_at: DateTime<Utc>,
+) -> Result<(SeriesDescriptor, Observation), AdapterError> {
+    let category = announcement
+        .category
+        .clone()
+        .unwrap_or_else(|| "Announcement".into());
+    let dataflow_id = announcements_dataflow_id();
+    let dimensions = BTreeMap::from([
+        (
+            DimensionId::new("ticker").expect("static dimension id is valid"),
+            asx_code_id("ticker", &announcement.ticker)?,
+        ),
+        (
+            DimensionId::new("announcement_id").expect("static dimension id is valid"),
+            asx_code_id("announcement id", &announcement.announcement_id)?,
+        ),
+        (
+            DimensionId::new("category").expect("static dimension id is valid"),
+            asx_code_id("category", &category)?,
+        ),
+    ]);
+    let series_key = SeriesKey::derive(
+        &dataflow_id,
+        dimensions
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    );
+    let descriptor = SeriesDescriptor {
+        series_key,
+        dataflow_id,
+        measure_id: MeasureId::new("event_count").expect("static measure id is valid"),
+        dimensions,
+        unit: "announcement".into(),
+    };
+    let mut attributes = BTreeMap::from([
+        ("announcement_id".into(), announcement.announcement_id),
+        ("category".into(), category),
+        ("source_url".into(), announcement.source_url),
+        ("ticker".into(), announcement.ticker),
+        ("title".into(), announcement.title),
+    ]);
+    if let Some(value) = announcement.description {
+        attributes.insert("description".into(), value);
+    }
+    if let Some(value) = announcement.market_sensitive {
+        attributes.insert("market_sensitive".into(), value.to_string());
+    }
+    let observation = Observation {
+        series_key,
+        time: announcement.published_at,
+        time_precision: TimePrecision::Day,
+        value: Some(1.0),
+        status: ObservationStatus::Normal,
+        revision_no: 0,
+        attributes,
+        ingested_at,
+        source_artifact_id: artifact.id,
+    };
+    Ok((descriptor, observation))
+}
+
+#[derive(Debug)]
+struct EodHeader {
+    ticker: usize,
+    date: usize,
+    open: usize,
+    high: usize,
+    low: usize,
+    close: usize,
+    volume: usize,
+    company_name: usize,
+}
+
+impl EodHeader {
+    fn from_header(header: &[String]) -> Result<Self, AdapterError> {
+        Ok(Self {
+            ticker: required_header(header, "ticker")?,
+            date: required_header(header, "date")?,
+            open: required_header(header, "open")?,
+            high: required_header(header, "high")?,
+            low: required_header(header, "low")?,
+            close: required_header(header, "close")?,
+            volume: required_header(header, "volume")?,
+            company_name: required_header(header, "company_name")
+                .or_else(|_| required_header(header, "entity_name"))?,
+        })
+    }
+}
+
+fn required_header(header: &[String], name: &str) -> Result<usize, AdapterError> {
+    header
+        .iter()
+        .position(|value| value == name)
+        .ok_or_else(|| AdapterError::FormatDrift(format!("ASX EOD CSV is missing `{name}` column")))
+}
+
+fn parse_eod_record(
+    record: &csv_async::StringRecord,
+    header: &EodHeader,
+    artifact: &ArtifactRef,
+    ingested_at: DateTime<Utc>,
+) -> Result<Vec<(SeriesDescriptor, Observation)>, AdapterError> {
+    let ticker = normalize_ticker(record_cell(record, header.ticker)).ok_or_else(|| {
+        AdapterError::FormatDrift(format!(
+            "invalid ASX EOD ticker `{}`",
+            record_cell(record, header.ticker)
+        ))
+    })?;
+    let time = parse_eod_date(record_cell(record, header.date))?;
+    let entity_name = record_cell(record, header.company_name).trim();
+    if entity_name.is_empty() {
+        return Err(AdapterError::FormatDrift(format!(
+            "ASX EOD row for `{ticker}` is missing company_name"
+        )));
+    }
+
+    let metrics = [
+        ("open", header.open, "AUD"),
+        ("high", header.high, "AUD"),
+        ("low", header.low, "AUD"),
+        ("close", header.close, "AUD"),
+        ("volume", header.volume, "shares"),
+    ];
+    metrics
+        .into_iter()
+        .map(|(metric, index, unit)| {
+            eod_row(EodMetricInput {
+                ticker: &ticker,
+                entity_name,
+                metric,
+                value: record_cell(record, index),
+                unit,
+                time,
+                artifact,
+                ingested_at,
+            })
+        })
+        .collect()
+}
+
+#[derive(Debug, Clone, Copy)]
+struct EodMetricInput<'a> {
+    ticker: &'a str,
+    entity_name: &'a str,
+    metric: &'a str,
+    value: &'a str,
+    unit: &'a str,
+    time: DateTime<Utc>,
+    artifact: &'a ArtifactRef,
+    ingested_at: DateTime<Utc>,
+}
+
+fn eod_row(input: EodMetricInput<'_>) -> Result<(SeriesDescriptor, Observation), AdapterError> {
+    let (value, status) = parse_numeric(input.value, input.metric)?;
+    let dataflow_id = eod_dataflow_id();
+    let dimensions = BTreeMap::from([
+        (
+            DimensionId::new("ticker").expect("static dimension id is valid"),
+            asx_code_id("ticker", input.ticker)?,
+        ),
+        (
+            DimensionId::new("entity_name").expect("static dimension id is valid"),
+            asx_code_id("entity name", input.entity_name)?,
+        ),
+        (
+            DimensionId::new("metric").expect("static dimension id is valid"),
+            asx_code_id("metric", input.metric)?,
+        ),
+    ]);
+    let series_key = SeriesKey::derive(
+        &dataflow_id,
+        dimensions
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str())),
+    );
+    let descriptor = SeriesDescriptor {
+        series_key,
+        dataflow_id,
+        measure_id: MeasureId::new("value").expect("static measure id is valid"),
+        dimensions,
+        unit: input.unit.into(),
+    };
+    let observation = Observation {
+        series_key,
+        time: input.time,
+        time_precision: TimePrecision::Day,
+        value,
+        status,
+        revision_no: 0,
+        attributes: BTreeMap::from([
+            ("company_name".into(), input.entity_name.into()),
+            ("metric".into(), input.metric.into()),
+            ("source_url".into(), input.artifact.source_url.clone()),
+            ("ticker".into(), input.ticker.into()),
+            ("trading_date".into(), input.time.date_naive().to_string()),
+        ]),
+        ingested_at: input.ingested_at,
+        source_artifact_id: input.artifact.id,
+    };
+    Ok((descriptor, observation))
+}
+
+fn record_cell(record: &csv_async::StringRecord, index: usize) -> &str {
+    record.get(index).unwrap_or("").trim()
+}
+
+fn parse_eod_date(value: &str) -> Result<DateTime<Utc>, AdapterError> {
+    let date = NaiveDate::parse_from_str(value.trim(), "%Y-%m-%d")
+        .or_else(|_| NaiveDate::parse_from_str(value.trim(), "%d/%m/%Y"))
+        .map_err(|_| AdapterError::FormatDrift(format!("invalid ASX EOD date `{value}`")))?;
+    Ok(Utc.from_utc_datetime(&date.and_hms_opt(0, 0, 0).expect("midnight is valid")))
+}
+
+fn parse_numeric(
+    value: &str,
+    metric: &str,
+) -> Result<(Option<f64>, ObservationStatus), AdapterError> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() || matches!(trimmed, "na" | "n/a" | "NA" | "N/A" | "-") {
+        return Ok((None, ObservationStatus::Missing));
+    }
+    trimmed
+        .replace(',', "")
+        .parse::<f64>()
+        .map(|value| (Some(value), ObservationStatus::Normal))
+        .map_err(|_| AdapterError::FormatDrift(format!("invalid ASX {metric} value `{value}`")))
+}
+
+fn validate_parse_artifact(
+    artifact: &ArtifactRef,
+    ctx: &ParseCtx,
+) -> Result<AsxArtifactKind, AdapterError> {
+    if artifact.source_id.as_str() != "asx" {
+        return Err(AdapterError::Validation(format!(
+            "ASX parse received artifact for source `{}`",
+            artifact.source_id.as_str()
+        )));
+    }
+    let expected = ctx.expected_dataflow_id().ok_or_else(|| {
+        AdapterError::Validation("ASX parse requires expected dataflow provenance".into())
+    })?;
+    match expected.as_str() {
+        ANNOUNCEMENTS_DATAFLOW_ID => Ok(AsxArtifactKind::AnnouncementsRss),
+        EOD_DATAFLOW_ID => Ok(AsxArtifactKind::EodCsv),
+        other => Err(AdapterError::Validation(format!(
+            "ASX parse received unsupported dataflow `{other}`"
+        ))),
+    }
+}
+
+async fn verify_parse_artifact_identity(
+    blob_store: &BlobStore,
+    key: &StorageKey,
+    artifact: &ArtifactRef,
+) -> Result<(), AdapterError> {
+    let canonical_key = StorageKey::canonical_for(&artifact.id).to_string();
+    if artifact.storage_key == canonical_key {
+        return Ok(());
+    }
+
+    if artifact.storage_key.starts_with("artifacts/") {
+        return Err(AdapterError::Validation(format!(
+            "ASX parse artifact storage key `{}` does not match artifact id `{}`",
+            artifact.storage_key, artifact.id
+        )));
+    }
+
+    if blob_store.matches_artifact_id(key, artifact.id).await? {
+        Ok(())
+    } else {
+        Err(AdapterError::Validation(format!(
+            "ASX parse artifact storage key `{}` does not match artifact id `{}`",
+            artifact.storage_key, artifact.id
+        )))
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AsxArtifactKind {
+    AnnouncementsRss,
+    EodCsv,
+}
+
+fn requested_or_all(ctx: &DiscoveryCtx, dataflow_id: &str) -> bool {
+    ctx.requested_dataflow_id()
+        .is_none_or(|requested| requested.as_str() == dataflow_id)
+}
+
+fn artifact_kind_for_dataflow(dataflow_id: &DataflowId) -> Result<&'static str, AdapterError> {
+    match dataflow_id.as_str() {
+        ANNOUNCEMENTS_DATAFLOW_ID => Ok("announcements_rss"),
+        EOD_DATAFLOW_ID => Ok("eod_csv"),
+        other => Err(AdapterError::Validation(format!(
+            "unsupported ASX dataflow `{other}`"
+        ))),
+    }
+}
+
+fn accept_for_job(job: &DiscoveredJob) -> &'static str {
+    match job.metadata.get("artifact_kind").map(String::as_str) {
+        Some("announcements_rss") => {
+            "application/rss+xml,application/xml,text/xml,application/json"
+        }
+        Some("eod_csv") => "text/csv",
+        _ => "application/octet-stream",
+    }
+}
+
+fn content_type_for_job(job: &DiscoveredJob) -> &'static str {
+    match job.metadata.get("artifact_kind").map(String::as_str) {
+        Some("announcements_rss") => "application/rss+xml",
+        Some("eod_csv") => "text/csv",
+        _ => "application/octet-stream",
+    }
+}
+
+fn source_id() -> SourceId {
+    SourceId::new("asx").expect("static source id is valid")
+}
+
+fn announcements_dataflow_id() -> DataflowId {
+    DataflowId::new(ANNOUNCEMENTS_DATAFLOW_ID).expect("static dataflow id is valid")
+}
+
+fn eod_dataflow_id() -> DataflowId {
+    DataflowId::new(EOD_DATAFLOW_ID).expect("static dataflow id is valid")
+}
+
+fn asx_code_id(field: &str, value: &str) -> Result<CodeId, AdapterError> {
+    CodeId::new(value.to_string()).map_err(|err| {
+        AdapterError::FormatDrift(format!("invalid ASX {field} code `{value}`: {err}"))
+    })
+}
+
+fn utc_rfc3339(time: DateTime<Utc>) -> String {
+    time.to_rfc3339_opts(SecondsFormat::Secs, true)
+}
+
+fn cancelled_parse_error() -> AdapterError {
+    CoreError::Io(io::Error::new(
+        io::ErrorKind::Interrupted,
+        "ASX parse cancelled",
+    ))
+    .into()
+}
+
+/// Builder for [`AsxAdapter`].
+#[derive(Debug, Clone)]
+pub struct AsxAdapterBuilder {
+    announcements_feed_url: String,
+    eod_file_url: String,
+}
+
+impl Default for AsxAdapterBuilder {
+    fn default() -> Self {
+        Self {
+            announcements_feed_url: DEFAULT_ANNOUNCEMENTS_FEED_URL.into(),
+            eod_file_url: DEFAULT_EOD_FILE_URL.into(),
+        }
+    }
+}
+
+impl AsxAdapterBuilder {
+    /// Override the announcements RSS feed URL.
+    #[must_use]
+    pub fn announcements_feed_url(mut self, url: impl Into<String>) -> Self {
+        self.announcements_feed_url = url.into();
+        self
+    }
+
+    /// Override the end-of-day CSV file URL.
+    #[must_use]
+    pub fn eod_file_url(mut self, url: impl Into<String>) -> Self {
+        self.eod_file_url = url.into();
+        self
+    }
+
+    /// Build the adapter.
+    #[must_use]
+    pub fn build(self) -> AsxAdapter {
+        AsxAdapter {
+            manifest: AdapterManifest {
+                source_id: source_id(),
+                name: "ASX".into(),
+                version: env!("CARGO_PKG_VERSION").into(),
+                rate_limit: RateLimit::new(30, Duration::from_secs(60))
+                    .expect("static ASX rate limit is valid"),
+                dataflows: vec![announcements_dataflow_id(), eod_dataflow_id()],
+            },
+            announcements_feed_url: self.announcements_feed_url,
+            eod_file_url: self.eod_file_url,
+        }
+    }
+}

--- a/crates/adapters/asx/tests/discover.rs
+++ b/crates/adapters/asx/tests/discover.rs
@@ -141,6 +141,74 @@ fn parse_announcements_json_feed_resolves_tickers_and_document_urls() {
 }
 
 #[test]
+fn parse_announcements_json_feed_accepts_company_ticker_and_source_url() {
+    let announcements = AsxAdapter::parse_announcements_feed(
+        r#"
+{
+  "data": {
+    "items": [
+      {
+        "announcementTypes": [],
+        "companies": [{"symbolDisplay": "ASX:abc"}],
+        "date": "2026-05-29T10:45:00.000Z",
+        "documentKey": "2924-03095500-6A1327674",
+        "headline": "Appendix 3Y",
+        "isPriceSensitive": true,
+        "symbol": "",
+        "url": "https://downloads.example.invalid/asx/2924-03095500-6A1327674.pdf"
+      }
+    ]
+  }
+}
+"#,
+    )
+    .expect("parse ASX JSON feed with company fallback");
+
+    assert_eq!(announcements.len(), 1);
+    assert_eq!(announcements[0].ticker, "ABC");
+    assert_eq!(announcements[0].category, None);
+    assert_eq!(announcements[0].market_sensitive, Some(true));
+    assert_eq!(
+        announcements[0].source_url,
+        "https://downloads.example.invalid/asx/2924-03095500-6A1327674.pdf"
+    );
+}
+
+#[test]
+fn parse_announcements_rss_accepts_url_ids_iso_dates_and_false_flags() {
+    let announcements = AsxAdapter::parse_announcements_feed(
+        r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:asx="https://www.asx.com.au/rss">
+  <channel>
+    <item>
+      <title>ABC - Investor presentation</title>
+      <link>https://www.asx.com.au/asxpdf/20260529/pdf/06fedcba.pdf?download=1</link>
+      <pubDate>2026-05-29T10:45:00Z</pubDate>
+      <asx:marketSensitive>no</asx:marketSensitive>
+      <description><![CDATA[Investor update.]]></description>
+    </item>
+  </channel>
+</rss>
+"#,
+    )
+    .expect("parse ASX RSS feed with alternate fields");
+
+    assert_eq!(announcements.len(), 1);
+    assert_eq!(announcements[0].announcement_id, "06fedcba");
+    assert_eq!(announcements[0].ticker, "ABC");
+    assert_eq!(
+        announcements[0].published_at.to_rfc3339(),
+        "2026-05-29T10:45:00+00:00"
+    );
+    assert_eq!(announcements[0].market_sensitive, Some(false));
+    assert_eq!(
+        announcements[0].description.as_deref(),
+        Some("Investor update.")
+    );
+}
+
+#[test]
 fn discoverable_jobs_skip_known_feed_revision_and_emit_eod_daily_job() {
     let announcements =
         AsxAdapter::parse_announcements_feed(ANNOUNCEMENTS_RSS).expect("parse ASX RSS");

--- a/crates/adapters/asx/tests/discover.rs
+++ b/crates/adapters/asx/tests/discover.rs
@@ -1,0 +1,224 @@
+use std::{collections::BTreeMap, time::Duration};
+
+use au_kpis_adapter::{AdapterHttpClient, DiscoveryCtx, SourceAdapter};
+use au_kpis_adapter_asx::{AsxAdapter, AsxEodFile, AsxRevision};
+use chrono::{NaiveDate, TimeZone, Utc};
+use serde_json::json;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+const TRACE_PARENT: &str = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+
+const ANNOUNCEMENTS_RSS: &str = r#"
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:asx="https://www.asx.com.au/rss">
+  <channel>
+    <title>ASX Market Announcements</title>
+    <item>
+      <title>BHP: Quarterly activities report</title>
+      <link>https://www.asx.com.au/asxpdf/20260529/pdf/06abc123.pdf</link>
+      <guid>06abc123</guid>
+      <pubDate>Fri, 29 May 2026 01:15:00 GMT</pubDate>
+      <category>Periodic Reports</category>
+      <asx:code>BHP</asx:code>
+      <asx:marketSensitive>true</asx:marketSensitive>
+      <description>Quarterly operating update.</description>
+    </item>
+    <item>
+      <title>CBA: Trading halt</title>
+      <link>https://www.asx.com.au/asxpdf/20260529/pdf/06def456.pdf</link>
+      <guid>06def456</guid>
+      <pubDate>Fri, 29 May 2026 00:45:00 GMT</pubDate>
+      <category>Trading Halt</category>
+      <description>Trading halt request.</description>
+    </item>
+  </channel>
+</rss>
+"#;
+
+const ANNOUNCEMENTS_JSON: &str = r#"
+{
+  "data": {
+    "items": [
+      {
+        "announcementTypes": ["End of Day"],
+        "date": "2026-05-29T09:30:19.000Z",
+        "documentKey": "2924-03095499-6A1327670",
+        "headline": "End of Day",
+        "isPriceSensitive": false,
+        "symbol": "ZOR"
+      },
+      {
+        "announcementTypes": ["Final Director's Interest Notice"],
+        "date": "2026-05-29T09:27:04.000Z",
+        "documentKey": "2924-03095498-6A1327673",
+        "headline": "Final Director's Interest Notice",
+        "isPriceSensitive": false,
+        "symbol": "MTL"
+      }
+    ]
+  }
+}
+"#;
+
+async fn serve_announcements_once(body: &'static str) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fixture server");
+    let addr = listener.local_addr().expect("fixture server address");
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).await.expect("read request");
+        let request = String::from_utf8_lossy(&request[..read]);
+        assert!(request.starts_with("GET /announcements.xml HTTP/1.1"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("user-agent: au-kpis-adapter-asx/")
+        );
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: application/rss+xml\r\ncontent-length: {}\r\n\r\n{}",
+            body.len(),
+            body
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response");
+    });
+
+    format!("http://{addr}/announcements.xml")
+}
+
+#[test]
+fn parse_announcements_rss_resolves_tickers_and_market_metadata() {
+    let announcements =
+        AsxAdapter::parse_announcements_feed(ANNOUNCEMENTS_RSS).expect("parse ASX RSS");
+
+    let snapshot = announcements
+        .iter()
+        .map(|announcement| {
+            json!({
+                "announcement_id": announcement.announcement_id,
+                "ticker": announcement.ticker,
+                "title": announcement.title,
+                "category": announcement.category,
+                "published_at": announcement.published_at.to_rfc3339(),
+                "market_sensitive": announcement.market_sensitive,
+                "source_url": announcement.source_url,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(announcements.len(), 2);
+    assert_eq!(announcements[0].ticker, "BHP");
+    assert_eq!(announcements[1].ticker, "CBA");
+    insta::assert_json_snapshot!(snapshot);
+}
+
+#[test]
+fn parse_announcements_json_feed_resolves_tickers_and_document_urls() {
+    let announcements =
+        AsxAdapter::parse_announcements_feed(ANNOUNCEMENTS_JSON).expect("parse ASX JSON feed");
+
+    assert_eq!(announcements.len(), 2);
+    assert_eq!(announcements[0].ticker, "ZOR");
+    assert_eq!(announcements[0].announcement_id, "2924-03095499-6A1327670");
+    assert_eq!(
+        announcements[0].source_url,
+        "https://asx.api.markitdigital.com/asx-research/1.0/file/2924-03095499-6A1327670"
+    );
+    assert_eq!(announcements[1].ticker, "MTL");
+    assert_eq!(
+        announcements[1].category.as_deref(),
+        Some("Final Director's Interest Notice")
+    );
+}
+
+#[test]
+fn discoverable_jobs_skip_known_feed_revision_and_emit_eod_daily_job() {
+    let announcements =
+        AsxAdapter::parse_announcements_feed(ANNOUNCEMENTS_RSS).expect("parse ASX RSS");
+    let eod_file = AsxEodFile::new(
+        "https://data.example.invalid/asx/eod/20260529.csv",
+        NaiveDate::from_ymd_opt(2026, 5, 29).unwrap(),
+        Utc.with_ymd_and_hms(2026, 5, 29, 8, 0, 0).unwrap(),
+    );
+    let known_revisions = BTreeMap::from([(
+        "ASX:ANNOUNCEMENTS:FEED".to_string(),
+        AsxRevision::new(
+            "2026-05-29T01:15:00Z:06abc123",
+            Some("2026-05-29T01:15:00Z"),
+        ),
+    )]);
+
+    let jobs = AsxAdapter::discoverable_jobs_with_started_at(
+        &announcements,
+        &[eod_file],
+        &known_revisions,
+        Utc.with_ymd_and_hms(2026, 5, 29, 8, 5, 0).unwrap(),
+        Some(TRACE_PARENT),
+    );
+
+    assert_eq!(jobs.len(), 1);
+    assert_eq!(jobs[0].source_id.as_str(), "asx");
+    assert_eq!(jobs[0].dataflow_id.as_str(), "asx.eod");
+    assert_eq!(jobs[0].trace_parent.as_deref(), Some(TRACE_PARENT));
+    assert_eq!(jobs[0].metadata["artifact_kind"], "eod_csv");
+    assert_eq!(jobs[0].metadata["revision_key"], "ASX:EOD:2026-05-29");
+    assert_eq!(jobs[0].metadata["trading_date"], "2026-05-29");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn discover_scrapes_announcements_feed_and_schedules_eod_file() {
+    let announcements_feed_url = serve_announcements_once(ANNOUNCEMENTS_RSS).await;
+    let adapter = AsxAdapter::builder()
+        .announcements_feed_url(&announcements_feed_url)
+        .eod_file_url("https://data.example.invalid/asx/eod/latest.csv")
+        .build();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = DiscoveryCtx::new(http, Utc.with_ymd_and_hms(2026, 5, 29, 8, 5, 0).unwrap())
+        .with_trace_parent(TRACE_PARENT);
+
+    let jobs = adapter.discover(&ctx).await.expect("discover ASX feeds");
+
+    assert_eq!(jobs.len(), 2);
+    assert_eq!(jobs[0].dataflow_id.as_str(), "asx.announcements");
+    assert_eq!(jobs[0].metadata["artifact_kind"], "announcements_rss");
+    assert_eq!(jobs[0].metadata["latest_ticker"], "BHP");
+    assert_eq!(jobs[1].dataflow_id.as_str(), "asx.eod");
+    assert_eq!(jobs[1].metadata["artifact_kind"], "eod_csv");
+}
+
+#[test]
+fn manifest_declares_asx_rate_limit_and_dataflow_metadata() {
+    let adapter = AsxAdapter::default();
+    let manifest = adapter.manifest();
+
+    assert_eq!(manifest.source_id.as_str(), "asx");
+    assert_eq!(manifest.rate_limit.max_requests, 30);
+    assert_eq!(manifest.rate_limit.per, Duration::from_secs(60));
+    assert_eq!(
+        manifest
+            .dataflows
+            .iter()
+            .map(|id| id.as_str())
+            .collect::<Vec<_>>(),
+        vec!["asx.announcements", "asx.eod"]
+    );
+
+    let dataflows = adapter.dataflow_metadata();
+    assert_eq!(dataflows.len(), 2);
+    assert_eq!(dataflows[0].id.as_str(), "asx.announcements");
+    assert_eq!(dataflows[1].id.as_str(), "asx.eod");
+    assert!(
+        dataflows
+            .iter()
+            .all(|dataflow| dataflow.attribution == "Source: ASX")
+    );
+}

--- a/crates/adapters/asx/tests/fetch.rs
+++ b/crates/adapters/asx/tests/fetch.rs
@@ -1,0 +1,134 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use au_kpis_adapter::{AdapterError, AdapterHttpClient, ArtifactRecorder, FetchCtx, SourceAdapter};
+use au_kpis_adapter_asx::{AsxAdapter, AsxEodFile};
+use au_kpis_domain::{Artifact, ArtifactId};
+use au_kpis_storage::{BlobStore, StorageKey};
+use bytes::Bytes;
+use chrono::{NaiveDate, TimeZone, Utc};
+use object_store::{ObjectStore, memory::InMemory, path::Path as ObjectPath};
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    net::TcpListener,
+};
+
+const EOD_CSV: &[u8] = b"ticker,date,open,high,low,close,volume,company_name\nBHP,2026-05-29,42.10,42.80,41.95,42.55,18234567,BHP Group Limited\n";
+
+#[derive(Debug, Default)]
+struct RecordingArtifactRecorder {
+    artifacts: tokio::sync::Mutex<Vec<Artifact>>,
+}
+
+#[async_trait]
+impl ArtifactRecorder for RecordingArtifactRecorder {
+    async fn get(&self, id: ArtifactId) -> Result<Option<Artifact>, AdapterError> {
+        Ok(self
+            .artifacts
+            .lock()
+            .await
+            .iter()
+            .find(|artifact| artifact.id == id)
+            .cloned())
+    }
+
+    async fn record(&self, artifact: &Artifact) -> Result<Artifact, AdapterError> {
+        self.artifacts.lock().await.push(artifact.clone());
+        Ok(artifact.clone())
+    }
+
+    async fn repair_storage_key(
+        &self,
+        artifact: &Artifact,
+        _observed_storage_key: &str,
+    ) -> Result<Artifact, AdapterError> {
+        Ok(artifact.clone())
+    }
+}
+
+async fn serve_artifact_once(body: &'static [u8]) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind fixture server");
+    let addr = listener.local_addr().expect("fixture server address");
+
+    tokio::spawn(async move {
+        let (mut stream, _) = listener.accept().await.expect("accept request");
+        let mut request = [0_u8; 4096];
+        let read = stream.read(&mut request).await.expect("read request");
+        let request = String::from_utf8_lossy(&request[..read]);
+        assert!(request.starts_with("GET /asx/eod/latest.csv HTTP/1.1"));
+        assert!(
+            request
+                .to_ascii_lowercase()
+                .contains("user-agent: au-kpis-adapter-asx/")
+        );
+
+        let response = format!(
+            "HTTP/1.1 200 OK\r\ncontent-type: text/csv\r\nx-asx-fixture: eod\r\ncontent-length: {}\r\n\r\n",
+            body.len(),
+        );
+        stream
+            .write_all(response.as_bytes())
+            .await
+            .expect("write response headers");
+        stream.write_all(body).await.expect("write response body");
+    });
+
+    format!("http://{addr}/asx/eod/latest.csv")
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn fetch_persists_raw_asx_eod_csv_artifact_with_response_headers() {
+    let eod_url = serve_artifact_once(EOD_CSV).await;
+    let adapter = AsxAdapter::builder().eod_file_url(&eod_url).build();
+    let eod_file = AsxEodFile::new(
+        &eod_url,
+        NaiveDate::from_ymd_opt(2026, 5, 29).unwrap(),
+        Utc.with_ymd_and_hms(2026, 5, 29, 8, 0, 0).unwrap(),
+    );
+    let job = AsxAdapter::current_jobs_with_started_at(
+        &[],
+        &[eod_file],
+        Utc.with_ymd_and_hms(2026, 5, 29, 8, 5, 0).unwrap(),
+    )
+    .into_iter()
+    .next()
+    .expect("EOD job emitted");
+    let recorder = Arc::new(RecordingArtifactRecorder::default());
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let blob_store = BlobStore::from_arc(object_store.clone());
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = FetchCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 8, 6, 0).unwrap(),
+        recorder.clone(),
+    );
+
+    let artifact = adapter
+        .fetch(job.clone(), &ctx)
+        .await
+        .expect("fetch EOD CSV");
+
+    assert_eq!(artifact.source_id.as_str(), "asx");
+    assert_eq!(artifact.source_url, job.source_url);
+    assert_eq!(artifact.content_type, "text/csv");
+    assert_eq!(artifact.response_headers["x-asx-fixture"], vec!["eod"]);
+    assert_eq!(artifact.size_bytes, EOD_CSV.len() as u64);
+    assert_eq!(artifact.id, ArtifactId::of_content(EOD_CSV));
+    assert_eq!(
+        artifact.storage_key,
+        StorageKey::canonical_for(&artifact.id).to_string()
+    );
+
+    let stored = object_store
+        .get(&ObjectPath::from(artifact.storage_key.clone()))
+        .await
+        .expect("stored artifact")
+        .bytes()
+        .await
+        .expect("artifact bytes");
+    assert_eq!(stored, Bytes::from_static(EOD_CSV));
+    assert_eq!(recorder.artifacts.lock().await.len(), 1);
+}

--- a/crates/adapters/asx/tests/parse.rs
+++ b/crates/adapters/asx/tests/parse.rs
@@ -1,0 +1,255 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use au_kpis_adapter::{AdapterHttpClient, ArtifactRef, ParseCtx, SourceAdapter};
+use au_kpis_adapter_asx::AsxAdapter;
+use au_kpis_domain::{ArtifactId, SourceId, TimePrecision};
+use au_kpis_storage::{BlobStore, StorageKey};
+use bytes::Bytes;
+use chrono::{TimeZone, Utc};
+use futures::StreamExt;
+use object_store::memory::InMemory;
+use serde::Serialize;
+
+const ANNOUNCEMENTS_RSS: &[u8] = br#"
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:asx="https://www.asx.com.au/rss">
+  <channel>
+    <item>
+      <title>BHP: Quarterly activities report</title>
+      <link>https://www.asx.com.au/asxpdf/20260529/pdf/06abc123.pdf</link>
+      <guid>06abc123</guid>
+      <pubDate>Fri, 29 May 2026 01:15:00 GMT</pubDate>
+      <category>Periodic Reports</category>
+      <asx:code>BHP</asx:code>
+      <asx:marketSensitive>true</asx:marketSensitive>
+      <description>Quarterly operating update.</description>
+    </item>
+    <item>
+      <title>CBA: Trading halt</title>
+      <link>https://www.asx.com.au/asxpdf/20260529/pdf/06def456.pdf</link>
+      <guid>06def456</guid>
+      <pubDate>Fri, 29 May 2026 00:45:00 GMT</pubDate>
+      <category>Trading Halt</category>
+      <description>Trading halt request.</description>
+    </item>
+  </channel>
+</rss>
+"#;
+
+const EOD_CSV: &[u8] = br#"ticker,date,open,high,low,close,volume,company_name
+BHP,2026-05-29,42.10,42.80,41.95,42.55,18234567,BHP Group Limited
+CBA,2026-05-29,169.25,170.10,168.40,169.80,3250123,Commonwealth Bank of Australia
+"#;
+
+#[derive(Debug, Serialize)]
+struct FixtureSnapshot {
+    observation_count: usize,
+    series_count: usize,
+    first_rows: Vec<SnapshotRow>,
+}
+
+#[derive(Debug, Serialize)]
+struct SnapshotRow {
+    dataflow_id: String,
+    measure_id: String,
+    dimensions: BTreeMap<String, String>,
+    unit: String,
+    time: String,
+    time_precision: String,
+    value: Option<f64>,
+    status: String,
+    attributes: BTreeMap<String, String>,
+    source_artifact_id: String,
+}
+
+async fn artifact_for(
+    blob_store: &BlobStore,
+    bytes: &'static [u8],
+    source_url: &str,
+    content_type: &str,
+) -> ArtifactRef {
+    let id = blob_store
+        .put_artifact(Bytes::from_static(bytes))
+        .await
+        .expect("store fixture artifact");
+    ArtifactRef {
+        id,
+        source_id: SourceId::new("asx").unwrap(),
+        source_url: source_url.into(),
+        content_type: content_type.into(),
+        response_headers: BTreeMap::new(),
+        storage_key: StorageKey::canonical_for(&id).to_string(),
+        size_bytes: bytes.len() as u64,
+        fetched_at: Utc.with_ymd_and_hms(2026, 5, 29, 8, 0, 0).unwrap(),
+    }
+}
+
+async fn snapshot_fixture(
+    artifact: ArtifactRef,
+    blob_store: BlobStore,
+    dataflow: &str,
+) -> FixtureSnapshot {
+    let adapter = AsxAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 8, 5, 0).unwrap(),
+    )
+    .with_expected_dataflow(
+        au_kpis_domain::DataflowId::new(dataflow).unwrap(),
+        BTreeMap::from([("test_dataflow".into(), dataflow.into())]),
+    );
+    let rows = adapter
+        .parse(artifact, &ctx)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("parse ASX fixture");
+
+    assert!(
+        rows.iter()
+            .all(|(_, observation)| observation.time_precision == TimePrecision::Day)
+    );
+    let series_count = rows
+        .iter()
+        .map(|(series, _)| series.series_key)
+        .collect::<BTreeSet<_>>()
+        .len();
+    let first_rows = rows
+        .iter()
+        .take(12)
+        .map(|(series, observation)| SnapshotRow {
+            dataflow_id: series.dataflow_id.as_str().to_string(),
+            measure_id: series.measure_id.as_str().to_string(),
+            dimensions: series
+                .dimensions
+                .iter()
+                .map(|(key, value)| (key.as_str().to_string(), value.as_str().to_string()))
+                .collect(),
+            unit: series.unit.clone(),
+            time: observation.time.to_rfc3339(),
+            time_precision: format!("{:?}", observation.time_precision),
+            value: observation.value,
+            status: format!("{:?}", observation.status),
+            attributes: observation.attributes.clone(),
+            source_artifact_id: observation.source_artifact_id.to_hex(),
+        })
+        .collect();
+
+    FixtureSnapshot {
+        observation_count: rows.len(),
+        series_count,
+        first_rows,
+    }
+}
+
+#[tokio::test]
+async fn parses_asx_announcements_and_eod_fixtures() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let announcement_artifact = artifact_for(
+        &blob_store,
+        ANNOUNCEMENTS_RSS,
+        "https://www.asx.com.au/announcements.xml",
+        "application/rss+xml",
+    )
+    .await;
+    let eod_artifact = artifact_for(
+        &blob_store,
+        EOD_CSV,
+        "https://data.example.invalid/asx/eod/latest.csv",
+        "text/csv",
+    )
+    .await;
+
+    let announcements = snapshot_fixture(
+        announcement_artifact,
+        blob_store.clone(),
+        "asx.announcements",
+    )
+    .await;
+    let eod = snapshot_fixture(eod_artifact, blob_store.clone(), "asx.eod").await;
+
+    assert_eq!(announcements.observation_count, 2);
+    assert_eq!(eod.observation_count, 10);
+    insta::assert_json_snapshot!("announcements_rss", announcements);
+    insta::assert_json_snapshot!("eod_csv", eod);
+}
+
+#[tokio::test]
+async fn parse_rejects_ambiguous_asx_provenance() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let mut artifact = artifact_for(
+        &blob_store,
+        ANNOUNCEMENTS_RSS,
+        "https://mirror.example.invalid/announcements.xml",
+        "application/rss+xml",
+    )
+    .await;
+    artifact.source_id = SourceId::new("rba").unwrap();
+
+    let adapter = AsxAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 8, 5, 0).unwrap(),
+    );
+    let err = adapter
+        .parse(artifact, &ctx)
+        .next()
+        .await
+        .expect("one parse result")
+        .expect_err("invalid provenance should fail");
+
+    assert!(
+        err.to_string()
+            .contains("ASX parse received artifact for source")
+    );
+}
+
+#[tokio::test]
+async fn parse_rejects_artifact_id_storage_key_mismatch() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let actual_id = blob_store
+        .put_artifact(Bytes::from_static(EOD_CSV))
+        .await
+        .expect("store fixture artifact");
+    let wrong_id = ArtifactId::of_content(b"different ASX artifact");
+    assert_ne!(actual_id, wrong_id);
+
+    let artifact = ArtifactRef {
+        id: wrong_id,
+        source_id: SourceId::new("asx").unwrap(),
+        source_url: "https://data.example.invalid/asx/eod/latest.csv".into(),
+        content_type: "text/csv".into(),
+        response_headers: BTreeMap::new(),
+        storage_key: StorageKey::canonical_for(&actual_id).to_string(),
+        size_bytes: EOD_CSV.len() as u64,
+        fetched_at: Utc.with_ymd_and_hms(2026, 5, 29, 8, 0, 0).unwrap(),
+    };
+    let adapter = AsxAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 8, 5, 0).unwrap(),
+    )
+    .with_expected_dataflow(
+        au_kpis_domain::DataflowId::new("asx.eod").unwrap(),
+        BTreeMap::new(),
+    );
+
+    let err = adapter
+        .parse(artifact, &ctx)
+        .next()
+        .await
+        .expect("one parse result")
+        .expect_err("mismatched storage key should fail");
+
+    assert!(
+        err.to_string().contains("does not match artifact id"),
+        "{err}"
+    );
+}

--- a/crates/adapters/asx/tests/parse.rs
+++ b/crates/adapters/asx/tests/parse.rs
@@ -41,6 +41,10 @@ BHP,2026-05-29,42.10,42.80,41.95,42.55,18234567,BHP Group Limited
 CBA,2026-05-29,169.25,170.10,168.40,169.80,3250123,Commonwealth Bank of Australia
 "#;
 
+const EOD_ENTITY_NAME_CSV: &[u8] = br#"ticker,date,open,high,low,close,volume,entity_name
+ABC,29/05/2026,-,,1,2,"1,234",ABC Limited
+"#;
+
 #[derive(Debug, Serialize)]
 struct FixtureSnapshot {
     observation_count: usize,
@@ -175,6 +179,43 @@ async fn parses_asx_announcements_and_eod_fixtures() {
     assert_eq!(eod.observation_count, 10);
     insta::assert_json_snapshot!("announcements_rss", announcements);
     insta::assert_json_snapshot!("eod_csv", eod);
+}
+
+#[tokio::test]
+async fn parses_eod_entity_name_slash_dates_and_missing_values() {
+    let blob_store = BlobStore::new(InMemory::new());
+    let eod_artifact = artifact_for(
+        &blob_store,
+        EOD_ENTITY_NAME_CSV,
+        "https://data.example.invalid/asx/eod/entity-name.csv",
+        "text/csv",
+    )
+    .await;
+
+    let adapter = AsxAdapter::default();
+    let http = AdapterHttpClient::new(adapter.manifest().rate_limit);
+    let ctx = ParseCtx::new(
+        http,
+        blob_store,
+        Utc.with_ymd_and_hms(2026, 5, 29, 8, 5, 0).unwrap(),
+    )
+    .with_expected_dataflow(
+        au_kpis_domain::DataflowId::new("asx.eod").unwrap(),
+        BTreeMap::new(),
+    );
+    let rows = adapter
+        .parse(eod_artifact, &ctx)
+        .collect::<Vec<_>>()
+        .await
+        .into_iter()
+        .collect::<Result<Vec<_>, _>>()
+        .expect("parse alternate ASX EOD fixture");
+
+    assert_eq!(rows.len(), 5);
+    assert_eq!(rows[0].1.time.to_rfc3339(), "2026-05-29T00:00:00+00:00");
+    assert_eq!(rows[0].1.value, None);
+    assert_eq!(rows[1].1.value, None);
+    assert_eq!(rows[4].1.value, Some(1234.0));
 }
 
 #[tokio::test]

--- a/crates/adapters/asx/tests/snapshots/discover__parse_announcements_rss_resolves_tickers_and_market_metadata.snap
+++ b/crates/adapters/asx/tests/snapshots/discover__parse_announcements_rss_resolves_tickers_and_market_metadata.snap
@@ -1,0 +1,24 @@
+---
+source: crates/adapters/asx/tests/discover.rs
+expression: snapshot
+---
+[
+  {
+    "announcement_id": "06abc123",
+    "category": "Periodic Reports",
+    "market_sensitive": true,
+    "published_at": "2026-05-29T01:15:00+00:00",
+    "source_url": "https://www.asx.com.au/asxpdf/20260529/pdf/06abc123.pdf",
+    "ticker": "BHP",
+    "title": "BHP: Quarterly activities report"
+  },
+  {
+    "announcement_id": "06def456",
+    "category": "Trading Halt",
+    "market_sensitive": null,
+    "published_at": "2026-05-29T00:45:00+00:00",
+    "source_url": "https://www.asx.com.au/asxpdf/20260529/pdf/06def456.pdf",
+    "ticker": "CBA",
+    "title": "CBA: Trading halt"
+  }
+]

--- a/crates/adapters/asx/tests/snapshots/parse__announcements_rss.snap
+++ b/crates/adapters/asx/tests/snapshots/parse__announcements_rss.snap
@@ -1,0 +1,57 @@
+---
+source: crates/adapters/asx/tests/parse.rs
+expression: announcements
+---
+{
+  "observation_count": 2,
+  "series_count": 2,
+  "first_rows": [
+    {
+      "dataflow_id": "asx.announcements",
+      "measure_id": "event_count",
+      "dimensions": {
+        "announcement_id": "06abc123",
+        "category": "Periodic Reports",
+        "ticker": "BHP"
+      },
+      "unit": "announcement",
+      "time": "2026-05-29T01:15:00+00:00",
+      "time_precision": "Day",
+      "value": 1.0,
+      "status": "Normal",
+      "attributes": {
+        "announcement_id": "06abc123",
+        "category": "Periodic Reports",
+        "description": "Quarterly operating update.",
+        "market_sensitive": "true",
+        "source_url": "https://www.asx.com.au/asxpdf/20260529/pdf/06abc123.pdf",
+        "ticker": "BHP",
+        "title": "BHP: Quarterly activities report"
+      },
+      "source_artifact_id": "8d63efbc88862f57adab575a9c0d7cda961989d2c51320933e5dc4f7f5cf5a58"
+    },
+    {
+      "dataflow_id": "asx.announcements",
+      "measure_id": "event_count",
+      "dimensions": {
+        "announcement_id": "06def456",
+        "category": "Trading Halt",
+        "ticker": "CBA"
+      },
+      "unit": "announcement",
+      "time": "2026-05-29T00:45:00+00:00",
+      "time_precision": "Day",
+      "value": 1.0,
+      "status": "Normal",
+      "attributes": {
+        "announcement_id": "06def456",
+        "category": "Trading Halt",
+        "description": "Trading halt request.",
+        "source_url": "https://www.asx.com.au/asxpdf/20260529/pdf/06def456.pdf",
+        "ticker": "CBA",
+        "title": "CBA: Trading halt"
+      },
+      "source_artifact_id": "8d63efbc88862f57adab575a9c0d7cda961989d2c51320933e5dc4f7f5cf5a58"
+    }
+  ]
+}

--- a/crates/adapters/asx/tests/snapshots/parse__eod_csv.snap
+++ b/crates/adapters/asx/tests/snapshots/parse__eod_csv.snap
@@ -1,0 +1,230 @@
+---
+source: crates/adapters/asx/tests/parse.rs
+expression: eod
+---
+{
+  "observation_count": 10,
+  "series_count": 10,
+  "first_rows": [
+    {
+      "dataflow_id": "asx.eod",
+      "measure_id": "value",
+      "dimensions": {
+        "entity_name": "BHP Group Limited",
+        "metric": "open",
+        "ticker": "BHP"
+      },
+      "unit": "AUD",
+      "time": "2026-05-29T00:00:00+00:00",
+      "time_precision": "Day",
+      "value": 42.1,
+      "status": "Normal",
+      "attributes": {
+        "company_name": "BHP Group Limited",
+        "metric": "open",
+        "source_url": "https://data.example.invalid/asx/eod/latest.csv",
+        "ticker": "BHP",
+        "trading_date": "2026-05-29"
+      },
+      "source_artifact_id": "33225d406768bc9190f1d974878130cc39a9a9906730db74a6365d3271dc6c96"
+    },
+    {
+      "dataflow_id": "asx.eod",
+      "measure_id": "value",
+      "dimensions": {
+        "entity_name": "BHP Group Limited",
+        "metric": "high",
+        "ticker": "BHP"
+      },
+      "unit": "AUD",
+      "time": "2026-05-29T00:00:00+00:00",
+      "time_precision": "Day",
+      "value": 42.8,
+      "status": "Normal",
+      "attributes": {
+        "company_name": "BHP Group Limited",
+        "metric": "high",
+        "source_url": "https://data.example.invalid/asx/eod/latest.csv",
+        "ticker": "BHP",
+        "trading_date": "2026-05-29"
+      },
+      "source_artifact_id": "33225d406768bc9190f1d974878130cc39a9a9906730db74a6365d3271dc6c96"
+    },
+    {
+      "dataflow_id": "asx.eod",
+      "measure_id": "value",
+      "dimensions": {
+        "entity_name": "BHP Group Limited",
+        "metric": "low",
+        "ticker": "BHP"
+      },
+      "unit": "AUD",
+      "time": "2026-05-29T00:00:00+00:00",
+      "time_precision": "Day",
+      "value": 41.95,
+      "status": "Normal",
+      "attributes": {
+        "company_name": "BHP Group Limited",
+        "metric": "low",
+        "source_url": "https://data.example.invalid/asx/eod/latest.csv",
+        "ticker": "BHP",
+        "trading_date": "2026-05-29"
+      },
+      "source_artifact_id": "33225d406768bc9190f1d974878130cc39a9a9906730db74a6365d3271dc6c96"
+    },
+    {
+      "dataflow_id": "asx.eod",
+      "measure_id": "value",
+      "dimensions": {
+        "entity_name": "BHP Group Limited",
+        "metric": "close",
+        "ticker": "BHP"
+      },
+      "unit": "AUD",
+      "time": "2026-05-29T00:00:00+00:00",
+      "time_precision": "Day",
+      "value": 42.55,
+      "status": "Normal",
+      "attributes": {
+        "company_name": "BHP Group Limited",
+        "metric": "close",
+        "source_url": "https://data.example.invalid/asx/eod/latest.csv",
+        "ticker": "BHP",
+        "trading_date": "2026-05-29"
+      },
+      "source_artifact_id": "33225d406768bc9190f1d974878130cc39a9a9906730db74a6365d3271dc6c96"
+    },
+    {
+      "dataflow_id": "asx.eod",
+      "measure_id": "value",
+      "dimensions": {
+        "entity_name": "BHP Group Limited",
+        "metric": "volume",
+        "ticker": "BHP"
+      },
+      "unit": "shares",
+      "time": "2026-05-29T00:00:00+00:00",
+      "time_precision": "Day",
+      "value": 18234567.0,
+      "status": "Normal",
+      "attributes": {
+        "company_name": "BHP Group Limited",
+        "metric": "volume",
+        "source_url": "https://data.example.invalid/asx/eod/latest.csv",
+        "ticker": "BHP",
+        "trading_date": "2026-05-29"
+      },
+      "source_artifact_id": "33225d406768bc9190f1d974878130cc39a9a9906730db74a6365d3271dc6c96"
+    },
+    {
+      "dataflow_id": "asx.eod",
+      "measure_id": "value",
+      "dimensions": {
+        "entity_name": "Commonwealth Bank of Australia",
+        "metric": "open",
+        "ticker": "CBA"
+      },
+      "unit": "AUD",
+      "time": "2026-05-29T00:00:00+00:00",
+      "time_precision": "Day",
+      "value": 169.25,
+      "status": "Normal",
+      "attributes": {
+        "company_name": "Commonwealth Bank of Australia",
+        "metric": "open",
+        "source_url": "https://data.example.invalid/asx/eod/latest.csv",
+        "ticker": "CBA",
+        "trading_date": "2026-05-29"
+      },
+      "source_artifact_id": "33225d406768bc9190f1d974878130cc39a9a9906730db74a6365d3271dc6c96"
+    },
+    {
+      "dataflow_id": "asx.eod",
+      "measure_id": "value",
+      "dimensions": {
+        "entity_name": "Commonwealth Bank of Australia",
+        "metric": "high",
+        "ticker": "CBA"
+      },
+      "unit": "AUD",
+      "time": "2026-05-29T00:00:00+00:00",
+      "time_precision": "Day",
+      "value": 170.1,
+      "status": "Normal",
+      "attributes": {
+        "company_name": "Commonwealth Bank of Australia",
+        "metric": "high",
+        "source_url": "https://data.example.invalid/asx/eod/latest.csv",
+        "ticker": "CBA",
+        "trading_date": "2026-05-29"
+      },
+      "source_artifact_id": "33225d406768bc9190f1d974878130cc39a9a9906730db74a6365d3271dc6c96"
+    },
+    {
+      "dataflow_id": "asx.eod",
+      "measure_id": "value",
+      "dimensions": {
+        "entity_name": "Commonwealth Bank of Australia",
+        "metric": "low",
+        "ticker": "CBA"
+      },
+      "unit": "AUD",
+      "time": "2026-05-29T00:00:00+00:00",
+      "time_precision": "Day",
+      "value": 168.4,
+      "status": "Normal",
+      "attributes": {
+        "company_name": "Commonwealth Bank of Australia",
+        "metric": "low",
+        "source_url": "https://data.example.invalid/asx/eod/latest.csv",
+        "ticker": "CBA",
+        "trading_date": "2026-05-29"
+      },
+      "source_artifact_id": "33225d406768bc9190f1d974878130cc39a9a9906730db74a6365d3271dc6c96"
+    },
+    {
+      "dataflow_id": "asx.eod",
+      "measure_id": "value",
+      "dimensions": {
+        "entity_name": "Commonwealth Bank of Australia",
+        "metric": "close",
+        "ticker": "CBA"
+      },
+      "unit": "AUD",
+      "time": "2026-05-29T00:00:00+00:00",
+      "time_precision": "Day",
+      "value": 169.8,
+      "status": "Normal",
+      "attributes": {
+        "company_name": "Commonwealth Bank of Australia",
+        "metric": "close",
+        "source_url": "https://data.example.invalid/asx/eod/latest.csv",
+        "ticker": "CBA",
+        "trading_date": "2026-05-29"
+      },
+      "source_artifact_id": "33225d406768bc9190f1d974878130cc39a9a9906730db74a6365d3271dc6c96"
+    },
+    {
+      "dataflow_id": "asx.eod",
+      "measure_id": "value",
+      "dimensions": {
+        "entity_name": "Commonwealth Bank of Australia",
+        "metric": "volume",
+        "ticker": "CBA"
+      },
+      "unit": "shares",
+      "time": "2026-05-29T00:00:00+00:00",
+      "time_precision": "Day",
+      "value": 3250123.0,
+      "status": "Normal",
+      "attributes": {
+        "company_name": "Commonwealth Bank of Australia",
+        "metric": "volume",
+        "source_url": "https://data.example.invalid/asx/eod/latest.csv",
+        "ticker": "CBA",
+        "trading_date": "2026-05-29"
+      },
+      "source_artifact_id": "33225d406768bc9190f1d974878130cc39a9a9906730db74a6365d3271dc6c96"
+    }
+  ]
+}

--- a/crates/au-kpis-api-http/tests/observations.rs
+++ b/crates/au-kpis-api-http/tests/observations.rs
@@ -426,6 +426,7 @@ impl TestDb {
             match au_kpis_db::connect(&cfg).await {
                 Ok(pool) => {
                     au_kpis_db::migrate(&pool).await.expect("apply migrations");
+                    disable_rollup_policies(&pool).await;
                     return Self {
                         pool,
                         _timescale: timescale,
@@ -442,6 +443,20 @@ impl TestDb {
 
     fn pool(&self) -> &PgPool {
         &self.pool
+    }
+}
+
+async fn disable_rollup_policies(pool: &PgPool) {
+    for view in [
+        "observations_rollup_weekly",
+        "observations_rollup_monthly",
+        "observations_rollup_quarterly",
+    ] {
+        sqlx::query("SELECT remove_continuous_aggregate_policy($1::regclass, if_exists => TRUE)")
+            .bind(view)
+            .execute(pool)
+            .await
+            .expect("remove continuous aggregate policy in observations test database");
     }
 }
 

--- a/crates/au-kpis-api-http/tests/subscriptions.rs
+++ b/crates/au-kpis-api-http/tests/subscriptions.rs
@@ -166,11 +166,16 @@ async fn due_webhook_deliveries_are_hmac_signed_and_marked_delivered() {
         .await
         .expect("enqueue deliveries");
     assert_eq!(enqueued, 1);
+    let due_at = delivery_state(&ctx.pool, subscription_id)
+        .await
+        .next_attempt_at
+        .expect("initial delivery due timestamp");
+    let now = due_at + ChronoDuration::seconds(1);
 
     let outcome = deliver_due_webhooks(
         &ctx.pool,
         &reqwest::Client::new(),
-        Utc.with_ymd_and_hms(2026, 5, 29, 10, 0, 1).unwrap(),
+        now,
         DeliveryOptions {
             max_attempts: 3,
             base_backoff: Duration::from_secs(10),
@@ -242,7 +247,11 @@ async fn failed_webhook_deliveries_retry_with_exponential_backoff_and_stop_after
         .await
         .expect("enqueue delivery");
 
-    let now = Utc.with_ymd_and_hms(2026, 5, 29, 11, 0, 1).unwrap();
+    let due_at = delivery_state(&ctx.pool, subscription_id)
+        .await
+        .next_attempt_at
+        .expect("initial delivery due timestamp");
+    let now = due_at + ChronoDuration::seconds(1);
     let options = DeliveryOptions {
         max_attempts: 2,
         base_backoff: Duration::from_secs(10),

--- a/crates/bins/au-kpis-ingestion/Cargo.toml
+++ b/crates/bins/au-kpis-ingestion/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1"
 au-kpis-adapter = { workspace = true }
 au-kpis-adapter-abs = { path = "../../adapters/abs" }
 au-kpis-adapter-apra = { path = "../../adapters/apra" }
+au-kpis-adapter-asx = { path = "../../adapters/asx" }
 au-kpis-adapter-rba = { path = "../../adapters/rba" }
 au-kpis-adapter-state-budgets = { path = "../../adapters/state-budgets" }
 au-kpis-adapter-treasury = { path = "../../adapters/treasury" }

--- a/crates/bins/au-kpis-ingestion/src/main.rs
+++ b/crates/bins/au-kpis-ingestion/src/main.rs
@@ -20,6 +20,7 @@ use anyhow::{Context, bail};
 use au_kpis_adapter::{AdapterError, AdapterHttpClient, Adapters, DiscoveryCtx, ParseCtx};
 use au_kpis_adapter_abs::AbsAdapter;
 use au_kpis_adapter_apra::ApraAdapter;
+use au_kpis_adapter_asx::AsxAdapter;
 use au_kpis_adapter_rba::RbaAdapter;
 use au_kpis_adapter_state_budgets::StateBudgetsAdapter;
 use au_kpis_adapter_treasury::TreasuryAdapter;
@@ -41,6 +42,10 @@ const ABS_CPI_DATAFLOW_SLUG: &str = "cpi";
 const ABS_CPI_DATAFLOW_ID: &str = "abs.cpi";
 const APRA_QUARTERLY_DATAFLOW_SLUG: &str = "quarterly-statistics";
 const APRA_QUARTERLY_DATAFLOW_ID: &str = "apra.quarterly_statistics";
+const ASX_ANNOUNCEMENTS_DATAFLOW_SLUG: &str = "announcements";
+const ASX_ANNOUNCEMENTS_DATAFLOW_ID: &str = "asx.announcements";
+const ASX_EOD_DATAFLOW_SLUG: &str = "eod";
+const ASX_EOD_DATAFLOW_ID: &str = "asx.eod";
 const RBA_STAT_TABLES_DATAFLOW_SLUG: &str = "statistical-tables";
 const RBA_STAT_TABLES_DATAFLOW_ID: &str = "rba.statistical_tables";
 const STATE_BUDGETS_NSW_DATAFLOW_SLUG: &str = "nsw-budget";
@@ -585,6 +590,16 @@ fn build_adapters() -> anyhow::Result<Adapters> {
         Err(_) => ApraAdapter::default(),
     };
     builder.register(apra).context("register APRA adapter")?;
+    let mut asx = AsxAdapter::builder();
+    if let Ok(feed_url) = env::var("AU_KPIS_ASX_ANNOUNCEMENTS_FEED_URL") {
+        asx = asx.announcements_feed_url(feed_url);
+    }
+    if let Ok(eod_file_url) = env::var("AU_KPIS_ASX_EOD_FILE_URL") {
+        asx = asx.eod_file_url(eod_file_url);
+    }
+    builder
+        .register(asx.build())
+        .context("register ASX adapter")?;
     let rba = match env::var("AU_KPIS_RBA_INDEX_URL") {
         Ok(index_url) => RbaAdapter::builder().index_url(index_url).build(),
         Err(_) => RbaAdapter::default(),
@@ -688,6 +703,14 @@ fn validate_once_target(source: &str, dataflow: &str) -> anyhow::Result<()> {
     match source {
         "abs" if dataflow == ABS_CPI_DATAFLOW_SLUG => Ok(()),
         "apra" if dataflow == APRA_QUARTERLY_DATAFLOW_SLUG => Ok(()),
+        "asx"
+            if matches!(
+                dataflow,
+                ASX_ANNOUNCEMENTS_DATAFLOW_SLUG | ASX_EOD_DATAFLOW_SLUG
+            ) =>
+        {
+            Ok(())
+        }
         "rba" if dataflow == RBA_STAT_TABLES_DATAFLOW_SLUG => Ok(()),
         "state-budgets"
             if matches!(
@@ -705,6 +728,9 @@ fn validate_once_target(source: &str, dataflow: &str) -> anyhow::Result<()> {
         ),
         "apra" => bail!(
             "unsupported dataflow `{dataflow}` for source `apra`; supported dataflow: {APRA_QUARTERLY_DATAFLOW_SLUG}"
+        ),
+        "asx" => bail!(
+            "unsupported dataflow `{dataflow}` for source `asx`; supported dataflows: {ASX_ANNOUNCEMENTS_DATAFLOW_SLUG}, {ASX_EOD_DATAFLOW_SLUG}"
         ),
         "rba" => bail!(
             "unsupported dataflow `{dataflow}` for source `rba`; supported dataflow: {RBA_STAT_TABLES_DATAFLOW_SLUG}"
@@ -724,6 +750,8 @@ fn once_run_request(source: &str, dataflow: &str) -> anyhow::Result<RunRequest> 
     let dataflow_id = match source {
         "abs" => ABS_CPI_DATAFLOW_ID,
         "apra" => APRA_QUARTERLY_DATAFLOW_ID,
+        "asx" if dataflow == ASX_ANNOUNCEMENTS_DATAFLOW_SLUG => ASX_ANNOUNCEMENTS_DATAFLOW_ID,
+        "asx" if dataflow == ASX_EOD_DATAFLOW_SLUG => ASX_EOD_DATAFLOW_ID,
         "rba" => RBA_STAT_TABLES_DATAFLOW_ID,
         "state-budgets" if dataflow == STATE_BUDGETS_NSW_DATAFLOW_SLUG => {
             STATE_BUDGETS_NSW_DATAFLOW_ID
@@ -779,10 +807,10 @@ fn job_run_request(kind: &JobKind, trace_parent: Option<&str>) -> anyhow::Result
 fn validate_supported_source(source: &str) -> anyhow::Result<()> {
     if !matches!(
         source,
-        "abs" | "apra" | "rba" | "state-budgets" | "treasury"
+        "abs" | "apra" | "asx" | "rba" | "state-budgets" | "treasury"
     ) {
         bail!(
-            "unsupported source `{source}`; supported sources: abs, apra, rba, state-budgets, treasury"
+            "unsupported source `{source}`; supported sources: abs, apra, asx, rba, state-budgets, treasury"
         );
     }
     Ok(())
@@ -793,6 +821,12 @@ fn validate_supported_dataflow_id(source: &str, dataflow_id: &str) -> anyhow::Re
         return Ok(());
     }
     if source == "apra" && dataflow_id == APRA_QUARTERLY_DATAFLOW_ID {
+        return Ok(());
+    }
+    if source == "asx" && dataflow_id == ASX_ANNOUNCEMENTS_DATAFLOW_ID {
+        return Ok(());
+    }
+    if source == "asx" && dataflow_id == ASX_EOD_DATAFLOW_ID {
         return Ok(());
     }
     if source == "rba" && dataflow_id == RBA_STAT_TABLES_DATAFLOW_ID {
@@ -811,7 +845,7 @@ fn validate_supported_dataflow_id(source: &str, dataflow_id: &str) -> anyhow::Re
         return Ok(());
     }
     bail!(
-        "unsupported dataflow `{dataflow_id}` for source `{source}`; supported dataflows: {ABS_CPI_DATAFLOW_ID}, {APRA_QUARTERLY_DATAFLOW_ID}, {RBA_STAT_TABLES_DATAFLOW_ID}, {STATE_BUDGETS_NSW_DATAFLOW_ID}, {STATE_BUDGETS_VIC_DATAFLOW_ID}, {STATE_BUDGETS_QLD_DATAFLOW_ID}, {TREASURY_BUDGET_DATAFLOW_ID}"
+        "unsupported dataflow `{dataflow_id}` for source `{source}`; supported dataflows: {ABS_CPI_DATAFLOW_ID}, {APRA_QUARTERLY_DATAFLOW_ID}, {ASX_ANNOUNCEMENTS_DATAFLOW_ID}, {ASX_EOD_DATAFLOW_ID}, {RBA_STAT_TABLES_DATAFLOW_ID}, {STATE_BUDGETS_NSW_DATAFLOW_ID}, {STATE_BUDGETS_VIC_DATAFLOW_ID}, {STATE_BUDGETS_QLD_DATAFLOW_ID}, {TREASURY_BUDGET_DATAFLOW_ID}"
     );
 }
 
@@ -995,7 +1029,7 @@ mod tests {
             .expect_err("unsupported source should fail")
             .to_string();
         assert!(err.contains("unsupported source"));
-        assert!(err.contains("abs, apra, rba, state-budgets, treasury"));
+        assert!(err.contains("abs, apra, asx, rba, state-budgets, treasury"));
     }
 
     #[test]
@@ -1067,6 +1101,57 @@ mod tests {
         assert_eq!(
             request.dataflow_id.as_ref(),
             Some(&DataflowId::new("state_budgets.qld_budget").unwrap())
+        );
+    }
+
+    #[test]
+    fn asx_once_mode_resolves_announcements_dataflow() {
+        let request =
+            once_run_request("asx", "announcements").expect("ASX announcements are supported");
+
+        assert_eq!(request.source_id.as_str(), "asx");
+        assert_eq!(
+            request.dataflow_id.as_ref(),
+            Some(&DataflowId::new("asx.announcements").unwrap())
+        );
+    }
+
+    #[test]
+    fn asx_once_mode_resolves_eod_dataflow() {
+        let request = once_run_request("asx", "eod").expect("ASX EOD is supported");
+
+        assert_eq!(request.source_id.as_str(), "asx");
+        assert_eq!(
+            request.dataflow_id.as_ref(),
+            Some(&DataflowId::new("asx.eod").unwrap())
+        );
+    }
+
+    #[test]
+    fn backfill_jobs_accept_asx_scoped_dataflows() {
+        let request = job_run_request(
+            &JobKind::Backfill {
+                source_id: SourceId::new("asx").unwrap(),
+                dataflow_id: Some(DataflowId::new("asx.eod").unwrap()),
+            },
+            None,
+        )
+        .expect("ASX EOD backfill is supported");
+
+        assert_eq!(request.source_id.as_str(), "asx");
+        assert_eq!(
+            request.dataflow_id.as_ref(),
+            Some(&DataflowId::new("asx.eod").unwrap())
+        );
+    }
+
+    #[test]
+    fn build_adapters_registers_asx_source() {
+        let adapters = build_adapters().expect("build production adapters");
+
+        assert!(
+            adapters.get("asx").is_ok(),
+            "production ingestion registry should include ASX"
         );
     }
 

--- a/crates/bins/au-kpis-scheduler/src/main.rs
+++ b/crates/bins/au-kpis-scheduler/src/main.rs
@@ -36,10 +36,12 @@ const SCHEDULER_LEADER_LOCK_ID: i64 = 30_000_030;
 const DEFAULT_TICK_MS: u64 = 1_000;
 const DEFAULT_ABS_INTERVAL_MS: u64 = 60 * 60 * 1_000;
 const DEFAULT_APRA_INTERVAL_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
+const DEFAULT_ASX_INTERVAL_MS: u64 = 15 * 60 * 1_000;
 const DEFAULT_RBA_INTERVAL_MS: u64 = 7 * 24 * 60 * 60 * 1_000;
 const DEFAULT_TREASURY_INTERVAL_MS: u64 = 24 * 60 * 60 * 1_000;
 const ABS_DISCOVERY_CRON: &str = "0 * * * *";
 const APRA_DISCOVERY_CRON: &str = "0 0 * * 1";
+const ASX_DISCOVERY_CRON: &str = "*/15 * * * *";
 const RBA_DISCOVERY_CRON: &str = "0 0 * * 1";
 const TREASURY_DISCOVERY_CRON: &str = "0 0 * * *";
 const DEFAULT_DATA_QUALITY_REPORT_PATH: &str = "target/data-quality/data-quality-report.md";
@@ -72,6 +74,14 @@ struct Cli {
         default_value_t = DEFAULT_APRA_INTERVAL_MS
     )]
     apra_interval_ms: u64,
+
+    /// Test/ops override for the ASX discovery cadence.
+    #[arg(
+        long,
+        env = "AU_KPIS_SCHEDULER_ASX_INTERVAL_MS",
+        default_value_t = DEFAULT_ASX_INTERVAL_MS
+    )]
+    asx_interval_ms: u64,
 
     /// Test/ops override for the RBA discovery cadence.
     #[arg(
@@ -257,6 +267,7 @@ async fn main() -> anyhow::Result<()> {
             Duration::from_millis(cli.rba_interval_ms),
             Duration::from_millis(cli.apra_interval_ms),
             Duration::from_millis(cli.treasury_interval_ms),
+            Duration::from_millis(cli.asx_interval_ms),
         ),
         worker_id: cli.worker_id.unwrap_or_else(default_worker_id),
     };
@@ -471,6 +482,7 @@ fn default_discovery_schedules(
     rba_interval: Duration,
     apra_interval: Duration,
     treasury_interval: Duration,
+    asx_interval: Duration,
 ) -> Vec<DiscoverySchedule> {
     vec![
         DiscoverySchedule {
@@ -496,6 +508,12 @@ fn default_discovery_schedules(
             cron_expression: TREASURY_DISCOVERY_CRON,
             emit_every: treasury_interval,
             job: Job::discover(SourceId::new("treasury").expect("static source id is valid")),
+        },
+        DiscoverySchedule {
+            id: "asx-discovery",
+            cron_expression: ASX_DISCOVERY_CRON,
+            emit_every: asx_interval,
+            job: Job::discover(SourceId::new("asx").expect("static source id is valid")),
         },
     ]
 }
@@ -618,9 +636,10 @@ mod tests {
             Duration::from_secs(604_800),
             Duration::from_secs(604_800),
             Duration::from_secs(86_400),
+            Duration::from_secs(900),
         );
 
-        assert_eq!(schedules.len(), 4);
+        assert_eq!(schedules.len(), 5);
         assert_eq!(schedules[0].id, "abs-discovery");
         assert_eq!(schedules[0].cron_expression, "0 * * * *");
         assert_eq!(schedules[0].emit_every, Duration::from_secs(3600));
@@ -648,6 +667,29 @@ mod tests {
         assert!(matches!(
             schedules[3].job.kind(),
             JobKind::Discover { source_id } if source_id.as_str() == "treasury"
+        ));
+    }
+
+    #[test]
+    fn default_schedule_registers_asx_discovery_cadence() {
+        let schedules = default_discovery_schedules(
+            Duration::from_secs(3600),
+            Duration::from_secs(604_800),
+            Duration::from_secs(604_800),
+            Duration::from_secs(86_400),
+            Duration::from_secs(900),
+        );
+
+        let asx = schedules
+            .iter()
+            .find(|schedule| schedule.id == "asx-discovery")
+            .expect("ASX discovery should be scheduled");
+
+        assert_eq!(asx.cron_expression, "*/15 * * * *");
+        assert_eq!(asx.emit_every, Duration::from_secs(900));
+        assert!(matches!(
+            asx.job.kind(),
+            JobKind::Discover { source_id } if source_id.as_str() == "asx"
         ));
     }
 


### PR DESCRIPTION
Closes #56

## Summary

- Adds the ASX adapter for market announcements feeds and end-of-day CSV pricing artifacts.
- Parses RSS announcement fixtures, ASX's current market-announcements JSON feed, and EOD OHLCV CSV rows into typed observations with ticker resolution.
- Registers ASX in the ingestion runner for once/backfill paths and adds a 15-minute scheduler discovery cadence.

## Pass requirements

- [x] Announcements RSS feed parsed
- [x] EOD file feed ingested
- [x] Entity resolution to tickers
- [x] `insta` snapshots

## Test plan

- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] `CARGO_INCREMENTAL=0 RUSTC_WRAPPER= cargo test -p au-kpis-adapter-asx`
- [x] `CARGO_INCREMENTAL=0 RUSTC_WRAPPER= cargo nextest run -p au-kpis-adapter-asx`
- [x] `CARGO_INCREMENTAL=0 RUSTC_WRAPPER= cargo test -p au-kpis-ingestion --bin au-kpis-ingestion`
- [x] `CARGO_INCREMENTAL=0 RUSTC_WRAPPER= cargo test -p au-kpis-scheduler --bin au-kpis-scheduler`
- [x] `CARGO_BUILD_JOBS=2 CARGO_INCREMENTAL=0 RUSTC_WRAPPER= cargo clippy --workspace --all-targets -- -D warnings`
- [x] `CARGO_INCREMENTAL=0 RUSTC_WRAPPER= cargo insta test --check -p au-kpis-adapter-asx`
- [x] `pnpm run lint`
- [x] `pnpm turbo run typecheck test`
- [x] `cargo deny check`
- [x] `cargo audit --ignore RUSTSEC-2023-0071 --ignore RUSTSEC-2025-0111`
- [x] `pnpm audit --audit-level critical`
- [x] `gitleaks protect --staged`
- [x] `CARGO_BUILD_JOBS=2 CARGO_INCREMENTAL=0 RUSTC_WRAPPER= cargo nextest run --workspace` (483 passed, 1 skipped)

## Spec impact

No Spec changes required; this implements `Spec.md` ASX adapter coverage for announcements + EOD feeds.